### PR TITLE
Update Dockerfile

### DIFF
--- a/starters/rest-api/.devcontainer/Dockerfile
+++ b/starters/rest-api/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
+FROM mcr.microsoft.com/devcontainers/rust:1
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
      && apt-get -y install --no-install-recommends postgresql-client \


### PR DESCRIPTION
sea-orm-cli complaint because rust version on the rust:0-1 is less than minimum requirement