### PR TITLE
Modified listen address to support IpV6

### DIFF
--- a/src/boot.rs
+++ b/src/boot.rs
@@ -165,7 +165,7 @@ pub async fn run_db<H: Hooks, M: MigratorTrait>(
 /// Starts the server using the provided [`Router`] and [`Config`].
 async fn serve(app: Router, config: &Config) -> Result<()> {
     let listener =
-        tokio::net::TcpListener::bind(&format!("0.0.0.0:{}", config.server.port)).await?;
+        tokio::net::TcpListener::bind(&format!("[::]:{}", config.server.port)).await?;
 
     axum::serve(listener, app).await?;
 

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -164,8 +164,7 @@ pub async fn run_db<H: Hooks, M: MigratorTrait>(
 
 /// Starts the server using the provided [`Router`] and [`Config`].
 async fn serve(app: Router, config: &Config) -> Result<()> {
-    let listener =
-        tokio::net::TcpListener::bind(&format!("[::]:{}", config.server.port)).await?;
+    let listener = tokio::net::TcpListener::bind(&format!("[::]:{}", config.server.port)).await?;
 
     axum::serve(listener, app).await?;
 


### PR DESCRIPTION
- Listen address was originally "0.0.0.0:{PORT}" which presented a problem when deploying to fly.io
- Modified the address to "[::]:{PORT} to support both IpV4 and IpV6 allowing fly.io deployment