### PR TITLE
Updated the command to reflect the help menu

### DIFF
--- a/docs-site/content/docs/the-app/controller.md
+++ b/docs-site/content/docs/the-app/controller.md
@@ -38,7 +38,7 @@ After generating the controller, navigate to the created file in `src/controller
 To view a list of all your registered controllers, execute the following command:
 
 ```sh
-$ cargo loco controller
+$ cargo loco routes
 
 [GET] /_health
 [GET] /_ping


### PR DESCRIPTION
I noticed reading the docs on loco.rs that there is no cargo loco controller command only cargo loco routes that output the same data. 