### PR TITLE
Site doc fixes for #359

### DIFF
--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -54,9 +54,9 @@ Now you can create your new app (choose "Saas app" for built-in authentication).
 $ loco new
 ✔ ❯ App name? · myapp
 ? ❯ What would you like to build? ›
-❯ lightweight-service (minimal, only controllers and views)
+  lightweight-service (minimal, only controllers and views)
   Rest API (with DB and user auth)
-  Saas app (with DB and user auth)
+❯ Saas app (with DB and user auth)
 🚂 Loco app generated successfully in:
 myapp
 ```

--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -418,15 +418,16 @@ Your `examples/` folder contains:
 Let's fetch data using your models, using `playground.rs`:
 
 ```rust
-// located in src/bin/playground.rs
+// located in examples/playground.rs
 // use this file to experiment with stuff
 use eyre::Context;
 use loco_rs::{cli::playground, prelude::*};
-use locoapp::{app::App, models::_entities::articles};
+// to refer to articles::ActiveModel, your imports should look like this:
+use myapp::{app::App, models::_entities::articles};
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    let ctx = playground::<App>().await.context("playground")?;
+    let ctx = playground::<App>().await.context("playground")?; // <- remove '_'
 
     // add this:
     let res = articles::Entity::find().all(&ctx.db).await.unwrap();
@@ -690,7 +691,7 @@ pub struct Params {
 }
 
 impl Params {
-    fn update(&self, item: &mut comments::ActiveModel) {
+    fn update(&self, item: &mut ActiveModel) {
         item.content = Set(self.content.clone());
         item.article_id = Set(self.article_id.clone()); // <- add this
     }
@@ -712,7 +713,7 @@ And implement the relation fetching:
 ```rust
 // to refer to comments::Entity, your imports should look like this:
 use crate::models::_entities::{
-    articles::{self, ActiveModel, Entity, Model},
+    articles::{ActiveModel, Entity, Model},
     comments,
 };
 
@@ -837,7 +838,7 @@ async fn add(
     Json(params): Json<Params>,
 ) -> Result<Json<CurrentResponse>> {
   // we only want to make sure it exists
-  let _current_user = users::Model::find_by_pid(&ctx.db, &auth.claims.pid).await?;
+  let _current_user = crate::models::users::Model::find_by_pid(&ctx.db, &auth.claims.pid).await?;
 
   // next, update
   // homework/bonus: make a comment _actually_ belong to user (user_id)

--- a/docs-site/content/docs/getting-started/tour/index.md
+++ b/docs-site/content/docs/getting-started/tour/index.md
@@ -16,7 +16,7 @@ top = false
 <br/>
 <br/>
 <br/>
-Let's create a backend on `loco` in 4 commands. First install `loco-cli` and `sea-orm-cli`:
+Let's create a blog backend on `loco` in 4 commands. First install `loco-cli` and `sea-orm-cli`:
 
 ```sh
 $ cargo install loco-cli

--- a/docs-site/content/docs/getting-started/tour/index.md
+++ b/docs-site/content/docs/getting-started/tour/index.md
@@ -16,7 +16,7 @@ top = false
 <br/>
 <br/>
 <br/>
-Let's create a blog on `loco` in 4 commands. First install `loco-cli` and `sea-orm-cli`:
+Let's create a backend on `loco` in 4 commands. First install `loco-cli` and `sea-orm-cli`:
 
 ```sh
 $ cargo install loco-cli
@@ -27,9 +27,11 @@ Now you can create your new app (choose "Saas app").
 
 ```sh
 $ loco new
-❯ App name? [myapp]:
+✔ ❯ App name? · myapp
+? ❯ What would you like to build? ›
+  lightweight-service (minimal, only controllers and views)
+  Rest API (with DB and user auth)
 ❯ Saas app (with DB and user auth)
-  Stateless service (minimal, no db)
 🚂 Loco app generated successfully in:
 myapp
 ```
@@ -86,7 +88,7 @@ You don't have to run things through `cargo` but in development it's highly reco
 
 ## Adding a CRUD API
 
-We have a base SaaS app with user authentication generated for us. Let's make it a blog by adding a `post` and a full CRUD API using `scaffold`:
+We have a base SaaS app with user authentication generated for us. Let's make it a blog backend by adding a `post` and a full CRUD API using `scaffold`:
 
 ```sh
 $ cargo loco generate scaffold post title:string content:text
@@ -127,7 +129,7 @@ You can list your posts:
 $ curl localhost:3000/api/posts
 ```
 
-For those counting -- the commands for creating a blog were:
+For those counting -- the commands for creating a blog backend were:
 
 1. `cargo install loco-cli`
 2. `cargo install sea-orm-cli`
@@ -139,6 +141,22 @@ Done! enjoy your ride with `loco` 🚂
 ## Checking Out SaaS Authentication
 
 Your generated app contains a fully working authentication suite, based on JWTs.
+
+To authenticate, you will need a running redis server. 
+
+This docker command starts up a redis server:
+```
+docker run -p 6379:6379 -d redis redis-server
+```
+Use doctor command to check the needed resources:
+```
+$ cargo loco doctor
+    Finished dev [unoptimized + debuginfo] target(s) in 0.32s
+     Running `target/debug/myapp-cli doctor`
+✅ SeaORM CLI is installed
+✅ DB connection: success
+✅ Redis connection: success
+```
 
 ### Registering a New User
 


### PR DESCRIPTION
This commit includes the following fixes to the site documentation:

1. Mentions you need to run redis in the Quick Tour
2. Clarifies that the Quick Tour creates a site backend
3. Updates the Quick Tour `loco new` text to reflect current text
4. Updates the guide `loco new` text to clearer show the starter choice with an arrow