### PR TITLE
Fix the doc test for `src/controller/mod.rs`

### DIFF
--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -12,12 +12,15 @@
 //! use loco_rs::{
 //!    app::{AppContext, Hooks},
 //!    boot::{create_app, BootResult, StartMode},
-//!    controller::{channels::AppChannels, AppRoutes},
+//!    controller::AppRoutes,
 //!    worker::Processor,
 //!    task::Tasks,
 //!    environment::Environment,
 //!    Result,
 //! };
+//! #[cfg(feature = "channels")] {
+//!    use loco_rs::controller::channels::AppChannels;
+//! }
 //! use sea_orm::DatabaseConnection;
 //! use std::path::Path;
 //!
@@ -49,6 +52,7 @@
 //!     }
 //!     
 //!    /// Only when `channels` feature is enabled
+//!    #[cfg(feature = "channels")]
 //!    fn register_channels(_ctx: &AppContext) -> AppChannels {
 //!        let channels = AppChannels::default();
 //!        //channels.register.ns("/", channels::application::on_connect);


### PR DESCRIPTION
Problem
-------
The sample rust code in `src/controller/mod.rs` does not compile with a fresh clone of `loco` because it is using some methods and imports that are only available when the `channels` feature is enabled.

Solution
--------
Update the sample code to guard the offending blocks of code with a `cfg` guard.