### PR TITLE
improve app logger by adding span to root app and task with details

### DIFF
--- a/examples/demo/tests/cmd/cli.trycmd
+++ b/examples/demo/tests/cmd/cli.trycmd
@@ -116,19 +116,19 @@ $ LOCO_ENV=test blo-cli db reset
 
 ```console 
 $ LOCO_ENV=teste2e blo-cli db migrate
-[[..][0m [32m INFO[0m [2mloco_rs::config[0m[2m:[0m loading environment from [3mselected_path[0m[2m=[0m"config/[..].yaml"
-[[..][0m [33m WARN[0m [2mloco_rs::boot[0m[2m:[0m migrate:
-[[..][0m [32m INFO[0m [2msea_orm_migration::migrator[0m[2m:[0m Applying all pending migrations
-[[..][0m [32m INFO[0m [2msea_orm_migration::migrator[0m[2m:[0m No pending migrations
+[2m2024-03-02T09:16:29.730103Z[0m [32m INFO[0m [1mapp[0m: [2mloco_rs::config[0m[2m:[0m loading environment from [3mselected_path[0m[2m=[0m"config/teste2e.yaml" [2m[3menvironment[0m[2m=[0mteste2e[0m
+[2m2024-03-02T09:16:29.811092Z[0m [33m WARN[0m [1mapp[0m: [2mloco_rs::boot[0m[2m:[0m migrate: [2m[3menvironment[0m[2m=[0mteste2e[0m
+[2m2024-03-02T09:16:29.812278Z[0m [32m INFO[0m [1mapp[0m: [2msea_orm_migration::migrator[0m[2m:[0m Applying all pending migrations [2m[3menvironment[0m[2m=[0mteste2e[0m
+[2m2024-03-02T09:16:29.814259Z[0m [32m INFO[0m [1mapp[0m: [2msea_orm_migration::migrator[0m[2m:[0m No pending migrations [2m[3menvironment[0m[2m=[0mteste2e[0m
 
 ```
 
 ```console 
 $ LOCO_ENV=teste2e blo-cli db status
-[[..][0m [32m INFO[0m [2mloco_rs::config[0m[2m:[0m loading environment from [3mselected_path[0m[2m=[0m"config/[..].yaml"
-[[..][0m [33m WARN[0m [2mloco_rs::boot[0m[2m:[0m status:
-[[..][0m [32m INFO[0m [2msea_orm_migration::migrator[0m[2m:[0m Checking migration status
-[[..][0m [32m INFO[0m [2msea_orm_migration::migrator[0m[2m:[0m Migration 'm20220101_000001_users'... Applied
-[[..][0m [32m INFO[0m [2msea_orm_migration::migrator[0m[2m:[0m Migration 'm20231103_114510_notes'... Applied
+[2m2024-03-02T09:16:29.827815Z[0m [32m INFO[0m [1mapp[0m: [2mloco_rs::config[0m[2m:[0m loading environment from [3mselected_path[0m[2m=[0m"config/teste2e.yaml" [2m[3menvironment[0m[2m=[0mteste2e[0m
+[2m2024-03-02T09:16:29.916085Z[0m [33m WARN[0m [1mapp[0m: [2mloco_rs::boot[0m[2m:[0m status: [2m[3menvironment[0m[2m=[0mteste2e[0m
+[2m2024-03-02T09:16:29.918344Z[0m [32m INFO[0m [1mapp[0m: [2msea_orm_migration::migrator[0m[2m:[0m Checking migration status [2m[3menvironment[0m[2m=[0mteste2e[0m
+[2m2024-03-02T09:16:29.926509Z[0m [32m INFO[0m [1mapp[0m: [2msea_orm_migration::migrator[0m[2m:[0m Migration 'm20220101_000001_users'... Applied [2m[3menvironment[0m[2m=[0mteste2e[0m
+[2m2024-03-02T09:16:29.926523Z[0m [32m INFO[0m [1mapp[0m: [2msea_orm_migration::migrator[0m[2m:[0m Migration 'm20231103_114510_notes'... Applied [2m[3menvironment[0m[2m=[0mteste2e[0m
 
 ```

