### PR TITLE
Make health check more informative.

### DIFF
--- a/src/controller/health.rs
+++ b/src/controller/health.rs
@@ -6,31 +6,43 @@ use axum::{extract::State, response::Response, routing::get};
 use serde::Serialize;
 
 use super::{format, routes::Routes};
-use crate::{app::AppContext, redis, Result};
+use crate::{app::AppContext, db, redis, Result};
 
 /// Represents the health status of the application.
 #[derive(Serialize)]
 struct Health {
     pub ok: bool,
+    pub redis: bool,
+    pub db: bool,
 }
 
 /// Check the healthiness of the application bt ping to the redis and the DB to
 /// insure that connection
 async fn health(State(ctx): State<AppContext>) -> Result<Response> {
-    let mut is_ok = match ctx.db.ping().await {
-        Ok(()) => true,
+    let db_ok = match ctx.db.ping().await {
+        Ok(()) => {
+            tracing::info!("health_db_ping_success");
+            true
+        }
         Err(error) => {
             tracing::error!(err.msg = %error, err.detail = ?error, "health_db_ping_error");
             false
         }
     };
+    let mut redis_ok = true;
     if let Some(pool) = ctx.redis {
         if let Err(error) = redis::ping(&pool).await {
             tracing::error!(err.msg = %error, err.detail = ?error, "health_redis_ping_error");
-            is_ok = false;
+            redis_ok = false;
+        } else {
+            tracing::info!("health_redis_ping_success");
         }
     }
-    format::json(Health { ok: is_ok })
+    format::json(Health {
+        ok: db_ok && redis_ok,
+        db: db_ok,
+        redis: redis_ok,
+    })
 }
 
 /// Defines and returns the health-related routes.

--- a/src/controller/health.rs
+++ b/src/controller/health.rs
@@ -6,7 +6,7 @@ use axum::{extract::State, response::Response, routing::get};
 use serde::Serialize;
 
 use super::{format, routes::Routes};
-use crate::{app::AppContext, db, redis, Result};
+use crate::{app::AppContext, redis, Result};
 
 /// Represents the health status of the application.
 #[derive(Serialize)]


### PR DESCRIPTION
I ran into an issue where it was difficult to tell which store was failing (redis or pg) so I figured this might be a helpful addition for others to make troubleshooting easier.