### PR TITLE
Add missing Json params to guide

### DIFF
--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -834,6 +834,7 @@ To require authentication, we need to modify the function signature in this way:
 async fn add(
     auth: auth::JWT,
     State(ctx): State<AppContext>,
+    Json(params): Json<Params>,
 ) -> Result<Json<CurrentResponse>> {
   // we only want to make sure it exists
   let _current_user = users::Model::find_by_pid(&ctx.db, &auth.claims.pid).await?;


### PR DESCRIPTION
This adds the missing Json parameter to the add function in the getting started guide.  This is done in order for the function to correctly reference params in later lines.