### PR TITLE
fix: issue #410 in db.rs

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -52,6 +52,7 @@ pub async fn verify_access(db: &DatabaseConnection) -> AppResult<()> {
                 ));
             }
         }
+        DatabaseConnection::SqlxMySqlPoolConnection(_) => {}
         DatabaseConnection::SqlxSqlitePoolConnection(_) => {}
         DatabaseConnection::Disconnected => {
             return Err(Error::string("connection to database has been closed"));


### PR DESCRIPTION
Fix the issue #410 where one could'nt use mysql for the driver because `DatabaseConnection` match case was not fully covered.