### PR TITLE
Response body content

### DIFF
--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -276,6 +276,8 @@ fn json_error_response(status_code: StatusCode, detail: ErrorDetail) -> Response
 
 #[cfg(test)]
 mod tests {
+    use std::env;
+
     use futures_util::TryStreamExt;
     use serde::ser::{self};
     use serde_json::{json, Value};
@@ -365,6 +367,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_backtrace_error() {
+        env::set_var("RUST_BACKTRACE", "1");
         let result: Result<()> = Err(Error::WithBacktrace {
             inner: Box::new(Error::BadRequest("bad request".to_string())),
             backtrace: Box::new(std::backtrace::Backtrace::capture()),


### PR DESCRIPTION
Corrected the handling of most API error responses to ignore the error content and only return the standardized body with `"error": "Bad Request"`. Additionally, altered the `Error::message` to return plain text instead of a JSON type. Implemented testing for API errors.