### PR TITLE
Allow setting an acquire timeout

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -157,6 +157,9 @@ pub struct Database {
     /// Set the idle duration before closing a connection
     pub idle_timeout: u64,
 
+    /// Set the timeout for acquiring a connection
+    pub acquire_timeout: Option<u64>,
+
     /// Run migration up when application loads. It is recommended to turn it on
     /// in development. In production keep it off, and explicitly migrate your
     /// database every time you need.

--- a/src/db.rs
+++ b/src/db.rs
@@ -139,6 +139,10 @@ pub async fn connect(config: &config::Database) -> Result<DbConn, sea_orm::DbErr
         .idle_timeout(Duration::from_millis(config.idle_timeout))
         .sqlx_logging(config.enable_logging);
 
+    if let Some(acquire_timeout) = config.acquire_timeout {
+        opt.acquire_timeout(Duration::from_millis(acquire_timeout));
+    }
+
     Database::connect(opt).await
 }
 


### PR DESCRIPTION
I struggled to connect to Fly.io through their proxy without setting an acquire_timeout >1s