### PR TITLE
typo: "postgress" -> "postgres"

### DIFF
--- a/.github/workflows/ci-example.yml
+++ b/.github/workflows/ci-example.yml
@@ -73,9 +73,9 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_DB: postgress_test
-          POSTGRES_USER: postgress
-          POSTGRES_PASSWORD: postgress
+          POSTGRES_DB: postgres_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
         ports:
           - "5432:5432"
         # Set health checks to wait until postgres has started
@@ -102,4 +102,4 @@ jobs:
         env:
           LOCO_CI_MODE: 1
           REDIS_URL: redis://localhost:${{job.services.redis.ports[6379]}}
-          DATABASE_URL: postgres://postgress:postgress@localhost:5432/postgress_test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres_test

--- a/.github/workflows/ci-generators.yml
+++ b/.github/workflows/ci-generators.yml
@@ -31,9 +31,9 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_DB: postgress_test
-          POSTGRES_USER: postgress
-          POSTGRES_PASSWORD: postgress
+          POSTGRES_DB: postgres_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
         ports:
           - "5432:5432"
         # Set health checks to wait until postgres has started
@@ -61,42 +61,42 @@ jobs:
         working-directory: ./examples/demo
         env:
           REDIS_URL: redis://localhost:${{job.services.redis.ports[6379]}}
-          DATABASE_URL: postgres://postgress:postgress@localhost:5432/postgress_test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres_test
 
       - name: model
         run: cargo run -- generate model post title:string content:text && cargo build
         working-directory: ./examples/demo
         env:
           REDIS_URL: redis://localhost:${{job.services.redis.ports[6379]}}
-          DATABASE_URL: postgres://postgress:postgress@localhost:5432/postgress_test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres_test
 
       - name: controller
         run: cargo run -- generate controller post && cargo build && cargo test requests::post
         working-directory: ./examples/demo
         env:
           REDIS_URL: redis://localhost:${{job.services.redis.ports[6379]}}
-          DATABASE_URL: postgres://postgress:postgress@localhost:5432/postgress_test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres_test
 
       - name: worker
         run: cargo run -- generate worker report_worker && cargo build && cargo test workers::report_worker::test_run_report_worker_worker
         working-directory: ./examples/demo
         env:
           REDIS_URL: redis://localhost:${{job.services.redis.ports[6379]}}
-          DATABASE_URL: postgres://postgress:postgress@localhost:5432/postgress_test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres_test
 
       - name: mailer
         run: cargo run -- generate mailer birthday_mailer && cargo build
         working-directory: ./examples/demo
         env:
           REDIS_URL: redis://localhost:${{job.services.redis.ports[6379]}}
-          DATABASE_URL: postgres://postgress:postgress@localhost:5432/postgress_test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres_test
 
       - name: task
         run: cargo run -- generate task mytask && cargo build && cargo test tasks::mytask::test_can_run_mytask
         working-directory: ./examples/demo
         env:
           REDIS_URL: redis://localhost:${{job.services.redis.ports[6379]}}
-          DATABASE_URL: postgres://postgress:postgress@localhost:5432/postgress_test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres_test
 
       - name: docker deployment
         run: cargo run -- generate deployment
@@ -104,7 +104,7 @@ jobs:
         env:
           LOCO_DEPLOYMENT_KIND: docker
           REDIS_URL: redis://localhost:${{job.services.redis.ports[6379]}}
-          DATABASE_URL: postgres://postgress:postgress@localhost:5432/postgress_test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres_test
 
   model_fields_generator:
     name: Run Tests
@@ -126,9 +126,9 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_DB: postgress_test
-          POSTGRES_USER: postgress
-          POSTGRES_PASSWORD: postgress
+          POSTGRES_DB: postgres_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
         ports:
           - "5432:5432"
         # Set health checks to wait until postgres has started
@@ -198,4 +198,4 @@ jobs:
         working-directory: ./examples/demo
         env:
           REDIS_URL: redis://localhost:${{job.services.redis.ports[6379]}}
