### PR TITLE
feat: update shuttle deployment template to 0.38

### DIFF
--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -128,8 +128,7 @@ pub fn generate<H: Hooks>(component: Component, config: &Config) -> Result<()> {
         }
         #[cfg(feature = "with-db")]
         Component::Migration { name } => {
-            let ts = Utc::now();
-            let vars = json!({ "name": name, "ts": ts, "pkg_name": H::app_name()});
+            let vars = json!({ "name": name, "ts": Utc::now(), "pkg_name": H::app_name()});
             rrgen.generate(MIGRATION_T, &vars)?;
         }
         Component::Controller { name } => {
@@ -139,13 +138,11 @@ pub fn generate<H: Hooks>(component: Component, config: &Config) -> Result<()> {
         }
         Component::Task { name } => {
             let vars = json!({"name": name, "pkg_name": H::app_name()});
-
             rrgen.generate(TASK_T, &vars)?;
             rrgen.generate(TASK_TEST_T, &vars)?;
         }
         Component::Worker { name } => {
             let vars = json!({"name": name, "pkg_name": H::app_name()});
-
             rrgen.generate(WORKER_T, &vars)?;
             rrgen.generate(WORKER_TEST_T, &vars)?;
         }

--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -33,8 +33,7 @@ const DEPLOYMENT_SHUTTLE_T: &str = include_str!("templates/deployment_shuttle.t"
 const DEPLOYMENT_SHUTTLE_CONFIG_T: &str = include_str!("templates/deployment_shuttle_config.t");
 const DEPLOYMENT_NGINX_T: &str = include_str!("templates/deployment_nginx.t");
 
-const DEPLOYMENT_SHUTTLE_RUNTIME_VERSION: &str = "0.35.0";
-const DEPLOYMENT_SHUTTLE_AXUM_VERSION: &str = "0.35.0";
+const DEPLOYMENT_SHUTTLE_RUNTIME_VERSION: &str = "0.38.0";
 
 const DEPLOYMENT_OPTIONS: &[(&str, DeploymentKind)] = &[
     ("Docker", DeploymentKind::Docker),
@@ -181,12 +180,20 @@ pub fn generate<H: Hooks>(component: Component, config: &Config) -> Result<()> {
                         .as_ref()
                         .map(|s| s.fallback.clone());
 
-                    let vars = json!({ "pkg_name": H::app_name(), "copy_asset_folder": copy_asset_folder, "fallback_file": fallback_file });
+                    let vars = json!({
+                        "pkg_name": H::app_name(),
+                        "copy_asset_folder": copy_asset_folder,
+                        "fallback_file": fallback_file
+                    });
                     rrgen.generate(DEPLOYMENT_DOCKER_T, &vars)?;
                     rrgen.generate(DEPLOYMENT_DOCKER_IGNORE_T, &vars)?;
                 }
                 DeploymentKind::Shuttle => {
-                    let vars = json!({ "pkg_name": H::app_name(), "shuttle_runtime_version": DEPLOYMENT_SHUTTLE_RUNTIME_VERSION, "shuttle_axum_version": DEPLOYMENT_SHUTTLE_AXUM_VERSION });
+                    let vars = json!({
+                        "pkg_name": H::app_name(),
+                        "shuttle_runtime_version": DEPLOYMENT_SHUTTLE_RUNTIME_VERSION,
+                        "with_db": cfg!(feature = "with-db")
+                    });
                     rrgen.generate(DEPLOYMENT_SHUTTLE_T, &vars)?;
                     rrgen.generate(DEPLOYMENT_SHUTTLE_CONFIG_T, &vars)?;
                 }
@@ -196,7 +203,11 @@ pub fn generate<H: Hooks>(component: Component, config: &Config) -> Result<()> {
                         .host
                         .replace("http://", "")
                         .replace("https://", "");
-                    let vars = json!({ "pkg_name": H::app_name(), "domain": &host, "port":  &config.server.port });
+                    let vars = json!({
+                        "pkg_name": H::app_name(),
+                        "domain": &host,
+                        "port": &config.server.port
+                    });
                     rrgen.generate(DEPLOYMENT_NGINX_T, &vars)?;
                 }
             }


### PR DESCRIPTION
Closes #395 

- Bumps shuttle versions to 0.38.0, use same version for all shuttle crates.
- Adds a shutte postgres connection if a `with-db` template is used.
- Fixed the environment parsing, and uses environment based on shuttle metadata.

I tested generating and running locally for the lightweight and the saas template.
TODO: Confirm deployment on Shuttle works. (the env + config etc)