### PR TITLE
create loco_extra crate that contains a list of common implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,24 @@
 [workspace]
-members = ["macros", "xtask"]
+members = ["macros", "xtask", "loco-extras"]
 exclude = ["starters"]
 
+[workspace.package]
+edition = "2021"
+rust-version = "1.70"
+license = "Apache-2.0"
 
 [package]
 name = "loco-rs"
 version = "0.2.3"
-rust-version = "1.70"
-edition = "2021"
 description = "The one-person framework for Rust"
-license = "Apache-2.0"
 homepage = "https://loco.rs/"
 documentation = "https://docs.rs/loco-rs"
 authors = ["Dotan Nahum <dotan@rng0.io>", "Elad Kaplan <kaplan.elad@gmail.com>"]
 repository = "https://github.com/loco-rs/loco"
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
@@ -53,10 +58,10 @@ serde_variant = "0.1.2"
 
 # worker fwk 
 rusty-sidekiq = { version = "0.8.2", default-features = false }
-async-trait = "0.1.74"
+async-trait = { workspace = true }
 bb8 = "0.8.1"
 
-axum = { version = "0.7.1", features = ["macros"] }
+axum = { workspace = true }
 axum-extra = { version = "0.9", features = ["cookie"] }
 regex = "1"
 lazy_static = "1.4.0"
@@ -116,6 +121,9 @@ requestty = "0.5.0"
 
 socketioxide = { version = "0.10.0", features = ["state"], optional = true }
 
+[workspace.dependencies]
+async-trait = { version = "0.1.74" }
+axum = { version = "0.7.1", features = ["macros"] }
 
 [dependencies.sea-orm-migration]
 optional = true

--- a/loco-extras/Cargo.toml
+++ b/loco-extras/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "loco-extras"
+version = "0.1.0"
+description = "Loco extras contains a list of common implementation that are generally useful when working with loco.rs"
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+loco-rs = { path = "../", default-features = false }
+async-trait = { workspace = true }
+axum = { workspace = true }
+
+# initializer
+axum-prometheus = { version = "0.6.1", optional = true }
+
+[features]
+default = []
+full = ["initializer-prometheus"]
+
+initializer-prometheus = ["dep:axum-prometheus"]

--- a/loco-extras/README.md
+++ b/loco-extras/README.md
@@ -1,0 +1,4 @@
+# Loco Extras
+
+Loco extras contains a list of common implementation that are generally useful when working with [Loco](https://loco.rs/). 
+

--- a/loco-extras/src/initializers/mod.rs
+++ b/loco-extras/src/initializers/mod.rs
@@ -22,7 +22,7 @@
 //! Once the `loco_extras` crate is included, proceed to the `initializers` hook
 //! function and add your initializations. Here's an example:
 //!
-//! ```rust
+//! ```rust,ignore
 //! impl Hooks for App {
 //!     .
 //!     .

--- a/loco-extras/src/initializers/mod.rs
+++ b/loco-extras/src/initializers/mod.rs
@@ -1,0 +1,51 @@
+//! Initializers
+//!
+//! Initializers are a way to encapsulate a piece of infrastructure "wiring"
+//! that you need to do in your app. read more [here](https://loco.rs/docs/the-app/initializers/)
+//!
+//! ### How To Use
+//!
+//! To integrate `loco-extras` into your project, add the following line to your
+//! `Cargo.toml` file:
+//!
+//! ```toml
+//! loco-extras = { version = "*",  features = ["FEATURE"] }
+//! ```
+//!
+//! After adding the crate to your project, navigate to the application hooks in
+//! `app.rs` and include the `loco_extras` crate:
+//!
+//! ```rust
+//! use loco_extras;
+//! ```
+//!
+//! Once the `loco_extras` crate is included, proceed to the `initializers` hook
+//! function and add your initializations. Here's an example:
+//!
+//! ```rust
+//! impl Hooks for App {
+//!     .
+//!     .
+//!     .
+//!     async fn initializers(_ctx: &AppContext) -> Result<Vec<Box<dyn Initializer>>> {
+//!        Ok(vec![
+//!            Box::new(loco_extras::initializers::[MODULE_NAME]),
+//!        ])
+//!    }
+//! }
+//! ```
+//!
+//! ### Customization
+//!
+//! The extras initializers are intentionally not designed for extensive
+//! modifications. The concept is to use them as-is without complexity. If you
+//! need to customize the initializers, copy the relevant file from the
+//! `loco_extras` project into your app, adapt it to your requirements, and
+//! update the hook to reference the new source.
+//!
+//! ### Prometheus:
+//!```rust
+#![doc = include_str!("././prometheus.rs")]
+//!````
+#[cfg(feature = "initializer-prometheus")]
+pub mod prometheus;

--- a/loco-extras/src/initializers/prometheus.rs
+++ b/loco-extras/src/initializers/prometheus.rs
@@ -1,0 +1,20 @@
+use async_trait::async_trait;
+use axum::Router as AxumRouter;
+use loco_rs::prelude::*;
+pub struct AxumPrometheusInitializer;
+use axum_prometheus::PrometheusMetricLayer;
+
+#[async_trait]
+impl Initializer for AxumPrometheusInitializer {
+    fn name(&self) -> String {
+        "axum-prometheus".to_string()
+    }
+
+    async fn after_routes(&self, router: AxumRouter, _ctx: &AppContext) -> Result<AxumRouter> {
+        let (prometheus_layer, metric_handle) = PrometheusMetricLayer::pair();
+        let router = router
+            .route("/metrics", get(|| async move { metric_handle.render() }))
+            .layer(prometheus_layer);
+        Ok(router)
+    }
+}

--- a/loco-extras/src/lib.rs
+++ b/loco-extras/src/lib.rs
@@ -1,0 +1,10 @@
+//! # Loco Extras
+//!
+//! Loco Extras provides a collection of common implementations that prove to be generally useful when working with [Loco](https://loco.rs/).
+//!
+//! ## Features
+//!
+//! ### initializers
+//! * `initializer-prometheus` For adding prometheus collection metrics
+//!   endpoint.
+pub mod initializers;


### PR DESCRIPTION
Creating a new crate to simplify adding basic common implementations to the app and easy to copy the code and edit for custom use cases 