-          DATABASE_URL: postgres://postgress:postgress@localhost:5432/postgress_test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres_test

--- a/.github/workflows/ci-starter-rest-api.yml
+++ b/.github/workflows/ci-starter-rest-api.yml
@@ -77,9 +77,9 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_DB: postgress_test
-          POSTGRES_USER: postgress
-          POSTGRES_PASSWORD: postgress
+          POSTGRES_DB: postgres_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
         ports:
           - "5432:5432"
         # Set health checks to wait until postgres has started
@@ -103,7 +103,7 @@ jobs:
         working-directory: ./starters/rest-api
         env:
           REDIS_URL: redis://localhost:${{job.services.redis.ports[6379]}}
-          DATABASE_URL: postgres://postgress:postgress@localhost:5432/postgress_test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres_test
 
   # generate_template:
   #   name: Generate Template

--- a/.github/workflows/ci-starter-saas.yml
+++ b/.github/workflows/ci-starter-saas.yml
@@ -77,9 +77,9 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_DB: postgress_test
-          POSTGRES_USER: postgress
-          POSTGRES_PASSWORD: postgress
+          POSTGRES_DB: postgres_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
         ports:
           - "5432:5432"
         # Set health checks to wait until postgres has started
@@ -103,7 +103,7 @@ jobs:
         working-directory: ./starters/saas
         env:
           REDIS_URL: redis://localhost:${{job.services.redis.ports[6379]}}
-          DATABASE_URL: postgres://postgress:postgress@localhost:5432/postgress_test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres_test
 
   # generate_template:
   #   name: Generate Template
@@ -126,9 +126,9 @@ jobs:
   #     postgres:
   #       image: postgres
   #       env:
-  #         POSTGRES_DB: postgress_test
-  #         POSTGRES_USER: postgress
-  #         POSTGRES_PASSWORD: postgress
+  #         POSTGRES_DB: postgres_test
+  #         POSTGRES_USER: postgres
+  #         POSTGRES_PASSWORD: postgres
   #       ports:
   #         - "5432:5432"
   #       # Set health checks to wait until postgres has started
@@ -161,4 +161,4 @@ jobs:
   #     working-directory: ./loco-cli
   #     env:
   #       APP_REDIS_URI: redis://localhost:${{job.services.redis.ports[6379]}}
-  #       APP_DATABASE_URI: postgres://postgress:postgress@localhost:5432/postgress_test
+  #       APP_DATABASE_URI: postgres://postgres:postgres@localhost:5432/postgres_test

--- a/starters/rest-api/.github/workflows/ci.yaml
+++ b/starters/rest-api/.github/workflows/ci.yaml
@@ -76,9 +76,9 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_DB: postgress_test
-          POSTGRES_USER: postgress
-          POSTGRES_PASSWORD: postgress
+          POSTGRES_DB: postgres_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
         ports:
           - "5432:5432"
         # Set health checks to wait until postgres has started
@@ -104,4 +104,4 @@ jobs:
           args: --all-features --all
         env:
           REDIS_URL: redis://localhost:${{job.services.redis.ports[6379]}}
-          DATABASE_URL: postgres://postgress:postgress@localhost:5432/postgress_test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres_test

--- a/starters/saas/.github/workflows/ci.yaml
+++ b/starters/saas/.github/workflows/ci.yaml
@@ -76,9 +76,9 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_DB: postgress_test
-          POSTGRES_USER: postgress
-          POSTGRES_PASSWORD: postgress
+          POSTGRES_DB: postgres_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
         ports:
           - "5432:5432"
         # Set health checks to wait until postgres has started
@@ -104,5 +104,5 @@ jobs:
           args: --all-features --all
         env:
           REDIS_URL: redis://localhost:${{job.services.redis.ports[6379]}}
-          DATABASE_URL: postgres://postgress:postgress@localhost:5432/postgress_test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres_test
           


### PR DESCRIPTION
Drive-by typo fix. Hopefully this doesn't cause downstream confusion, but better to fix the templates now than later.