### PR TITLE
Adding a new command to the CLI to generate JWT secret keys

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -156,6 +156,8 @@ enum ComponentArg {
     },
     /// Generate a deployment infrastructure
     Deployment {},
+    /// Generate a new JWT secret
+    JwtSecret {}
 }
 
 impl From<ComponentArg> for Component {
@@ -172,6 +174,7 @@ impl From<ComponentArg> for Component {
             ComponentArg::Worker { name } => Self::Worker { name },
             ComponentArg::Mailer { name } => Self::Mailer { name },
             ComponentArg::Deployment {} => Self::Deployment {},
+            ComponentArg::JwtSecret {} => Self::JwtSecret {  }
         }
     }
 }

--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use rrgen::{GenResult, RRgen};
 use serde_json::json;
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
 
 #[cfg(feature = "with-db")]
 mod model;
@@ -99,6 +100,7 @@ pub enum Component {
         name: String,
     },
     Deployment {},
+    JwtSecret {}
 }
 
 pub fn generate<H: Hooks>(component: Component, config: &Config) -> Result<()> {
@@ -177,6 +179,14 @@ pub fn generate<H: Hooks>(component: Component, config: &Config) -> Result<()> {
                     rrgen.generate(DEPLOYMENT_SHUTTLE_CONFIG_T, &vars)?;
                 }
             }
+        }
+        Component::JwtSecret {} => {  
+            let new_secret: String = thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(20)
+                .map(char::from)
+                .collect();
+            println!("New JWT secret: {}", new_secret);
         }
     }
     Ok(())


### PR DESCRIPTION
After my own mistake with this while releasing to production I've decided that the CLI needs a way to generate new JWT secrets