### PR TITLE
fix: Dockerfile grant write access to the vscode user in the /usr/local/cargo path

### DIFF
--- a/starters/rest-api/.devcontainer/Dockerfile
+++ b/starters/rest-api/.devcontainer/Dockerfile
@@ -2,6 +2,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
      && apt-get -y install --no-install-recommends postgresql-client \
-     && cargo install sea-orm-cli
+     && cargo install sea-orm-cli \
+     && chown -R vscode /usr/local/cargo
 
 COPY .env /.env

--- a/starters/saas/.devcontainer/Dockerfile
+++ b/starters/saas/.devcontainer/Dockerfile
@@ -2,6 +2,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
      && apt-get -y install --no-install-recommends postgresql-client \
-     && cargo install sea-orm-cli
+     && cargo install sea-orm-cli \
+     && chown -R vscode /usr/local/cargo
 
 COPY .env /.env


### PR DESCRIPTION
fix: https://github.com/loco-rs/loco/issues/186
grant write access to the vscode user in the /usr/local/cargo path