### PR TITLE
Put the loco-cli as workspace member

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["macros", "xtask", "loco-extras"]
+members = ["macros", "xtask", "loco-extras", "loco-cli"]
 exclude = ["starters"]
 
 [workspace.package]
@@ -59,7 +59,7 @@ serde_json = "1"
 serde_yaml = "0.9"
 serde_variant = "0.1.2"
 
-# worker fwk 
+# worker fwk
 rusty-sidekiq = { version = "0.8.2", default-features = false }
 async-trait = { workspace = true }
 bb8 = "0.8.1"
@@ -111,7 +111,7 @@ bytes = "1.1"
 
 axum-test = { version = "14.3.0", optional = true }
 
-# gen 
+# gen
 rrgen = "0.5.3"
 chrono = "0.4.31"
 cargo_metadata = "0.18.1"

--- a/loco-cli/Cargo.toml
+++ b/loco-cli/Cargo.toml
@@ -1,5 +1,3 @@
-[workspace]
-
 [package]
 name = "loco-cli"
 version = "0.2.5"
@@ -43,7 +41,10 @@ lazy_static = "1.4.0"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 git2 = { version = "0.18.1", optional = true }
-gix = {version = "0.56.0", features = ["blocking-network-client", "blocking-http-transport-reqwest-rust-tls-trust-dns"], optional = true}
+gix = { version = "0.56.0", features = [
+  "blocking-network-client",
+  "blocking-http-transport-reqwest-rust-tls-trust-dns",
+], optional = true }
 cfg-if = "1.0.0"
 
 [dev-dependencies]


### PR DESCRIPTION
It makes things easier for me when working on loco-cli: I don't have to open it as a separate project, and can work on it when opening the root dir.
I can understand if you decide not to accept this  PR