### PR TITLE
crete database

### DIFF
--- a/examples/demo/tests/cmd/cli.trycmd
+++ b/examples/demo/tests/cmd/cli.trycmd
@@ -30,6 +30,7 @@ Perform DB operations
 Usage: blo-cli db [OPTIONS] <COMMAND>
 
 Commands:
+  create    Create schema
   migrate   Migrate schema (up)
   reset     Drop all tables, then reapply all migrations
   status    Migration status

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -24,6 +24,17 @@ use crate::{
     worker::{self, AppWorker, Pool, Processor, RedisConnectionManager, DEFAULT_QUEUES},
     Result,
 };
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    // Getting the table name from the environment configuration.
+    // For example:
+    // postgres://loco:loco@localhost:5432/loco_app
+    // mysql://loco:loco@localhost:3306/loco_app
+    // the results will be loco_app
+    static ref EXTRACT_DB_NAME: Regex = Regex::new(r"/([^/]+)$").unwrap();
+}
 
 /// Represents the application startup mode.
 pub enum StartMode {
@@ -113,6 +124,8 @@ pub async fn run_task<H: Hooks>(
 /// Represents commands for handling database-related operations.
 #[derive(Debug)]
 pub enum RunDbCommand {
+    /// Create schema.
+    Create,
     /// Apply pending migrations.
     Migrate,
     /// Drop all tables, then reapply all migrations.
@@ -138,6 +151,16 @@ pub async fn run_db<H: Hooks, M: MigratorTrait>(
     cmd: RunDbCommand,
 ) -> Result<()> {
     match cmd {
+        RunDbCommand::Create => {
+            let db_name = EXTRACT_DB_NAME
+                .captures(&app_context.config.database.uri)
+                .and_then(|cap| cap.get(1).map(|db| db.as_str()))
+                .ok_or(Error::Message(
+                    "table name not found in given DB uri".to_string(),
+                ))?;
+
+            db::create(&app_context.db, db_name).await?;
+        }
         RunDbCommand::Migrate => {
             tracing::warn!("migrate:");
             let _ = db::migrate::<M>(&app_context.db).await;

--- a/src/db.rs
+++ b/src/db.rs
@@ -23,6 +23,18 @@ use crate::{
     errors::Error as LocoError,
 };
 
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    // Getting the table name from the environment configuration.
+    // For example:
+    // postgres://loco:loco@localhost:5432/loco_app
+    // mysql://loco:loco@localhost:3306/loco_app
+    // the results will be loco_app
+    pub static ref EXTRACT_DB_NAME: Regex = Regex::new(r"/([^/]+)$").unwrap();
+}
+
 /// converge database logic
 ///
 /// # Errors
@@ -70,19 +82,28 @@ pub async fn connect(config: &config::Database) -> Result<DbConn, sea_orm::DbErr
     Database::connect(opt).await
 }
 
-/// Create a new  database.
-/// The db connection should't include the destination of your db that we need to create.
-/// For example in postgres if
+///  Create a new database. This functionality is currently exclusive to Postgre databases.
 ///
 /// # Errors
 ///
 /// Returns a [`sea_orm::DbErr`] if an error occurs during run migration up.
-pub async fn create(db: &DatabaseConnection, db_name: &str) -> Result<(), sea_orm::DbErr> {
-    match db.get_database_backend() {
-        sea_orm::DatabaseBackend::MySql => create_mysql_database(db_name, db).await,
-        sea_orm::DatabaseBackend::Postgres => create_postgres_database(db_name, db).await,
-        sea_orm::DatabaseBackend::Sqlite => Ok(()),
+pub async fn create(db_uri: &str) -> AppResult<()> {
+    if !db_uri.starts_with("postgres://") {
+        return Err(LocoError::Message(
+            "Only Postgres databases are supported for table creation".to_string(),
+        ));
     }
+    let db_name = EXTRACT_DB_NAME
+        .captures(db_uri)
+        .and_then(|cap| cap.get(1).map(|db| db.as_str()))
+        .ok_or(Error::Message(
+            "The specified table name was not found in the given Postgre database URI".to_string(),
+        ))?;
+
+    let conn = EXTRACT_DB_NAME.replace(db_uri, "/postgres").to_string();
+    let db = Database::connect(conn).await?;
+
+    Ok(create_postgres_database(db_name, &db).await?)
 }
 
 /// Apply migrations to the database using the provided migrator.
@@ -278,28 +299,6 @@ async fn create_postgres_database(
     let query = format!("CREATE DATABASE {table_name} WITH {with_options}");
     tracing::info!(query, "creating mysql table");
 
-    db.execute(sea_orm::Statement::from_string(
-        sea_orm::DatabaseBackend::Postgres,
-        query,
-    ))
-    .await?;
-    Ok(())
-}
-
-/// Create a mysql table from the given table name.
-///
-/// To create the table with `LOCO_MYSQL_TABLE_OPTIONS`
-async fn create_mysql_database(
-    table_name: &str,
-    db: &DatabaseConnection,
-) -> Result<(), sea_orm::DbErr> {
-    let with_options = std::env::var("LOCO_MYSQL_TABLE_OPTIONS").map_or_else(
-        |_| "DEFAULT CHARACTER SET `utf8mb4`".to_string(),
-        |options| options,
-    );
-
-    let query = format!("CREATE DATABASE {table_name} {with_options}");
-    tracing::info!(query, "creating mysql table");
     db.execute(sea_orm::Statement::from_string(
         sea_orm::DatabaseBackend::Postgres,
         query,


### PR DESCRIPTION
Add the option to create a database from the CLI. #112 

This PR is still in progress.

In `db` cli command we call `create_context` which creates  DB connection from the yaml config. At this point when the user wants to create a DB the database does not exists and the `create_context` returns an error.

My investigation:
**postgres** 
We can replace the DB name to Postgres and open the connection, which creates automatically and then we can create the Database
`postgres://loco:loco@localhost:5432/postgress`

**MySql**
We can remove the db name from the connection string and create the DB
`mysql://loco:loco@localhost:3306/`


 

