### PR TITLE
Allow trailing slashes in URIs by adding the NormalizePathLayer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ tower-http = { version = "0.5.0", features = [
   "fs",
   "set-header",
   "compression-full",
+  "normalize-path",
 ] }
 byte-unit = "4.0.19"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,6 @@ tower-http = { version = "0.5.0", features = [
   "fs",
   "set-header",
   "compression-full",
-  "normalize-path"
 ] }
 
 [dependencies.sea-orm-migration]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,17 +86,7 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 # cli/migrations
 duct = "0.13.6"
 
-tower-http = { version = "0.5.0", features = [
-  "trace",
-  "catch-panic",
-  "timeout",
-  "add-extension",
-  "cors",
-  "fs",
-  "set-header",
-  "compression-full",
-  "normalize-path",
-] }
+tower-http = { workspace = true }
 byte-unit = "4.0.19"
 
 argon2 = { version = "0.5.2", features = ["std"] }
@@ -105,7 +95,7 @@ jsonwebtoken = { version = "9.1.0", optional = true }
 bcrypt = { version = "0.15.0", optional = true }
 validator = { version = "0.16.1", features = ["derive"] }
 futures-util = "0.3"
-tower = "0.4"
+tower = { workspace = true }
 hyper = "1.1"
 mime = "0.3"
 bytes = "1.1"
@@ -132,6 +122,18 @@ object_store = { version = "0.9.0", default-features = false }
 [workspace.dependencies]
 async-trait = { version = "0.1.74" }
 axum = { version = "0.7.1", features = ["macros"] }
+tower = "0.4"
+tower-http = { version = "0.5.0", features = [
+  "trace",
+  "catch-panic",
+  "timeout",
+  "add-extension",
+  "cors",
+  "fs",
+  "set-header",
+  "compression-full",
+  "normalize-path"
+] }
 
 [dependencies.sea-orm-migration]
 optional = true

--- a/examples/demo/Cargo.lock
+++ b/examples/demo/Cargo.lock
@@ -2569,6 +2569,8 @@ dependencies = [
  "axum-prometheus",
  "loco-rs",
  "serde_json",
+ "tower",
+ "tower-http",
 ]
 
 [[package]]

--- a/examples/demo/src/app.rs
+++ b/examples/demo/src/app.rs
@@ -2,7 +2,6 @@ use std::path::Path;
 
 use async_trait::async_trait;
 use loco_extras;
