### PR TITLE
Fix nullable jsonb column schema definition.

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -406,5 +406,5 @@ pub fn jsonb_null<T>(name: T) -> ColumnDef
 where
     T: IntoIden,
 {
-    ColumnDef::new(name).json_binary().not_null().clone()
+    ColumnDef::new(name).json_binary().clone()
 }


### PR DESCRIPTION
Probably a copy / paste error, but the nullable version of the `jsonb` column was not generating a nullable column.