### PR TITLE
adding cors router + adding after_router hook

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ tower-http = { version = "0.5.0", features = [
   "catch-panic",
   "timeout",
   "add-extension",
+  "cors",
 ] }
 byte-unit = "4.0.19"
 

--- a/examples/demo/config/development.yaml
+++ b/examples/demo/config/development.yaml
@@ -40,6 +40,19 @@ server:
       enable: true
       # Duration time in milliseconds.
       timeout: 5000
+    cors:
+      enable: true
+      # Set the value of the [`Access-Control-Allow-Origin`][mdn] header
+      # allow_origins:
+      #   - https://loco.rs
+      # Set the value of the [`Access-Control-Allow-Headers`][mdn] header
+      # allow_headers:
+      # - Content-Type
+      # Set the value of the [`Access-Control-Allow-Methods`][mdn] header
+      # allow_methods:
+      #   - POST
+      # Set the value of the [`Access-Control-Max-Age`][mdn] header in seconds
+      # max_age: 3600
 
 # Worker Configuration
 workers:

--- a/examples/demo/config/test.yaml
+++ b/examples/demo/config/test.yaml
@@ -40,6 +40,19 @@ server:
       enable: true
       # Duration time in milliseconds.
       timeout: 5000
+    cors:
+      enable: true
+      # Set the value of the [`Access-Control-Allow-Origin`][mdn] header
+      # allow_origins:
+      #   - https://loco.rs
+      # Set the value of the [`Access-Control-Allow-Headers`][mdn] header
+      # allow_headers:
+      # - Content-Type
+      # Set the value of the [`Access-Control-Allow-Methods`][mdn] header
+      # allow_methods:
+      #   - POST
+      # Set the value of the [`Access-Control-Max-Age`][mdn] header in seconds
+      # max_age: 3600
 
 # Worker Configuration
 workers:

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,8 +6,7 @@ cfg_if::cfg_if! {
         use sea_orm::DatabaseConnection;
     } else {}
 }
