### PR TITLE
Fix Clippy warnings in starter templates

### DIFF
--- a/starters/rest-api/src/models/users.rs
+++ b/starters/rest-api/src/models/users.rs
@@ -71,7 +71,7 @@ impl Authenticable for super::_entities::users::Model {
     }
 
     async fn find_by_claims_key(db: &DatabaseConnection, claims_key: &str) -> ModelResult<Self> {
-        super::_entities::users::Model::find_by_pid(db, claims_key).await
+        Self::find_by_pid(db, claims_key).await
     }
 }
 

--- a/starters/saas/src/models/users.rs
+++ b/starters/saas/src/models/users.rs
@@ -71,7 +71,7 @@ impl Authenticable for super::_entities::users::Model {
     }
 
     async fn find_by_claims_key(db: &DatabaseConnection, claims_key: &str) -> ModelResult<Self> {
-        super::_entities::users::Model::find_by_pid(db, claims_key).await
+        Self::find_by_pid(db, claims_key).await
     }
 }
 


### PR DESCRIPTION
When running the Clippy command in the starter templates there is a `use_self` error. This PR changes the templates to use `Self` and make Clippy happy.