### PR TITLE
fix: don't use package name in request test

### DIFF
--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -103,7 +103,7 @@ pub fn generate<H: Hooks>(component: Component, config: &Config) -> Result<()> {
             println!("{}", scaffold::generate::<H>(&rrgen, &name, &fields)?);
         }
         Component::Controller { name } => {
-            let vars = json!({ "name": name, "pkg_name": H::app_name()});
+            let vars = json!({ "name": name });
             rrgen.generate(CONTROLLER_T, &vars)?;
             rrgen.generate(CONTROLLER_TEST_T, &vars)?;
         }

--- a/src/gen/templates/request_test.t
+++ b/src/gen/templates/request_test.t
@@ -8,7 +8,7 @@ injections:
   append: true
   content: "pub mod {{ file_name }};"
 ---
-use {{pkg_name}}::app::App;
+use crate::app::App;
 use migration::Migrator;
 use loco_rs::testing;
 use serial_test::serial;


### PR DESCRIPTION
This removes an error where app_name is not correctly set.

In my app the name was set to `blo::app::App;` instead of `mealplanning::app::App;`, but `crate::app::App;` solves this without relying on a hard-coded name.
