### PR TITLE
Update Cargo.toml link to repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://docs.rs/loco-rs"
 documentation = "https://docs.rs/loco-rs"
 authors = ["Dotan Nahum <dotan@rng0.io>", "Elad Kaplan <kaplan.elad@gmail.com>"]
+repository = "https://github.com/loco-rs/loco"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]


### PR DESCRIPTION
To allow Crates.io, Rust-Digger and others to link to it.