--- a/examples/demo/tests/cmd/cli.trycmd
+++ b/examples/demo/tests/cmd/cli.trycmd
@@ -116,19 +116,19 @@ $ LOCO_ENV=test blo-cli db reset
 
 ```console 
 $ LOCO_ENV=teste2e blo-cli db migrate
-[2m2024-03-02T09:16:29.730103Z[0m [32m INFO[0m [1mapp[0m: [2mloco_rs::config[0m[2m:[0m loading environment from [3mselected_path[0m[2m=[0m"config/teste2e.yaml" [2m[3menvironment[0m[2m=[0mteste2e[0m
-[2m2024-03-02T09:16:29.811092Z[0m [33m WARN[0m [1mapp[0m: [2mloco_rs::boot[0m[2m:[0m migrate: [2m[3menvironment[0m[2m=[0mteste2e[0m
-[2m2024-03-02T09:16:29.812278Z[0m [32m INFO[0m [1mapp[0m: [2msea_orm_migration::migrator[0m[2m:[0m Applying all pending migrations [2m[3menvironment[0m[2m=[0mteste2e[0m
-[2m2024-03-02T09:16:29.814259Z[0m [32m INFO[0m [1mapp[0m: [2msea_orm_migration::migrator[0m[2m:[0m No pending migrations [2m[3menvironment[0m[2m=[0mteste2e[0m
+[..][0m [32m INFO[0m [1mapp[0m: [2mloco_rs::config[0m[2m:[0m loading environment from [3mselected_path[0m[2m=[0m"config/teste2e.yaml" [2m[3menvironment[0m[2m=[0mteste2e[0m
+[..][0m [33m WARN[0m [1mapp[0m: [2mloco_rs::boot[0m[2m:[0m migrate: [2m[3menvironment[0m[2m=[0mteste2e[0m
+[..][0m [32m INFO[0m [1mapp[0m: [2msea_orm_migration::migrator[0m[2m:[0m Applying all pending migrations [2m[3menvironment[0m[2m=[0mteste2e[0m
+[..][0m [32m INFO[0m [1mapp[0m: [2msea_orm_migration::migrator[0m[2m:[0m No pending migrations [2m[3menvironment[0m[2m=[0mteste2e[0m
 
 ```
 
 ```console 
 $ LOCO_ENV=teste2e blo-cli db status
-[2m2024-03-02T09:16:29.827815Z[0m [32m INFO[0m [1mapp[0m: [2mloco_rs::config[0m[2m:[0m loading environment from [3mselected_path[0m[2m=[0m"config/teste2e.yaml" [2m[3menvironment[0m[2m=[0mteste2e[0m
-[2m2024-03-02T09:16:29.916085Z[0m [33m WARN[0m [1mapp[0m: [2mloco_rs::boot[0m[2m:[0m status: [2m[3menvironment[0m[2m=[0mteste2e[0m
-[2m2024-03-02T09:16:29.918344Z[0m [32m INFO[0m [1mapp[0m: [2msea_orm_migration::migrator[0m[2m:[0m Checking migration status [2m[3menvironment[0m[2m=[0mteste2e[0m
-[2m2024-03-02T09:16:29.926509Z[0m [32m INFO[0m [1mapp[0m: [2msea_orm_migration::migrator[0m[2m:[0m Migration 'm20220101_000001_users'... Applied [2m[3menvironment[0m[2m=[0mteste2e[0m
-[2m2024-03-02T09:16:29.926523Z[0m [32m INFO[0m [1mapp[0m: [2msea_orm_migration::migrator[0m[2m:[0m Migration 'm20231103_114510_notes'... Applied [2m[3menvironment[0m[2m=[0mteste2e[0m
+[..][0m [32m INFO[0m [1mapp[0m: [2mloco_rs::config[0m[2m:[0m loading environment from [3mselected_path[0m[2m=[0m"config/teste2e.yaml" [2m[3menvironment[0m[2m=[0mteste2e[0m
+[..][0m [33m WARN[0m [1mapp[0m: [2mloco_rs::boot[0m[2m:[0m status: [2m[3menvironment[0m[2m=[0mteste2e[0m
+[..][0m [32m INFO[0m [1mapp[0m: [2msea_orm_migration::migrator[0m[2m:[0m Checking migration status [2m[3menvironment[0m[2m=[0mteste2e[0m
+[..][0m [32m INFO[0m [1mapp[0m: [2msea_orm_migration::migrator[0m[2m:[0m Migration 'm20220101_000001_users'... Applied [2m[3menvironment[0m[2m=[0mteste2e[0m
+[..][0m [32m INFO[0m [1mapp[0m: [2msea_orm_migration::migrator[0m[2m:[0m Migration 'm20231103_114510_notes'... Applied [2m[3menvironment[0m[2m=[0mteste2e[0m
 
 ```

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -109,6 +109,8 @@ pub async fn run_task<H: Hooks>(
     H::register_tasks(&mut tasks);
 
     if let Some(task) = task {
+        let task_span = tracing::span!(tracing::Level::DEBUG, "task", task,);
+        let _guard = task_span.enter();
         tasks.run(app_context, task, vars).await?;
     } else {
         let list = tasks.list();


### PR DESCRIPTION
Improving app logging by creating a root span to the app with the environment fields:
Looks like that:
```
...
2024-03-02T08:57:16.380563Z  INFO App: loco_rs::db: auto migrating environment=development
2024-03-02T08:57:16.384577Z  INFO App: sea_orm_migration::migrator: Applying all pending migrations environment=development
2024-03-02T08:57:16.390564Z  INFO App: sea_orm_migration::migrator: No pending migrations environment=development
2024-03-02T08:57:16.391272Z  INFO App: loco_rs::boot: initializers loaded initializers="axum-session,view-engine,custom-view-engine,axum-prometheus" environment=development
2024-03-02T08:57:16.402759Z  INFO App: loco_rs::controller::app_routes: [GET] /_ping environment=development
2024-03-02T08:57:16.402790Z  INFO App: loco_rs::controller::app_routes: [GET] /_health environment=development
...
```

Also added a span when running a task with the name of the task:
```
cargo loco task foo
2024-03-02T09:04:51.985393Z  INFO app:task: blo::tasks::foo: log in task environment=development task="foo"
```