### PR TITLE
(docs) enable `compression` for CompressionLayer, not etag

### DIFF
--- a/docs-site/content/docs/the-app/controller.md
+++ b/docs-site/content/docs/the-app/controller.md
@@ -190,7 +190,7 @@ To enable response compression, based on `accept-encoding` request header, simpl
 ```yaml
 #...
   middlewares:
-    etag:
+    compression:
       enable: true
 ```
 


### PR DESCRIPTION
Just a quick documentation edit i found while reading the docs and configuring. After this change, I got my requests being compressed :sparkles: 