-
-use async_trait::async_trait;
+use axum::Router as AXRouter;
 
 use crate::{
     config::Config,
@@ -18,6 +17,7 @@ use crate::{
     worker::{Pool, Processor, RedisConnectionManager},
     Result,
 };
+use async_trait::async_trait;
 
 /// Represents the application context for a web server.
 ///
@@ -111,15 +111,27 @@ pub trait Hooks {
     /// ```
     fn app_name() -> &'static str;
 
+    /// Invoke this function after the Loco routers have been constructed. This function enables you to configure custom Axum logics, such as layers, that are compatible with Axum.
+    ///
+    /// # Errors
+    /// Axum router error
+    fn after_router(router: AXRouter, _ctx: &AppContext) -> Result<AXRouter> {
+        Ok(router)
+    }
+
+    /// Calling the function before run the app
+    /// You can now code some custom loading of resources or other things before the app runs
     async fn before_run(_app_context: &AppContext) -> Result<()> {
         Ok(())
     }
 
     /// Defines the application's routing configuration.
     fn routes() -> AppRoutes;
+
     /// Connects custom workers to the application using the provided
     /// [`Processor`] and [`AppContext`].
     fn connect_workers<'a>(p: &'a mut Processor, ctx: &'a AppContext);
+
     /// Registers custom tasks with the provided [`Tasks`] object.
     fn register_tasks(tasks: &mut Tasks);
 

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -109,7 +109,7 @@ pub struct BootResult {
 /// # Errors
 ///
 /// When could not initialize the application.
-pub async fn start(boot: BootResult) -> Result<()> {
+pub async fn start<H: Hooks>(boot: BootResult) -> Result<()> {
     print_banner(&boot);
 
     let BootResult {
@@ -125,10 +125,10 @@ pub async fn start(boot: BootResult) -> Result<()> {
                     tracing::error!("Error in processing: {:?}", err);
                 }
             });
-            serve(router, &app_context.config).await?;
+            serve::<H>(router, &app_context).await?;
         }
         (Some(router), None) => {
-            serve(router, &app_context.config).await?;
+            serve::<H>(router, &app_context).await?;
         }
         (None, Some(processor)) => {
             process(processor).await?;
@@ -220,11 +220,12 @@ pub async fn run_db<H: Hooks, M: MigratorTrait>(
 }
 
 /// Starts the server using the provided [`Router`] and [`Config`].
-async fn serve(app: Router, config: &Config) -> Result<()> {
+async fn serve<H: Hooks>(app: Router, ctx: &AppContext) -> Result<()> {
+    let router = H::after_router(app, ctx)?;
     let listener =
-        tokio::net::TcpListener::bind(&format!("0.0.0.0:{}", config.server.port)).await?;
+        tokio::net::TcpListener::bind(&format!("0.0.0.0:{}", ctx.config.server.port)).await?;
 
-    axum::serve(listener, app).await?;
+    axum::serve(listener, router).await?;
 
     Ok(())
 }
@@ -304,6 +305,7 @@ pub fn run_app<H: Hooks>(mode: &StartMode, app_context: AppContext) -> Result<Bo
     match mode {
         StartMode::ServerOnly => {
             let app = H::routes().to_router(app_context.clone())?;
+
             Ok(BootResult {
                 app_context,
                 router: Some(app),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -252,7 +252,7 @@ pub async fn main<H: Hooks, M: MigratorTrait>() -> eyre::Result<()> {
             };
 
             let boot_result = create_app::<H, M>(start_mode, &environment).await?;
-            start(boot_result).await?;
+            start::<H>(boot_result).await?;
         }
         #[cfg(feature = "with-db")]
         Commands::Db { command } => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -252,7 +252,7 @@ pub async fn main<H: Hooks, M: MigratorTrait>() -> eyre::Result<()> {
             };
 
             let boot_result = create_app::<H, M>(start_mode, &environment).await?;
-            start::<H>(boot_result).await?;
+            start(boot_result).await?;
         }
         #[cfg(feature = "with-db")]
         Commands::Db { command } => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,6 +142,17 @@ pub struct Middlewares {
     pub catch_panic: Option<EnableMiddleware>,
     /// Setting a global timeout for the requests
     pub timeout_request: Option<TimeoutRequestMiddleware>,
+    // Setting cors configuration
+    pub cors: Option<CorsMiddleware>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CorsMiddleware {
+    pub enable: bool,
+    pub allow_origins: Option<Vec<String>>,
+    pub allow_headers: Option<Vec<String>>,
+    pub allow_methods: Option<Vec<String>>,
+    pub max_age: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,10 @@
 //! # Application Error Handling
 
-use axum::http::StatusCode;
+use axum::http::{
+    header::{InvalidHeaderName, InvalidHeaderValue},
+    method::InvalidMethod,
+    StatusCode,
+};
 use config::ConfigError;
 use lettre::{address::AddressError, transport::smtp};
 
@@ -61,6 +65,15 @@ pub enum Error {
 
     #[error("")]
     CustomError(StatusCode, ErrorDetail),
+
+    #[error(transparent)]
+    InvalidHeaderValue(#[from] InvalidHeaderValue),
+
+    #[error(transparent)]
+    InvalidHeaderName(#[from] InvalidHeaderName),
+
+    #[error(transparent)]
+    InvalidMethod(#[from] InvalidMethod),
 
     #[cfg(feature = "with-db")]
     // Model

--- a/starters/saas/config/development.yaml
+++ b/starters/saas/config/development.yaml
@@ -40,6 +40,19 @@ server:
       enable: true
       # Duration time in milliseconds.
       timeout: 5000
+    cors:
+      enable: true
+      # Set the value of the [`Access-Control-Allow-Origin`][mdn] header
+      # allow_origins:
+      #   - https://loco.rs
+      # Set the value of the [`Access-Control-Allow-Headers`][mdn] header
+      # allow_headers:
+      # - Content-Type
+      # Set the value of the [`Access-Control-Allow-Methods`][mdn] header
+      # allow_methods:
+      #   - POST
+      # Set the value of the [`Access-Control-Max-Age`][mdn] header in seconds
+      # max_age: 3600
 
 # Worker Configuration
 workers:

--- a/starters/saas/config/test.yaml
+++ b/starters/saas/config/test.yaml
@@ -40,6 +40,19 @@ server:
       enable: true
       # Duration time in milliseconds.
       timeout: 5000
+    cors:
+      enable: true
+      # Set the value of the [`Access-Control-Allow-Origin`][mdn] header
+      # allow_origins:
+      #   - https://loco.rs
+      # Set the value of the [`Access-Control-Allow-Headers`][mdn] header
+      # allow_headers:
+      # - Content-Type
+      # Set the value of the [`Access-Control-Allow-Methods`][mdn] header
+      # allow_methods:
+      #   - POST
+      # Set the value of the [`Access-Control-Max-Age`][mdn] header in seconds
+      # max_age: 3600
 
 # Worker Configuration
 workers:

--- a/starters/stateless/config/development.yaml
+++ b/starters/stateless/config/development.yaml
@@ -40,6 +40,19 @@ server:
       enable: true
       # Duration time in milliseconds.
       timeout: 5000
+    cors:
+      enable: true
+      # Set the value of the [`Access-Control-Allow-Origin`][mdn] header
+      # allow_origins:
+      #   - https://loco.rs
+      # Set the value of the [`Access-Control-Allow-Headers`][mdn] header
+      # allow_headers:
+      # - Content-Type
+      # Set the value of the [`Access-Control-Allow-Methods`][mdn] header
+      # allow_methods:
+      #   - POST
+      # Set the value of the [`Access-Control-Max-Age`][mdn] header in seconds
+      # max_age: 3600
 
 # Worker Configuration
 workers:

--- a/starters/stateless/config/test.yaml
+++ b/starters/stateless/config/test.yaml
@@ -40,6 +40,19 @@ server:
       enable: true
       # Duration time in milliseconds.
       timeout: 5000
+    cors:
+      enable: true
+      # Set the value of the [`Access-Control-Allow-Origin`][mdn] header
+      # allow_origins:
+      #   - https://loco.rs
+      # Set the value of the [`Access-Control-Allow-Headers`][mdn] header
+      # allow_headers:
+      # - Content-Type
+      # Set the value of the [`Access-Control-Allow-Methods`][mdn] header
+      # allow_methods:
+      #   - POST
+      # Set the value of the [`Access-Control-Max-Age`][mdn] header in seconds
+      # max_age: 3600
 
 # Worker Configuration
 workers:

--- a/starters/stateless_html/config/development.yaml
+++ b/starters/stateless_html/config/development.yaml
@@ -40,6 +40,19 @@ server:
       enable: true
       # Duration time in milliseconds.
       timeout: 5000
+    cors:
+      enable: true
+      # Set the value of the [`Access-Control-Allow-Origin`][mdn] header
+      # allow_origins:
+      #   - https://loco.rs
+      # Set the value of the [`Access-Control-Allow-Headers`][mdn] header
+      # allow_headers:
+      # - Content-Type
+      # Set the value of the [`Access-Control-Allow-Methods`][mdn] header
+      # allow_methods:
+      #   - POST
+      # Set the value of the [`Access-Control-Max-Age`][mdn] header in seconds
+      # max_age: 3600
 
 # Worker Configuration
 workers:

--- a/starters/stateless_html/config/test.yaml
+++ b/starters/stateless_html/config/test.yaml
@@ -40,6 +40,19 @@ server:
       enable: true
       # Duration time in milliseconds.
       timeout: 5000
+    cors:
+      enable: true
+      # Set the value of the [`Access-Control-Allow-Origin`][mdn] header
+      # allow_origins:
+      #   - https://loco.rs
+      # Set the value of the [`Access-Control-Allow-Headers`][mdn] header
+      # allow_headers:
+      # - Content-Type
+      # Set the value of the [`Access-Control-Allow-Methods`][mdn] header
+      # allow_methods:
+      #   - POST
+      # Set the value of the [`Access-Control-Max-Age`][mdn] header in seconds
+      # max_age: 3600
 
 # Worker Configuration
 workers:


### PR DESCRIPTION
Implemented CORS #89 middleware and introduced an`after_router` hook. This hook em allows the users to seamlessly extend the Axum router with custom logic, enabling the integration of additional layers and ensuring compatibility with the Axum router.