-use loco_rs::controller::channels::AppChannels;
 use loco_rs::{
     app::{AppContext, Hooks, Initializer},
     boot::{create_app, BootResult, StartMode},

--- a/examples/demo/src/app.rs
+++ b/examples/demo/src/app.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use async_trait::async_trait;
 use loco_extras;
+use loco_rs::controller::channels::AppChannels;
 use loco_rs::{
     app::{AppContext, Hooks, Initializer},
     boot::{create_app, BootResult, StartMode},
@@ -46,6 +47,7 @@ impl Hooks for App {
             Box::new(initializers::axum_session::AxumSessionInitializer),
             Box::new(initializers::view_engine::ViewEngineInitializer),
             Box::new(initializers::hello_view_engine::HelloViewEngineInitializer),
+            Box::new(loco_extras::initializers::normalize_path::NormalizePathInitializer),
         ];
 
         if ctx.environment != Environment::Test {

--- a/examples/demo/tests/requests/mod.rs
+++ b/examples/demo/tests/requests/mod.rs
@@ -1,6 +1,6 @@
 mod auth;
 mod notes;
+mod ping;
 mod prepare_data;
 mod upload;
 mod user;
-mod ping;

--- a/examples/demo/tests/requests/mod.rs
+++ b/examples/demo/tests/requests/mod.rs
@@ -3,3 +3,4 @@ mod notes;
 mod prepare_data;
 mod upload;
 mod user;
+mod ping;

--- a/examples/demo/tests/requests/ping.rs
+++ b/examples/demo/tests/requests/ping.rs
@@ -1,0 +1,37 @@
+use blo::{app::App, models::_entities::notes::Entity};
+use insta::{assert_debug_snapshot, with_settings};
+use loco_rs::db::reset;
+use loco_rs::testing;
+use rstest::rstest;
+use sea_orm::entity::prelude::*;
+use serde_json;
+use serial_test::serial;
+
+// TODO: see how to dedup / extract this to app-local test utils
+// not to framework, because that would require a runtime dep on insta
+macro_rules! configure_insta {
+    ($($expr:expr),*) => {
+        let mut settings = insta::Settings::clone_current();
+        settings.set_prepend_module_to_snapshot(false);
+        settings.set_snapshot_suffix("ping_request");
+        let _guard = settings.bind_to_scope();
+    };
+}
+
+// This tests the `_ping` endpoint, as well as the `NormalizePathLayer` that removes trailing
+// slashes from the request path.
+#[rstest]
+#[case("ping", "/_ping")]
+#[case("ping_with_trailing_slash", "/_ping/")]
+#[case("ping_with_multiple_trailing_slashes", "/_ping////")]
+#[tokio::test]
+async fn ping(#[case] test_name: &str, #[case] path: &str) {
+    configure_insta!();
+
+    testing::request::<App, _, _>(|request, _ctx| async move {
+        let response = request.get(path).await;
+
+        assert_debug_snapshot!(test_name, (response.text(), response.status_code()));
+    })
+    .await;
+}

--- a/examples/demo/tests/requests/ping.rs
+++ b/examples/demo/tests/requests/ping.rs
@@ -1,11 +1,9 @@
-use blo::{app::App, models::_entities::notes::Entity};
-use insta::{assert_debug_snapshot, with_settings};
-use loco_rs::db::reset;
+use blo::app::App;
+use insta::assert_debug_snapshot;
+
 use loco_rs::testing;
 use rstest::rstest;
 use sea_orm::entity::prelude::*;
-use serde_json;
-use serial_test::serial;
 
 // TODO: see how to dedup / extract this to app-local test utils
 // not to framework, because that would require a runtime dep on insta

--- a/examples/demo/tests/requests/ping.rs
+++ b/examples/demo/tests/requests/ping.rs
@@ -3,7 +3,6 @@ use insta::assert_debug_snapshot;
 
 use loco_rs::testing;
 use rstest::rstest;
-use sea_orm::entity::prelude::*;
 
 // TODO: see how to dedup / extract this to app-local test utils
 // not to framework, because that would require a runtime dep on insta

--- a/examples/demo/tests/requests/snapshots/ping@ping_request.snap
+++ b/examples/demo/tests/requests/snapshots/ping@ping_request.snap
@@ -1,0 +1,8 @@
+---
+source: tests/requests/ping.rs
+expression: "(response.text(), response.status_code())"
+---
+(
+    "{\"ok\":true}",
+    200,
+)

--- a/examples/demo/tests/requests/snapshots/ping_with_multiple_trailing_slashes@ping_request.snap
+++ b/examples/demo/tests/requests/snapshots/ping_with_multiple_trailing_slashes@ping_request.snap
@@ -1,0 +1,8 @@
+---
+source: tests/requests/ping.rs
+expression: "(response.text(), response.status_code())"
+---
+(
+    "{\"ok\":true}",
+    200,
+)

--- a/examples/demo/tests/requests/snapshots/ping_with_trailing_slash@ping_request.snap
+++ b/examples/demo/tests/requests/snapshots/ping_with_trailing_slash@ping_request.snap
@@ -1,0 +1,8 @@
+---
+source: tests/requests/ping.rs
+expression: "(response.text(), response.status_code())"
+---
+(
+    "{\"ok\":true}",
+    200,
+)

--- a/loco-extras/Cargo.toml
+++ b/loco-extras/Cargo.toml
@@ -17,7 +17,9 @@ axum-prometheus = { version = "0.6.1", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 tower = { workspace = true, optional = true }
-tower-http = { workspace = true, optional = true }
+tower-http = { workspace = true, optional = true, features = [
+  "normalize-path"
+] }
 
 [dependencies.loco-rs]
 path = "../"

--- a/loco-extras/Cargo.toml
+++ b/loco-extras/Cargo.toml
@@ -16,6 +16,8 @@ axum = { workspace = true }
 axum-prometheus = { version = "0.6.1", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
+tower = { workspace = true, optional = true }
+tower-http = { workspace = true, optional = true }
 
 [dependencies.loco-rs]
 path = "../"
@@ -28,8 +30,10 @@ full = [
     "initializer-prometheus",
     "initializer-extra-db",
     "initializer-multi-db",
+    "initializer-normalize-path",
 ]
 
 initializer-prometheus = ["dep:axum-prometheus"]
 initializer-extra-db = []
 initializer-multi-db = ["dep:serde_json"]
+initializer-normalize-path = ["dep:tower", "dep:tower-http"]

--- a/loco-extras/src/initializers/mod.rs
+++ b/loco-extras/src/initializers/mod.rs
@@ -55,9 +55,15 @@
 //! ```rust
 #![doc = include_str!("././multi_db.rs")]
 //!````
+//! ### Normalize path:
+//! ```rust
+#![doc = include_str!("././normalize_path.rs")]
+//!````
 #[cfg(feature = "initializer-extra-db")]
 pub mod extra_db;
 #[cfg(feature = "initializer-multi-db")]
 pub mod multi_db;
+#[cfg(feature = "initializer-normalize-path")]
+pub mod normalize_path;
 #[cfg(feature = "initializer-prometheus")]
 pub mod prometheus;

--- a/loco-extras/src/initializers/normalize_path.rs
+++ b/loco-extras/src/initializers/normalize_path.rs
@@ -1,0 +1,34 @@
+//! [Initializer] to add a [NormalizePathLayer] middleware to handle a trailing `/` at the end of URIs.
+//!
+//! See the [layer's docs][normalize-docs] for more details.
+//!
+//! Note that the normal approach to adding middleware via [Router::layer] results in the middleware
+//! running after routing has already occurred. This means that any middleware that re-writes the
+//! request URI, including [NormalizePathLayer], will not work as expected if added using
+//! [Router::layer]. As a workaround, the middleware can be added by wrapping the entire router.
+//! See [axum's docs][axum-docs] for more details and an example.
+//!
+//! [normalize-docs]: https://docs.rs/tower-http/latest/tower_http/normalize_path/index.html
+//! [axum-docs]: https://docs.rs/axum/latest/axum/middleware/index.html#rewriting-request-uri-in-middleware
+use async_trait::async_trait;
+use axum::Router;
+use tower::Layer;
+use tower_http::normalize_path::NormalizePathLayer;
+
+use loco_rs::prelude::*;
+
+#[allow(clippy::module_name_repetitions)]
+pub struct NormalizePathInitializer;
+
+#[async_trait]
+impl Initializer for NormalizePathInitializer {
+    fn name(&self) -> String {
+        "normalize-path".to_string()
+    }
+
+    async fn after_routes(&self, router: Router, _ctx: &AppContext) -> Result<Router> {
+        let router = NormalizePathLayer::trim_trailing_slash().layer(router);
+        let router = Router::new().nest_service("", router);
+        Ok(router)
+    }
+}

--- a/loco-extras/src/lib.rs
+++ b/loco-extras/src/lib.rs
@@ -9,4 +9,5 @@
 //!   endpoint.
 //! * `initializer-extra-db` Adding extra DB connection
 //! * `initializer-multi-db` Adding extra DB's connection
+//! * `initializer-normalize-path` Normalize the request path
 pub mod initializers;

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,9 @@ cfg_if::cfg_if! {
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use axum::Router as AxumRouter;
+use axum::{Router as AxumRouter, ServiceExt};
+use tower::Layer;
+use tower_http::normalize_path::NormalizePathLayer;
 
 #[cfg(feature = "channels")]
 use crate::controller::channels::AppChannels;
@@ -106,13 +108,25 @@ pub trait Hooks {
     /// # Returns
     /// A Result indicating success () or an error if the server fails to start.
     async fn serve(app: AxumRouter, server_config: ServeParams) -> Result<()> {
+        // Add the NormalizePathLayer to handle a trailing `/` at the end of URIs.
+        // Normally, adding a layer via the axum `Route::layer` method causes the layer to run
+        // after routing has already completed. This means the `NormalizePathLayer` would not normalize
+        // the uri for the purposes of routing, which defeats the point of the layer.
+        // The workaround is to wrap the entire router with `NormalizePathLayer`.
+        // See: https://docs.rs/axum/latest/axum/middleware/index.html#rewriting-request-uri-in-middleware
+        let app = NormalizePathLayer::trim_trailing_slash().layer(app);
+        // This line is used to make the rust type system happy -- without this, rust complains
+        // about the `into_make_service()` call below. I think this is because `NormalizePathLayer`
+        // doesn't know anything about the request type, but `tower::util::MapRequestLayer` does.
+        let app = tower::util::MapRequestLayer::new(|f| f).layer(app);
+
         let listener = tokio::net::TcpListener::bind(&format!(
             "{}:{}",
             server_config.binding, server_config.port
         ))
         .await?;
 
-        axum::serve(listener, app).await?;
+        axum::serve(listener, app.into_make_service()).await?;
 
         Ok(())
     }


### PR DESCRIPTION
Problem
-------
Some clients may append a trailing slash to URIs, either intentionally or accidentally. We should support both routes that do and don't have trailing slashes for maximum compatibility.

Solution
--------
Normally, when we define a route, it will not have a trailing slash. We can add support for trailing slashes by adding the `NormalizePathLayer`, which will automatically remove the trailing slash from the requested URI, allowing it to map to the route we created without a trailing slash.