### PR TITLE
add static assets in docker deployment if exist

### DIFF
--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -7,7 +7,7 @@ mod model;
 mod scaffold;
 use std::str::FromStr;
 
-use crate::{app::Hooks, errors, Result};
+use crate::{app::Hooks, config::Config, errors, Result};
 
 const CONTROLLER_T: &str = include_str!("templates/controller.t");
 const CONTROLLER_TEST_T: &str = include_str!("templates/request_test.t");
@@ -90,7 +90,7 @@ pub enum Component {
     Deployment {},
 }
 
-pub fn generate<H: Hooks>(component: Component) -> Result<()> {
+pub fn generate<H: Hooks>(component: Component, config: &Config) -> Result<()> {
     let rrgen = RRgen::default();
 
     match component {
@@ -136,7 +136,21 @@ pub fn generate<H: Hooks>(component: Component) -> Result<()> {
 
             match deployment_kind {
                 DeploymentKind::Docker => {
-                    let vars = json!({ "pkg_name": H::app_name() });
+                    let copy_asset_folder = &config
+                        .server
+                        .middlewares
+                        .static_assets
+                        .as_ref()
+                        .and_then(|a| a.folder.as_ref().map(|f| f.path.to_string()));
+
+                    let fallback_file = &config
+                        .server
+                        .middlewares
+                        .static_assets
+                        .as_ref()
+                        .and_then(|a| a.fallback.as_ref().map(std::string::ToString::to_string));
+
+                    let vars = json!({ "pkg_name": H::app_name(), "copy_asset_folder": copy_asset_folder, "fallback_file": fallback_file });
                     rrgen.generate(DEPLOYMENT_DOCKER_T, &vars)?;
                     rrgen.generate(DEPLOYMENT_DOCKER_IGNORE_T, &vars)?;
                 }

--- a/src/gen/templates/deployment_docker.t
+++ b/src/gen/templates/deployment_docker.t
@@ -14,6 +14,12 @@ FROM debian:bookworm-slim
 
 WORKDIR /usr/app
 
+{% if copy_asset_folder -%}
+COPY --from=builder /usr/src/{{copy_asset_folder}} /usr/app/{{copy_asset_folder}}
+{% endif -%}
+{% if fallback_file -%}
+COPY --from=builder /usr/src/{{fallback_file}} /usr/app/{{fallback_file}}
+{% endif -%}
 COPY --from=builder /usr/src/config /usr/app/config
 COPY --from=builder /usr/src/target/release/{{pkg_name}}-cli /usr/app/{{pkg_name}}-cli
 


### PR DESCRIPTION
When static assets are enabled in configuration, the docker deployment copy the paths from 

The following path are added :
```
COPY --from=builder /usr/src/[from-config] /usr/app/[from-config]
COPY --from=builder /usr/src/[from-config] /usr/app/[from-config]
```