### PR TITLE
Remove the tracing::field::debug method of is_a_git_repo function

### DIFF
--- a/loco-cli/src/git.rs
+++ b/loco-cli/src/git.rs
@@ -159,10 +159,6 @@ pub fn is_a_git_repo(destination_path: &Path) -> eyre::Result<bool> {
             if output.status.success() {
                 Ok(true)
             } else {
-                tracing::error!(
-                    error = tracing::field::debug(output),
-                    "git command returned an error"
-                );
                 Ok(false)
             }
         }


### PR DESCRIPTION
Hi @jondot 

### What?

Please take a look #500 .

We added a good feature to let user know they're if there's any `.git` in the destination path.

### My thinking

Because of the command check the `destination_path` is a git repo or not only contains two situations.

One is yes, and the other one is not. so we don't need to consider it as an error and display it to the user, they will be confused.

### How?

1. Remove it