### PR TITLE
Loco cli clone via local git

### DIFF
--- a/loco-cli/Cargo.lock
+++ b/loco-cli/Cargo.lock
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "loco-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "eyre",

--- a/loco-cli/Cargo.toml
+++ b/loco-cli/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "loco-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "loco cli website generator"
 license = "Apache-2.0"
@@ -25,13 +25,6 @@ required-features = []
 
 [features]
 default = []
-
-# Enable this feature exclusively for GitHub Actions.
-# The purpose behind this feature is to run tests against the fork repository url when users fork our project and open a pull request, validating the starters projects.
-# When a user forks and opens a pull request from their branch, we must reference the opener's repository, not the local repository.
-# Enabling this feature makes the `LOCO_CURRENT_REPOSITORY` environment variable mandatory.
-# This is a feature becouse when releaseing a version we don't want the ability to change the source cloning starters
-github_ci = []
 
 [dependencies]
 clap = { version = "4.4.7", features = ["derive"] }


### PR DESCRIPTION
After investigating issue #139, I successfully reproduced the error by adding the following configuration to the .gitconfig file (Special thanks to @lucasgrvarela for reporting and providing insightful details):

```
[url "ssh://git@github.com/"]
    insteadOf = https://github.com/
```

I change the default cloning to execute local `git` instead using the lib (if git installed)