### PR TITLE
add repository field

### DIFF
--- a/loco-cli/Cargo.toml
+++ b/loco-cli/Cargo.toml
@@ -8,6 +8,7 @@ description = "loco cli website generator"
 license = "Apache-2.0"
 homepage = "https://docs.rs/loco-cli"
 documentation = "https://docs.rs/loco-cli"
+repository = "https://github.com/loco-rs/loco"
 authors = ["Dotan Nahum <dotan@rng0.io>", "Elad Kaplan <kaplan.elad@gmail.com>"]
 
 [profile.release]

--- a/loco-extras/Cargo.toml
+++ b/loco-extras/Cargo.toml
@@ -5,6 +5,7 @@ description = "Common loco components"
 license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+repository.workspace = true
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.

