### PR TITLE
fix: fix cargo cli to support fork prs

### DIFF
--- a/.github/workflows/ci-starter-saas.yml
+++ b/.github/workflows/ci-starter-saas.yml
@@ -147,8 +147,8 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
       - name: Generate template
         run: |
-          cargo build --release
-          LOCO_CI_MODE=true LOCO_APP_NAME=saas_starter LOCO_TEMPLATE=saas LOCO_BRANCH=${{ env.GITHUB_HEAD_REF_SLUG }} ./target/release/loco new
+          cargo build --release --features github_ci
+          RUST_LOG=debug LOCO_CURRENT_REPOSITORY=${{ github.event.pull_request.head.repo.html_url }} LOCO_CI_MODE=true LOCO_APP_NAME=saas_starter LOCO_TEMPLATE=saas LOCO_BRANCH=${{ env.GITHUB_HEAD_REF_SLUG }} ./target/release/loco new
           cd saas_starter
           echo "Building generate template..."
           cargo build --release

--- a/.github/workflows/ci-stateless-saas.yml
+++ b/.github/workflows/ci-stateless-saas.yml
@@ -95,8 +95,8 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
       - name: Generate template
         run: |
-          cargo build --release
-          LOCO_CI_MODE=true LOCO_APP_NAME=stateless_starter LOCO_TEMPLATE=stateless LOCO_BRANCH=${{ env.GITHUB_HEAD_REF_SLUG }} ./target/release/loco new
+          cargo build --release --features github_ci
+          RUST_LOG=debug  LOCO_CURRENT_REPOSITORY=${{ github.event.pull_request.head.repo.html_url }} LOCO_CI_MODE=true LOCO_APP_NAME=stateless_starter LOCO_TEMPLATE=stateless LOCO_BRANCH=${{ env.GITHUB_HEAD_REF_SLUG }} ./target/release/loco new
           cd stateless_starter
           echo "Building generate template..."
           cargo build --release

--- a/loco-cli/Cargo.toml
+++ b/loco-cli/Cargo.toml
@@ -30,6 +30,7 @@ default = []
 # The purpose behind this feature is to run tests against the fork repository url when users fork our project and open a pull request, validating the starters projects.
 # When a user forks and opens a pull request from their branch, we must reference the opener's repository, not the local repository.
 # Enabling this feature makes the `LOCO_CURRENT_REPOSITORY` environment variable mandatory.
+# This is a feature becouse when releaseing a version we don't want the ability to change the source cloning starters
 github_ci = []
 
 [dependencies]

--- a/loco-cli/Cargo.toml
+++ b/loco-cli/Cargo.toml
@@ -22,6 +22,16 @@ name = "loco"
 path = "src/bin/main.rs"
 required-features = []
 
+
+[features]
+default = []
+
+# Enable this feature exclusively for GitHub Actions.
+# The purpose behind this feature is to run tests against the fork repository url when users fork our project and open a pull request, validating the starters projects.
+# When a user forks and opens a pull request from their branch, we must reference the opener's repository, not the local repository.
+# Enabling this feature makes the `LOCO_CURRENT_REPOSITORY` environment variable mandatory.
+github_ci = []
+
 [dependencies]
 clap = { version = "4.4.7", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }

--- a/loco-cli/src/git.rs
+++ b/loco-cli/src/git.rs
@@ -14,6 +14,9 @@ pub fn debug_path() -> Option<PathBuf> {
     env::var("LOCO_DEBUG_PATH").ok().map(PathBuf::from)
 }
 
+#[cfg(not(feature = "github_ci"))]
+const BASE_REPO_URL: &str = "https://github.com/loco-rs/loco";
+
 const DEFAULT_BRANCH: &str = "master";
 
 /// Define the starter template in Loco repository
@@ -121,10 +124,18 @@ fn clone_repo() -> Result<PathBuf, git2::Error> {
     );
     let mut opt = git2::FetchOptions::new();
     opt.depth(1);
+
+    // read more information in Cargo.toml
+    #[cfg(feature = "github_ci")]
+    let repo_url = env::var("LOCO_CURRENT_REPOSITORY").expect("LOCO_CURRENT_REPOSITORY not set");
+    #[cfg(not(feature = "github_ci"))]
+    let repo_url = BASE_REPO_URL.to_string();
+
+    tracing::debug(repo_url, "cloning repo url");
     git2::build::RepoBuilder::new()
         .branch(&from_branch)
         .fetch_options(opt)
-        .clone("https://github.com/loco-rs/loco", &temp_clone_dir)?;
+        .clone(&repo_url, &temp_clone_dir)?;
 
     Ok(temp_clone_dir)
 }

--- a/loco-cli/src/git.rs
+++ b/loco-cli/src/git.rs
@@ -131,7 +131,7 @@ fn clone_repo() -> Result<PathBuf, git2::Error> {
     #[cfg(not(feature = "github_ci"))]
     let repo_url = BASE_REPO_URL.to_string();
 
-    tracing::debug(repo_url, "cloning repo url");
+    tracing::debug!(repo_url, "cloning repo url");
     git2::build::RepoBuilder::new()
         .branch(&from_branch)
         .fetch_options(opt)

--- a/loco-cli/src/git.rs
+++ b/loco-cli/src/git.rs
@@ -117,11 +117,6 @@ fn clone_repo() -> Result<PathBuf, git2::Error> {
         },
     );
 
-    tracing::debug!(
-        branch = from_branch,
-        clone_folder = temp_clone_dir.display().to_string(),
-        "cloning loco"
-    );
     let mut opt = git2::FetchOptions::new();
     opt.depth(1);
 
@@ -131,7 +126,13 @@ fn clone_repo() -> Result<PathBuf, git2::Error> {
     #[cfg(not(feature = "github_ci"))]
     let repo_url = BASE_REPO_URL.to_string();
 
-    tracing::debug!(repo_url, "cloning repo url");
+    tracing::debug!(
+        repo_url,
+        branch = from_branch,
+        clone_folder = temp_clone_dir.display().to_string(),
+        "cloning loco"
+    );
+
     git2::build::RepoBuilder::new()
         .branch(&from_branch)
         .fetch_options(opt)


### PR DESCRIPTION
In our starters CI, we test the generation the projects via `loco-cli`. we want to ensure that the newly generated project compiles correctly on the current pull request branch.

The `loco-cli` is configured for the `https://github.com/loco-rs/loco` project, but when users fork the repository, the URL and branch differ.

This pull request aims to resolve the issue by obtaining the current repository from the GitHub environment only for CI .