### PR TITLE
Use SQLite by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,8 @@ myapp
 ```
 
 <div class="infobox">
-To configure a database , please run a local postgres database with <code>loco:loco</code> and a db named <code>loco_app</code>.
+<code>loco new</code> uses SQLite by default. In production you should replace this with a more scalable database system, like Postgres.
 </div>
-
-You can use Docker to run a Postgres instance:
-
-```
-$ docker run -d -p 5432:5432 -e POSTGRES_USER=loco -e POSTGRES_DB=loco_app -e POSTGRES_PASSWORD="loco" postgres:15.3-alpine
-```
 
 Now `cd` into your `myapp` and start your app:
 

--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -52,8 +52,7 @@ Make sure you also have locally installed or running (via Docker or otherwise):
 - Redis
 
 <div class="infobox">
-To configure a database , please run a local postgres database with <code>loco:loco</code> and a db named <code>loco_app</code>: 
-<code>docker run -d -p 5432:5432 -e POSTGRES_USER=loco -e POSTGRES_DB=loco_app -e POSTGRES_PASSWORD="loco" postgres:15.3-alpine</code>
+<code>loco new</code> uses SQLite by default. In production you should replace this with a more scalable database system, like Postgres.
 </div>
 
 ### Creating a new Loco app

--- a/docs-site/content/docs/getting-started/tour/index.md
+++ b/docs-site/content/docs/getting-started/tour/index.md
@@ -35,14 +35,8 @@ myapp
 ```
 
 <div class="infobox">
-To configure a database , please run a local postgres database with <code>loco:loco</code> and a db named <code>loco_app</code>.
+<code>loco new</code> uses SQLite by default. In production you should replace this with a more scalable database system, like Postgres.
 </div>
-
-You can use Docker to run a Postgres instance:
-
-```
-$ docker run -d -p 5432:5432 -e POSTGRES_USER=loco -e POSTGRES_DB=loco_app -e POSTGRES_PASSWORD="loco" postgres:15.3-alpine
-```
 
 Now `cd` into your `myapp` and start your app:
 

--- a/starters/rest-api/config/development.yaml
+++ b/starters/rest-api/config/development.yaml
@@ -83,7 +83,7 @@ mailer:
 # Database Configuration
 database:
   # Database connection URI
-  uri: {{ get_env(name="DATABASE_URL", default="postgres://loco:loco@localhost:5432/loco_app") }}
+  uri: {{ get_env(name="DATABASE_URL", default="sqlite://loco_app.sqlite?mode=rwc") }}
   # When enabled, the sql query will be logged.
   enable_logging: false
   # Set the timeout duration when acquiring a connection.
@@ -116,4 +116,3 @@ auth:
     secret: PqRwLF2rhHe8J22oBeHy
     # Token expiration time in seconds
     expiration: 604800 # 7 days
-

--- a/starters/rest-api/config/test.yaml
+++ b/starters/rest-api/config/test.yaml
@@ -82,7 +82,7 @@ mailer:
 # Database Configuration
 database:
   # Database connection URI
-  uri: {{get_env(name="DATABASE_URL", default="postgres://loco:loco@localhost:5432/loco_app")}} 
+  uri: {{ get_env(name="DATABASE_URL", default="sqlite://loco_app.sqlite?mode=rwc") }}
   # When enabled, the sql query will be logged.
   enable_logging: false
   # Set the timeout duration when acquiring a connection.
@@ -115,4 +115,3 @@ auth:
     secret: PqRwLF2rhHe8J22oBeHy
     # Token expiration time in seconds
     expiration: 604800 # 7 days
-

--- a/starters/saas/config/development.yaml
+++ b/starters/saas/config/development.yaml
@@ -90,7 +90,7 @@ mailer:
 # Database Configuration
 database:
   # Database connection URI
-  uri: {{ get_env(name="DATABASE_URL", default="postgres://loco:loco@localhost:5432/loco_app") }}
+  uri: {{ get_env(name="DATABASE_URL", default="sqlite://loco_app.sqlite?mode=rwc") }}
   # When enabled, the sql query will be logged.
   enable_logging: false
   # Set the timeout duration when acquiring a connection.
@@ -123,4 +123,3 @@ auth:
     secret: PqRwLF2rhHe8J22oBeHy
     # Token expiration time in seconds
     expiration: 604800 # 7 days
-

--- a/starters/saas/config/test.yaml
+++ b/starters/saas/config/test.yaml
@@ -89,7 +89,7 @@ mailer:
 # Database Configuration
 database:
   # Database connection URI
-  uri: {{ get_env(name="DATABASE_URL", default="postgres://loco:loco@localhost:5432/loco_app") }}
+  uri: {{ get_env(name="DATABASE_URL", default="sqlite://loco_app.sqlite?mode=rwc") }}
   # When enabled, the sql query will be logged.
   enable_logging: false
   # Set the timeout duration when acquiring a connection.
@@ -122,4 +122,3 @@ auth:
     secret: PqRwLF2rhHe8J22oBeHy
     # Token expiration time in seconds
     expiration: 604800 # 7 days
-


### PR DESCRIPTION
Currently trying out the starter examples is quite an intensive task, due to the requirement for Postgres. In production there is definitely the need for something as scalable as Postgres, but I don't think that's the case for the starters. To lower the initial hurdle, both Rails and Django opt for SQLite by default, which is enough to hit the ground running and start playing with the frameworks.

I'd recommend loco do the same, and this PR implements that. It replaces Postgres with SQLite in the configs, and mentions the eventual need for Postgres in the readme and docs.