### PR TITLE
Fix wrong path in tour commands

### DIFF
--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -150,7 +150,7 @@ listening on port 3000
 And now, let's see that it's alive:
 
 ```sh
-$ curl localhost:3000/api/_ping
+$ curl localhost:3000/_ping
 {"ok":true}
 ```
 
@@ -159,7 +159,7 @@ The built in `_ping` route will tell your load balancer everything is up.
 Let's see that all services that are required are up:
 
 ```sh
-$ curl localhost:3000/api/_health
+$ curl localhost:3000/_health
 {"ok":true}
 ```
 

--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -504,9 +504,9 @@ Edit `src/controllers/articles.rs`:
 #![allow(clippy::unused_async)]
 use loco_rs::prelude::*;
 
-use crate::models::_entities::articles;
+use crate::models::_entities::articles::{self, Model};
 
-pub async fn list(State(ctx): State<AppContext>) -> Result<Response> {
+pub async fn list(State(ctx): State<AppContext>) -> Result<Json<Vec<Model>>> {
     let res = articles::Entity::find().all(&ctx.db).await?;
     format::json(res)
 }
@@ -525,7 +525,7 @@ $ cargo loco start
 And make a request:
 
 ```sh
-$ curl localhost:3000/api/articles
+$ curl localhost:3000/articles
 [{"created_at":"...","updated_at":"...","id":1,"title":"how to build apps in 3 steps","content":"use Loco: https://loco.rs"}]
 ```
 

--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -212,7 +212,7 @@ $ cargo loco start
 Now, let's test it out:
 
 ```sh
-$ curl localhost:3000/api/guide
+$ curl localhost:3000/guide
 hello
 ```
 

--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -627,14 +627,14 @@ Add a new article:
 $ curl -X POST -H "Content-Type: application/json" -d '{
   "title": "Your Title",
   "content": "Your Content xxx"
-}' localhost:3000/api/articles
+}' localhost:3000/articles
 {"created_at":"...","updated_at":"...","id":2,"title":"Your Title","content":"Your Content xxx"}
 ```
 
 Get a list:
 
 ```sh
-$ curl localhost:3000/api/articles
+$ curl localhost:3000/articles
 [{"created_at":"...","updated_at":"...","id":1,"title":"how to build apps in 3 steps","content":"use Loco: https://loco.rs"},{"created_at":"...","updated_at":"...","id":2,"title":"Your Title","content":"Your Content xxx"}
 ```
 

--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -562,11 +562,11 @@ async fn load_item(ctx: &AppContext, id: i32) -> Result<Model> {
     item.ok_or_else(|| Error::NotFound)
 }
 
-pub async fn list(State(ctx): State<AppContext>) -> Result<Response> {
+pub async fn list(State(ctx): State<AppContext>) -> Result<Json<Vec<Model>>> {
     format::json(Entity::find().all(&ctx.db).await?)
 }
 
-pub async fn add(State(ctx): State<AppContext>, Json(params): Json<Params>) -> Result<Response> {
+pub async fn add(State(ctx): State<AppContext>, Json(params): Json<Params>) -> Result<Json<Model>> {
     let mut item = ActiveModel {
         ..Default::default()
     };
@@ -579,7 +579,7 @@ pub async fn update(
     Path(id): Path<i32>,
     State(ctx): State<AppContext>,
     Json(params): Json<Params>,
-) -> Result<Response> {
+) -> Result<Json<Model>> {
     let item = load_item(&ctx, id).await?;
     let mut item = item.into_active_model();
     params.update(&mut item);
@@ -592,7 +592,7 @@ pub async fn remove(Path(id): Path<i32>, State(ctx): State<AppContext>) -> Resul
     format::empty()
 }
 
-pub async fn get_one(Path(id): Path<i32>, State(ctx): State<AppContext>) -> Result<Response> {
+pub async fn get_one(Path(id): Path<i32>, State(ctx): State<AppContext>) -> Result<Json<Model>> {
     format::json(load_item(&ctx, id).await?)
 }
 

--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -307,7 +307,7 @@ $
 
 ## MVC and You
 
-**Traditional MVC (model-view-controller) comes desktop UI programming paradigms**. However, it quickly made it into web services as well, the golden era of MVC was around the early 2010's, and since then many more different paradigms and architectures emerged.
+**Traditional MVC (model-view-controller) comes from desktop UI programming paradigms**. However, it quickly made it into web services as well, the golden era of MVC was around the early 2010's, and since then many more different paradigms and architectures emerged.
 
 **MVC is still a very strong principle and architecture to follow for simplifying projects**, and this is what Loco follows too.
 

--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -283,7 +283,7 @@ $ cargo loco start
 And hit `/home/hello`:
 
 ```sh
-$ curl localhost:3000/api/home/hello
+$ curl localhost:3000/home/hello
 ola, mundo
 ```
 

--- a/docs-site/content/docs/getting-started/tour/index.md
+++ b/docs-site/content/docs/getting-started/tour/index.md
@@ -121,13 +121,13 @@ Next, try adding a `post` with `curl`:
 $ curl -X POST -H "Content-Type: application/json" -d '{
   "title": "Your Title",
   "content": "Your Content xxx"
-}' localhost:3000/api/posts
+}' localhost:3000/posts
 ```
 
 You can list your posts:
 
 ```sh
-$ curl localhost:3000/api/posts
+$ curl localhost:3000/posts
 ```
 
 For those counting -- the commands for creating a blog backend were:


### PR DESCRIPTION
When following the tour `posts` seem to be created without the `api` prefix.

<img width="640" alt="Screenshot 2024-04-11 at 15 59 11" src="https://github.com/loco-rs/loco/assets/7774918/b497961d-314e-489d-8405-a88d649e5416">

This seems to be throughout the whole guide so not sure if it's the docs or the scaffolding commands.

Also missing `from` in MVC description