### PR TITLE
wip: disable init logger in testing mode

### DIFF
--- a/docs-site/content/docs/testing/overview.md
+++ b/docs-site/content/docs/testing/overview.md
@@ -91,4 +91,8 @@ async fn is_user_exists() {
 }
 ```
 
+### Logger
+To prevent concurrent logging, the logger is disabled when the `testing` feature is active. If you need to record logs, you have the option to create your own logger subscriber
+
+
 This documentation provides an in-depth guide on leveraging Loco's testing helpers, covering database cleanup, data cleanup for snapshot testing, and seeding data for tests.

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -10,6 +10,10 @@ use tracing::{trace, warn};
 
 #[cfg(feature = "with-db")]
 use crate::db;
+
+#[cfg(not(feature = "testing"))]
+use crate::logger;
+
 use crate::{
     app::{AppContext, Hooks},
     banner::print_banner,
@@ -17,7 +21,6 @@ use crate::{
     controller::ListRoutes,
     environment::Environment,
     errors::Error,
-    logger,
     mailer::{EmailSender, MailerWorker},
     redis,
     task::Tasks,

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -181,6 +181,8 @@ pub async fn create_context<H: Hooks>(environment: &str) -> Result<AppContext> {
     let environment = Environment::from_str(environment)
         .unwrap_or_else(|_| Environment::Any(environment.to_string()));
     let config = environment.load()?;
+
+    #[cfg(not(feature = "testing"))]
     if config.logger.enable {
         logger::init::<H>(&config.logger);
     }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -47,8 +47,11 @@ impl std::fmt::Display for LogLevel {
         to_variant_name(self).expect("only enum supported").fmt(f)
     }
 }
+#[allow(dead_code)]
 // Function to initialize the logger based on the provided configuration
 const MODULE_WHITELIST: &[&str] = &["loco_rs", "sea_orm_migration", "tower_http", "sqlx::query"];
+
+#[allow(dead_code)]
 ///
 /// Tracing filtering rules:
 /// 1. if `RUST_LOG`, use that filter


### PR DESCRIPTION
Following issue: #120 we need to disable the logger when loco running in test mode. to avoid this error:
```
a global default trace dispatcher has already been set
``` 