### PR TITLE
move serve webserver to app hooks

### DIFF
--- a/examples/demo/examples/start.rs
+++ b/examples/demo/examples/start.rs
@@ -14,6 +14,6 @@ async fn main() -> eyre::Result<()> {
         port: boot_result.app_context.config.server.port,
         binding: boot_result.app_context.config.server.binding.to_string(),
     };
-    start(boot_result, serve_params).await?;
+    start::<App>(boot_result, serve_params).await?;
     Ok(())
 }

--- a/examples/demo/examples/workers.rs
+++ b/examples/demo/examples/workers.rs
@@ -14,6 +14,6 @@ async fn main() -> eyre::Result<()> {
         port: boot_result.app_context.config.server.port,
         binding: boot_result.app_context.config.server.binding.to_string(),
     };
-    start(boot_result, serve_params).await?;
+    start::<App>(boot_result, serve_params).await?;
     Ok(())
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,7 @@ use axum::Router as AxumRouter;
 #[cfg(feature = "channels")]
 use crate::controller::channels::AppChannels;
 use crate::{
-    boot::{BootResult, StartMode},
+    boot::{BootResult, ServeParams, StartMode},
     config::{self, Config},
     controller::AppRoutes,
     environment::Environment,
@@ -94,6 +94,23 @@ pub trait Hooks {
     /// # Errors
     /// Could not boot the application
     async fn boot(mode: StartMode, environment: &Environment) -> Result<BootResult>;
+
+    /// Start serving the Axum web application on the specified address and
+    /// port.
+    ///
+    /// # Returns
+    /// A Result indicating success () or an error if the server fails to start.
+    async fn serve(app: AxumRouter, server_config: ServeParams) -> Result<()> {
+        let listener = tokio::net::TcpListener::bind(&format!(
+            "{}:{}",
+            server_config.binding, server_config.port
+        ))
+        .await?;
+
+        axum::serve(listener, app).await?;
+
+        Ok(())
+    }
 
     /// Override and return `Ok(true)` to provide an alternative logging and
     /// tracing stack of your own.

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -61,7 +61,7 @@ pub struct ServeParams {
 /// # Errors
 ///
 /// When could not initialize the application.
-pub async fn start(boot: BootResult, server_config: ServeParams) -> Result<()> {
+pub async fn start<H: Hooks>(boot: BootResult, server_config: ServeParams) -> Result<()> {
     print_banner(&boot, &server_config);
 
     let BootResult {
@@ -77,10 +77,10 @@ pub async fn start(boot: BootResult, server_config: ServeParams) -> Result<()> {
                     tracing::error!("Error in processing: {:?}", err);
                 }
             });
-            serve(router, server_config).await?;
+            H::serve(router, server_config).await?;
         }
         (Some(router), None) => {
-            serve(router, server_config).await?;
+            H::serve(router, server_config).await?;
         }
         (None, Some(processor)) => {
             process(processor).await?;
@@ -169,17 +169,6 @@ pub async fn run_db<H: Hooks, M: MigratorTrait>(
             H::truncate(&app_context.db).await?;
         }
     }
-    Ok(())
-}
-
-/// Starts the server using the provided [`Router`] and [`ServeParams`].
-async fn serve(app: Router, server_config: ServeParams) -> Result<()> {
-    let listener =
-        tokio::net::TcpListener::bind(&format!("{}:{}", server_config.binding, server_config.port))
-            .await?;
-
-    axum::serve(listener, app).await?;
-
     Ok(())
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -315,7 +315,7 @@ pub async fn main<H: Hooks, M: MigratorTrait>() -> eyre::Result<()> {
                     |b| b,
                 ),
             };
-            start(boot_result, serve_params).await?;
+            start::<H>(boot_result, serve_params).await?;
         }
         #[cfg(feature = "with-db")]
         Commands::Db { command } => {
@@ -394,7 +394,7 @@ pub async fn main<H: Hooks>() -> eyre::Result<()> {
                     |b| b,
                 ),
             };
-            start(boot_result, serve_params).await?;
+            start::<H>(boot_result, serve_params).await?;
         }
         Commands::Routes {} => {
             let app_context = create_context::<H>(&environment).await?;


### PR DESCRIPTION
After considering the points discussed in [this GitHub discussion](https://github.com/loco-rs/loco/discussions/324), I've relocated the serve function to the application hook. This modification enables users to customize and use different serve implementations for the web server by overriding this specific hook.