### PR TITLE
feat: update docs site models and fix generate model schema data type…

### DIFF
--- a/docs-site/content/docs/the-app/models.md
+++ b/docs-site/content/docs/the-app/models.md
@@ -83,7 +83,9 @@ These fields are ignored if you provide them in your migration command. In addit
 For schema data types, you can use the following mapping to understand the schema:
 
 ```rust
-("uuid", "uuid"),
+("uuid", "uuid_null"),
+("uuid!", "uuid"),
+("uuid^", "uuid_uniq"),
 ("string", "string_null"),
 ("string!", "string"),
 ("string^", "string_uniq"),
@@ -109,8 +111,8 @@ For schema data types, you can use the following mapping to understand the schem
 ("decimal!", "decimal"),
 ("decimal_len", "decimal_len_null"),
 ("decimal_len!", "decimal_len"),
-("bool", "bool_null"),
-("bool!", "bool"),
+("boolean", "boolean_null"),
+("boolean!", "boolean"),
 ("tstz", "timestamptz_null"),
 ("tstz!", "timestamptz"),
 ("date", "date_null"),
@@ -119,8 +121,8 @@ For schema data types, you can use the following mapping to understand the schem
 ("ts!", "timestamp"),
 ("json", "json_null"),
 ("json!", "json"),
-("jsonb", "jsonb_null"),
-("jsonb!", "jsonb"),
+("jsonb", "json_binary_null"),
+("jsonb!", "json_binary"),
 ```
 
 

--- a/src/gen/model.rs
+++ b/src/gen/model.rs
@@ -20,9 +20,9 @@ pub const IGNORE_FIELDS: &[&str] = &["created_at", "updated_at", "create_at", "u
 
 lazy_static! {
     static ref TYPEMAP: HashMap<&'static str, &'static str> = HashMap::from([
-        ("uuid", "uuid"),
-        ("uuid_col!", "uuid_col"),
-        ("uuid_col", "uuid_col_null"),
+        ("uuid", "uuid_null"),
+        ("uuid!", "uuid"),
+        ("uuid^", "uuid_uniq"),
         ("string", "string_null"),
         ("string!", "string"),
         ("string^", "string_uniq"),
@@ -48,8 +48,8 @@ lazy_static! {
         ("decimal!", "decimal"),
         ("decimal_len", "decimal_len_null"),
         ("decimal_len!", "decimal_len"),
-        ("bool", "bool_null"),
-        ("bool!", "bool"),
+        ("boolean", "boolean_null"),
+        ("boolean!", "boolean"),
         ("tstz", "timestamptz_null"),
         ("tstz!", "timestamptz"),
         ("date", "date_null"),
@@ -58,8 +58,8 @@ lazy_static! {
         ("ts!", "timestamp"),
         ("json", "json_null"),
         ("json!", "json"),
-        ("jsonb", "jsonb_null"),
-        ("jsonb!", "jsonb"),
+        ("jsonb", "json_binary_null"),
+        ("jsonb!", "json_binary"),
     ]);
 }
 

--- a/src/gen/model.rs
+++ b/src/gen/model.rs
@@ -20,9 +20,9 @@ pub const IGNORE_FIELDS: &[&str] = &["created_at", "updated_at", "create_at", "u
 
 lazy_static! {
     static ref TYPEMAP: HashMap<&'static str, &'static str> = HashMap::from([
-        ("uuid", "uuid_null"),
-        ("uuid!", "uuid"),
-        ("uuid^", "uuid_uniq"),
+        ("uuid", "uuid_uniq"),
+        ("uuid_col", "uuid_null"),
+        ("uuid_col!", "uuid"),
         ("string", "string_null"),
         ("string!", "string"),
         ("string^", "string_uniq"),
@@ -48,10 +48,10 @@ lazy_static! {
         ("decimal!", "decimal"),
         ("decimal_len", "decimal_len_null"),
         ("decimal_len!", "decimal_len"),
-        ("boolean", "boolean_null"),
-        ("boolean!", "boolean"),
-        ("tstz", "timestamptz_null"),
-        ("tstz!", "timestamptz"),
+        ("bool", "boolean_null"),
+        ("bool!", "boolean"),
+        ("tstz", "timestamp_with_time_zone_null"),
+        ("tstz!", "timestamp_with_time_zone"),
         ("date", "date_null"),
         ("date!", "date"),
         ("ts", "timestamp_null"),

--- a/src/gen/templates/model.t
+++ b/src/gen/templates/model.t
@@ -38,7 +38,11 @@ impl MigrationTrait for Migration {
                     .col(pk_auto({{model}}::Id))
                     {% endif -%}
                     {% for column in columns -%}
+                    {% if column.1 == "decimal_len_null" or column.1 == "decimal_len" -%}
+                    .col({{column.1}}({{model}}::{{column.0 | pascal_case }}, 16, 4))
+                    {% else -%}
                     .col({{column.1}}({{model}}::{{column.0 | pascal_case}}))
+                    {% endif -%}
                     {% endfor -%}
                     {% for ref in references -%}
                     .foreign_key(


### PR DESCRIPTION
# What's changed and what's your intention?

https://github.com/loco-rs/loco/issues/455
Fix `cargo loco generate model` bug caused by upgrading SeaORM

I'm not sure, if I need to handle all supported types in `sea_orm_migration::schema`, so only make changes to the types previously supported by loco.
Regarding the adjustment of uuid, I am not sure whether I fixed it correctly. In order to keep it consistent with other field types, change it to:

```
uuid-> uuid_null
uuid!->uuid
uuid^->uuid_uniq
```

# Checklist

- [ ]  docs site models 
- [ ]  update `src/gen/model.rs` TYPEMAP ,Contains uuid, boolean, jsonb