### PR TITLE
fix: starters devcontainer Dockerfile image update

### DIFF
--- a/starters/lightweight-service/.devcontainer/Dockerfile
+++ b/starters/lightweight-service/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
+FROM mcr.microsoft.com/devcontainers/rust:1
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
      && apt-get -y install --no-install-recommends postgresql-client \

--- a/starters/rest-api/.devcontainer/Dockerfile
+++ b/starters/rest-api/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
+FROM mcr.microsoft.com/devcontainers/rust:1
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
      && apt-get -y install --no-install-recommends postgresql-client \

--- a/starters/saas/.devcontainer/Dockerfile
+++ b/starters/saas/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
+FROM mcr.microsoft.com/devcontainers/rust:1
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
      && apt-get -y install --no-install-recommends postgresql-client \


### PR DESCRIPTION

Currently, when using vsocde devcontainer, the code generated by loco new cannot be compiled because the rustc version is too low.
```
error: package `clap_lex v0.7.0` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.70.0
Either upgrade to rustc 1.74 or newer, or use
cargo update -p clap_lex@0.7.0 --precise ver
where `ver` is the latest version of `clap_lex` supporting rustc 1.70.0
```

At the same time,according to https://github.com/microsoft/vscode-dev-containers/blob/main/containers/rust/README.md
> We'll now be publishing the rust image from [devcontainers/images/src/rust](https://github.com/devcontainers/images/tree/main/src/rust).

So updated the Dockerfile of all starters devcontainer