### PR TITLE
Adding the debug macro to the templates to have better errors.

### DIFF
--- a/starters/lightweight-service/src/controllers/home.rs
+++ b/starters/lightweight-service/src/controllers/home.rs
@@ -1,7 +1,9 @@
+use axum::debug_handler;
 use loco_rs::prelude::*;
 
 use crate::views::home::HomeResponse;
 
+#[debug_handler]
 async fn current() -> Result<Response> {
     format::json(HomeResponse::new("loco"))
 }

--- a/starters/rest-api/src/controllers/auth.rs
+++ b/starters/rest-api/src/controllers/auth.rs
@@ -1,3 +1,4 @@
+use axum::debug_handler;
 use loco_rs::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -27,6 +28,7 @@ pub struct ResetParams {
 
 /// Register function creates a new user with the given parameters and sends a
 /// welcome email to the user
+#[debug_handler]
 async fn register(
     State(ctx): State<AppContext>,
     Json(params): Json<RegisterParams>,
@@ -57,6 +59,7 @@ async fn register(
 
 /// Verify register user. if the user not verified his email, he can't login to
 /// the system.
+#[debug_handler]
 async fn verify(
     State(ctx): State<AppContext>,
     Json(params): Json<VerifyParams>,
@@ -78,6 +81,7 @@ async fn verify(
 /// and send email to the user. In case the email not found in our DB, we are
 /// returning a valid request for for security reasons (not exposing users DB
 /// list).
+#[debug_handler]
 async fn forgot(
     State(ctx): State<AppContext>,
     Json(params): Json<ForgotParams>,
@@ -99,6 +103,7 @@ async fn forgot(
 }
 
 /// reset user password by the given parameters
+#[debug_handler]
 async fn reset(State(ctx): State<AppContext>, Json(params): Json<ResetParams>) -> Result<Response> {
     let Ok(user) = users::Model::find_by_reset_token(&ctx.db, &params.token).await else {
         // we don't want to expose our users email. if the email is invalid we still
@@ -115,6 +120,7 @@ async fn reset(State(ctx): State<AppContext>, Json(params): Json<ResetParams>) -
 }
 
 /// Creates a user login and returns a token
+#[debug_handler]
 async fn login(State(ctx): State<AppContext>, Json(params): Json<LoginParams>) -> Result<Response> {
     let user = users::Model::find_by_email(&ctx.db, &params.email).await?;
 

--- a/starters/rest-api/src/controllers/notes.rs
+++ b/starters/rest-api/src/controllers/notes.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::unnecessary_struct_initialization)]
 #![allow(clippy::unused_async)]
+use axum::debug_handler;
 use loco_rs::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -24,10 +25,12 @@ async fn load_item(ctx: &AppContext, id: i32) -> Result<Model> {
     item.ok_or_else(|| Error::NotFound)
 }
 
+#[debug_handler]
 pub async fn list(State(ctx): State<AppContext>) -> Result<Response> {
     format::json(Entity::find().all(&ctx.db).await?)
 }
 
+#[debug_handler]
 pub async fn add(State(ctx): State<AppContext>, Json(params): Json<Params>) -> Result<Response> {
     let mut item = ActiveModel {
         ..Default::default()
@@ -37,6 +40,7 @@ pub async fn add(State(ctx): State<AppContext>, Json(params): Json<Params>) -> R
     format::json(item)
 }
 
+#[debug_handler]
 pub async fn update(
     Path(id): Path<i32>,
     State(ctx): State<AppContext>,
@@ -49,11 +53,13 @@ pub async fn update(
     format::json(item)
 }
 
+#[debug_handler]
 pub async fn remove(Path(id): Path<i32>, State(ctx): State<AppContext>) -> Result<Response> {
     load_item(&ctx, id).await?.delete(&ctx.db).await?;
     format::empty()
 }
 
+#[debug_handler]
 pub async fn get_one(Path(id): Path<i32>, State(ctx): State<AppContext>) -> Result<Response> {
     format::json(load_item(&ctx, id).await?)
 }

--- a/starters/rest-api/src/controllers/user.rs
+++ b/starters/rest-api/src/controllers/user.rs
@@ -1,7 +1,9 @@
+use axum::debug_handler;
 use loco_rs::prelude::*;
 
 use crate::{models::_entities::users, views::user::CurrentResponse};
 
+#[debug_handler]
 async fn current(auth: auth::JWT, State(ctx): State<AppContext>) -> Result<Response> {
     let user = users::Model::find_by_pid(&ctx.db, &auth.claims.pid).await?;
     format::json(CurrentResponse::new(&user))

--- a/starters/saas/src/controllers/auth.rs
+++ b/starters/saas/src/controllers/auth.rs
@@ -1,3 +1,4 @@
+use axum::debug_handler;
 use loco_rs::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -27,6 +28,7 @@ pub struct ResetParams {
 
 /// Register function creates a new user with the given parameters and sends a
 /// welcome email to the user
+#[debug_handler]
 async fn register(
     State(ctx): State<AppContext>,
     Json(params): Json<RegisterParams>,
@@ -57,6 +59,7 @@ async fn register(
 
 /// Verify register user. if the user not verified his email, he can't login to
 /// the system.
+#[debug_handler]
 async fn verify(
     State(ctx): State<AppContext>,
     Json(params): Json<VerifyParams>,
@@ -78,6 +81,7 @@ async fn verify(
 /// and send email to the user. In case the email not found in our DB, we are
 /// returning a valid request for for security reasons (not exposing users DB
 /// list).
+#[debug_handler]
 async fn forgot(
     State(ctx): State<AppContext>,
     Json(params): Json<ForgotParams>,
@@ -99,6 +103,7 @@ async fn forgot(
 }
 
 /// reset user password by the given parameters
+#[debug_handler]
 async fn reset(State(ctx): State<AppContext>, Json(params): Json<ResetParams>) -> Result<Response> {
     let Ok(user) = users::Model::find_by_reset_token(&ctx.db, &params.token).await else {
         // we don't want to expose our users email. if the email is invalid we still
@@ -115,6 +120,7 @@ async fn reset(State(ctx): State<AppContext>, Json(params): Json<ResetParams>) -
 }
 
 /// Creates a user login and returns a token
+#[debug_handler]
 async fn login(State(ctx): State<AppContext>, Json(params): Json<LoginParams>) -> Result<Response> {
     let user = users::Model::find_by_email(&ctx.db, &params.email).await?;
 

--- a/starters/saas/src/controllers/notes.rs
+++ b/starters/saas/src/controllers/notes.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::unnecessary_struct_initialization)]
 #![allow(clippy::unused_async)]
+use axum::debug_handler;
 use loco_rs::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -24,10 +25,12 @@ async fn load_item(ctx: &AppContext, id: i32) -> Result<Model> {
     item.ok_or_else(|| Error::NotFound)
 }
 
+#[debug_handler]
 pub async fn list(State(ctx): State<AppContext>) -> Result<Response> {
     format::json(Entity::find().all(&ctx.db).await?)
 }
 
+#[debug_handler]
 pub async fn add(State(ctx): State<AppContext>, Json(params): Json<Params>) -> Result<Response> {
     let mut item = ActiveModel {
         ..Default::default()
@@ -37,6 +40,7 @@ pub async fn add(State(ctx): State<AppContext>, Json(params): Json<Params>) -> R
     format::json(item)
 }
 
+#[debug_handler]
 pub async fn update(
     Path(id): Path<i32>,
     State(ctx): State<AppContext>,
@@ -49,11 +53,13 @@ pub async fn update(
     format::json(item)
 }
 
+#[debug_handler]
 pub async fn remove(Path(id): Path<i32>, State(ctx): State<AppContext>) -> Result<Response> {
     load_item(&ctx, id).await?.delete(&ctx.db).await?;
     format::empty()
 }
 
+#[debug_handler]
 pub async fn get_one(Path(id): Path<i32>, State(ctx): State<AppContext>) -> Result<Response> {
     format::json(load_item(&ctx, id).await?)
 }

--- a/starters/saas/src/controllers/user.rs
+++ b/starters/saas/src/controllers/user.rs
@@ -1,7 +1,9 @@
+use axum::debug_handler;
 use loco_rs::prelude::*;
 
 use crate::{models::_entities::users, views::user::CurrentResponse};
 
+#[debug_handler]
 async fn current(auth: auth::JWT, State(ctx): State<AppContext>) -> Result<Response> {
     let user = users::Model::find_by_pid(&ctx.db, &auth.claims.pid).await?;
     format::json(CurrentResponse::new(&user))


### PR DESCRIPTION
I'm new to Axum and Loco frameworks and encountered an error when trying to use a handler to return HTML instead of JSON. The issue stemmed from not adding Json as the final argument in the handler function, which the improved error message helped identify as you can see below.

I thought this would help with new users and DX, there might be a better way, let me know what you think. Maybe simply adding it to the docs might be sufficient.

[Doc](https://docs.rs/axum/latest/axum/attr.debug_handler.html)

![image](https://github.com/loco-rs/loco/assets/17557003/804c65ff-4479-42e2-80a7-910b3b066f37)
