### PR TITLE
creating a deployment generator to shuttle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2567,9 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "rrgen"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da8d2780fb6862c57c934655103bce0448045a57902dc957de154abfe56951f"
+checksum = "e40013551787f9f535e7dbc8dafc164591d941aeae48881a385d8b0393dd45f6"
 dependencies = [
  "cruet",
  "fs-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ validator = { version = "0.16.1", features = ["derive"] }
 axum-test = { version = "14.0.0-rc.1", optional = true }
 
 # gen 
-rrgen = "0.5.2"
+rrgen = "0.5.3"
 chrono = "0.4.31"
 cargo_metadata = "0.18.1"
 

--- a/docs-site/content/docs/getting-started/deployment.md
+++ b/docs-site/content/docs/getting-started/deployment.md
@@ -89,14 +89,30 @@ auth:
 
 Loco offers a deployment template enabling the creation of a deployment infrastructure.
 
-Presently, we exclusively support Docker deployment, but stay tuned for future updates! 🙂
-
 ```sh
 cargo loco generate deployment
 ? ❯ Choose your deployment ›
 ❯ Docker
+❯ Shuttle
 ..
 ✔ ❯ Choose your deployment · Docker
 skipped (exists): "dockerfile"
 added: ".dockerignore"
 ```
+
+Deployment Options:
+
+1. Docker:
+
+- Generates a Dockerfile ready for building and deploying.
+- Creates a .dockerignore file.
+
+2. Shuttle:
+
+- Generates a shuttle main function.
+- Adds `shuttle-runtime` and `shuttle-axum` as dependencies.
+- Adds a bin entrypoint for the deployment.
+
+Choose the option that best fits your deployment needs. Happy deploying!
+
+If you have a preference for deploying on a different cloud, feel free to open a pull request. Your contributions are more than welcome!

--- a/examples/demo/Cargo.lock
+++ b/examples/demo/Cargo.lock
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "loco-rs"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "argon2",
  "async-trait",
@@ -3008,9 +3008,9 @@ dependencies = [
 
 [[package]]
 name = "rrgen"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da8d2780fb6862c57c934655103bce0448045a57902dc957de154abfe56951f"
+checksum = "e40013551787f9f535e7dbc8dafc164591d941aeae48881a385d8b0393dd45f6"
 dependencies = [
  "cruet",
  "fs-err",

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -35,7 +35,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }
 
 
 [[bin]]
-name = "demo"
+name = "blo-cli"
 path = "src/bin/main.rs"
 required-features = []
 

--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -29,6 +29,9 @@ const DEPLOYMENT_DOCKER_IGNORE_T: &str = include_str!("templates/deployment_dock
 const DEPLOYMENT_SHUTTLE_T: &str = include_str!("templates/deployment_shuttle.t");
 const DEPLOYMENT_SHUTTLE_CONFIG_T: &str = include_str!("templates/deployment_shuttle_config.t");
 
+const DEPLOYMENT_SHUTTLE_RUNTIME_VERSION: &str = "0.35.0";
+const DEPLOYMENT_SHUTTLE_AXUM_VERSION: &str = "0.35.0";
+
 const DEPLOYMENT_OPTIONS: &[(&str, DeploymentKind)] = &[
     ("Docker", DeploymentKind::Docker),
     ("Shuttle", DeploymentKind::Shuttle),
@@ -100,7 +103,7 @@ pub fn generate<H: Hooks>(component: Component) -> Result<()> {
             println!("{}", scaffold::generate::<H>(&rrgen, &name, &fields)?);
         }
         Component::Controller { name } => {
-            let vars = json!({"name": name});
+            let vars = json!({ "name": name });
             rrgen.generate(CONTROLLER_T, &vars)?;
             rrgen.generate(CONTROLLER_TEST_T, &vars)?;
         }
@@ -117,7 +120,7 @@ pub fn generate<H: Hooks>(component: Component) -> Result<()> {
             rrgen.generate(WORKER_TEST_T, &vars)?;
         }
         Component::Mailer { name } => {
-            let vars = json!({"name": name});
+            let vars = json!({ "name": name });
             rrgen.generate(MAILER_T, &vars)?;
             rrgen.generate(MAILER_SUB_T, &vars)?;
             rrgen.generate(MAILER_TEXT_T, &vars)?;
@@ -130,13 +133,15 @@ pub fn generate<H: Hooks>(component: Component) -> Result<()> {
                 })?,
                 Err(_err) => prompt_deployment_selection().map_err(Box::from)?,
             };
-            let vars = json!({ "pkg_name": H::app_name()});
+
             match deployment_kind {
                 DeploymentKind::Docker => {
+                    let vars = json!({ "pkg_name": H::app_name() });
                     rrgen.generate(DEPLOYMENT_DOCKER_T, &vars)?;
                     rrgen.generate(DEPLOYMENT_DOCKER_IGNORE_T, &vars)?;
                 }
                 DeploymentKind::Shuttle => {
+                    let vars = json!({ "pkg_name": H::app_name(), "shuttle_runtime_version": DEPLOYMENT_SHUTTLE_RUNTIME_VERSION, "shuttle_axum_version": DEPLOYMENT_SHUTTLE_AXUM_VERSION });
                     rrgen.generate(DEPLOYMENT_SHUTTLE_T, &vars)?;
                     rrgen.generate(DEPLOYMENT_SHUTTLE_CONFIG_T, &vars)?;
                 }

--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -23,14 +23,21 @@ const TASK_TEST_T: &str = include_str!("templates/task_test.t");
 const WORKER_T: &str = include_str!("templates/worker.t");
 const WORKER_TEST_T: &str = include_str!("templates/worker_test.t");
 
+// Deployment templates
 const DEPLOYMENT_DOCKER_T: &str = include_str!("templates/deployment_docker.t");
 const DEPLOYMENT_DOCKER_IGNORE_T: &str = include_str!("templates/deployment_docker_ignore.t");
+const DEPLOYMENT_SHUTTLE_T: &str = include_str!("templates/deployment_shuttle.t");
+const DEPLOYMENT_SHUTTLE_CONFIG_T: &str = include_str!("templates/deployment_shuttle_config.t");
 
-const DEPLOYMENT_OPTIONS: &[(&str, DeploymentKind)] = &[("Docker", DeploymentKind::Docker)];
+const DEPLOYMENT_OPTIONS: &[(&str, DeploymentKind)] = &[
+    ("Docker", DeploymentKind::Docker),
+    ("Shuttle", DeploymentKind::Shuttle),
+];
 
 #[derive(Debug, Clone)]
 pub enum DeploymentKind {
     Docker,
+    Shuttle,
 }
 impl FromStr for DeploymentKind {
     type Err = ();
@@ -38,6 +45,7 @@ impl FromStr for DeploymentKind {
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "docker" => Ok(Self::Docker),
+            "shuttle" => Ok(Self::Shuttle),
             _ => Err(()),
         }
     }
@@ -127,6 +135,10 @@ pub fn generate<H: Hooks>(component: Component) -> Result<()> {
                 DeploymentKind::Docker => {
                     rrgen.generate(DEPLOYMENT_DOCKER_T, &vars)?;
                     rrgen.generate(DEPLOYMENT_DOCKER_IGNORE_T, &vars)?;
+                }
+                DeploymentKind::Shuttle => {
+                    rrgen.generate(DEPLOYMENT_SHUTTLE_T, &vars)?;
+                    rrgen.generate(DEPLOYMENT_SHUTTLE_CONFIG_T, &vars)?;
                 }
             }
         }

--- a/src/gen/templates/deployment_shuttle.t
+++ b/src/gen/templates/deployment_shuttle.t
@@ -16,10 +16,10 @@ injections:
     path = "src/bin/shuttle.rs"
 - into: Cargo.toml
   after: \[dependencies\]
-  content: "shuttle-runtime = { version = \"0.35.0\", default-features = false }"
+  content: "shuttle-runtime = { version = \"{{shuttle_runtime_version}}\", default-features = false }"
 - into: Cargo.toml
   after: \[dependencies\]
-  content: "shuttle-axum = { version = \"0.35.0\", default-features = false, features = [\"axum-0-7\",] }"
+  content: "shuttle-axum = { version = \"{{shuttle_axum_version}}\", default-features = false, features = [\"axum-0-7\",] }"
 ---
 use loco_rs::boot::{create_app, StartMode};
 use loco_rs::environment::resolve_from_env;

--- a/src/gen/templates/deployment_shuttle.t
+++ b/src/gen/templates/deployment_shuttle.t
@@ -1,0 +1,37 @@
+to: "src/bin/shuttle.rs"
+skip_exists: true
+message: "Shuttle deployment ready do use"
+injections:
+- into: .cargo/config.toml
+  remove_lines: "loco ="
+  content: ""
+- into: .cargo/config.toml
+  after: \[alias\]
+  content: "loco = \"run --bin {{pkg_name}}-cli --\""
+- into: Cargo.toml
+  before: \[dev-dependencies\]
+  content: |
+    [[bin]]
+    name = "{{pkg_name}}"
+    path = "src/bin/shuttle.rs"
+- into: Cargo.toml
+  after: \[dependencies\]
+  content: "shuttle-runtime = { version = \"0.35.0\", default-features = false }"
+- into: Cargo.toml
+  after: \[dependencies\]
+  content: "shuttle-axum = { version = \"0.35.0\", default-features = false, features = [\"axum-0-7\",] }"
+---
+use loco_rs::boot::{create_app, StartMode};
+use loco_rs::environment::resolve_from_env;
+use {{pkg_name}}::app::App;
+
+#[shuttle_runtime::main]
+async fn main() -> shuttle_axum::ShuttleAxum {
+    let environment = resolve_from_env().unwrap_or_else(|| "development".to_string());
+    let boot_result = create_app::<App>(StartMode::ServerOnly, &environment)
+        .await
+        .unwrap();
+
+    let router = boot_result.router.unwrap();
+    Ok(router.into())
+}

--- a/src/gen/templates/deployment_shuttle_config.t
+++ b/src/gen/templates/deployment_shuttle_config.t
@@ -1,5 +1,5 @@
 to: "Shuttle.toml"
 skip_exists: true
-message: "Suttle.toml file created successfully"
+message: "Shuttle.toml file created successfully"
 ---
 name = "{{pkg_name}}"

--- a/src/gen/templates/deployment_shuttle_config.t
+++ b/src/gen/templates/deployment_shuttle_config.t
@@ -1,0 +1,5 @@
+to: "Shuttle.toml"
+skip_exists: true
+message: "Suttle.toml file created successfully"
+---
+name = "{{pkg_name}}"

--- a/starters/saas/Cargo.toml
+++ b/starters/saas/Cargo.toml
@@ -33,7 +33,7 @@ uuid = { version = "1.6.0", features = ["v4"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }
 
 [[bin]]
-name = "loco_starter_template"
+name = "loco_starter_template-cli"
 path = "src/bin/main.rs"
 required-features = []
 

--- a/starters/stateless/Cargo.toml
+++ b/starters/stateless/Cargo.toml
@@ -24,7 +24,7 @@ uuid = { version = "*", features = ["v4"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }
 
 [[bin]]
-name = "loco_starter_template"
+name = "loco_starter_template-cli"
 path = "src/bin/main.rs"
 required-features = []
 

--- a/starters/stateless_html/Cargo.toml
+++ b/starters/stateless_html/Cargo.toml
@@ -25,7 +25,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }
 tera = "1.19.1"
 
 [[bin]]
-name = "loco_starter_template"
+name = "loco_starter_template-cli"
 path = "src/bin/main.rs"
 required-features = []
 


### PR DESCRIPTION
Creating a Shuttle Deployment Generator

**User Flow:**

1. Run `loco new` and select the HTML template for easy testing.
2. Go to the app direactory and execute `cargo loco generate deployment`. You will be prompted with the following options:
    ```sh
    ? ❯ Choose your deployment ›
    ❯ Docker
      Shuttle
    ```

3. The Shuttle generator will:
    - Create a `Shuttle.toml` file with the app's name.
    - Generate a new binary entrypoint at `src/bin/shuttle.rs`.
    - Update the `loco` alias in `.cargo/config.toml` to support the CLI binary.
    - Add the Shuttle binary entry in `Cargo.toml`.
    - Inject dependencies `shuttle-runtime` and `shuttle-axum`.

4. Run the Shuttle deployment, and it's ready to go!


Changed also the docs