### PR TITLE
Update tour and guide doc resource paths to match current behaviour.

### DIFF
--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -190,7 +190,7 @@ pub async fn echo(req_body: String) -> String {
     req_body
 }
 
-pub async fn hello(State(_ctx): State<AppContext>) -> Result<String> {
+pub async fn hello(State(_ctx): State<AppContext>) -> Result<Response> {
     // do something with context (database, etc)
     format::text("hello")
 }
@@ -212,7 +212,7 @@ $ cargo loco start
 Now, let's test it out:
 
 ```sh
-$ curl localhost:3000/api/guide
+$ curl localhost:3000/guide
 hello
 ```
 
@@ -238,12 +238,12 @@ Next, set up a _hello_ route, this is the contents of `home.rs`:
 use loco_rs::prelude::*;
 
 // _ctx contains your database connection, as well as other app resource that you'll need
-async fn hello(State(_ctx): State<AppContext>) -> Result<String> {
+async fn hello(State(_ctx): State<AppContext>) -> Result<Response> {
     format::text("ola, mundo")
 }
 
 pub fn routes() -> Routes {
-    Routes::new().prefix("api/home").add("/hello", get(hello))
+    Routes::new().prefix("home").add("/hello", get(hello))
 }
 ```
 
@@ -283,7 +283,7 @@ $ cargo loco start
 And hit `/home/hello`:
 
 ```sh
-$ curl localhost:3000/api/home/hello
+$ curl localhost:3000/home/hello
 ola, mundo
 ```
 
@@ -297,7 +297,7 @@ $ cargo loco routes
 [POST] /api/auth/register
 [POST] /api/auth/reset
 [POST] /api/auth/verify
-[GET] /api/home/hello      <---- this is our new route!
+[GET] /home/hello      <---- this is our new route!
 [GET] /api/notes
 [POST] /api/notes
   ..
@@ -530,7 +530,7 @@ $ cargo loco start
 And make a request:
 
 ```sh
-$ curl localhost:3000/api/articles
+$ curl localhost:3000/articles
 [{"created_at":"...","updated_at":"...","id":1,"title":"how to build apps in 3 steps","content":"use Loco: https://loco.rs"}]
 ```
 
@@ -638,14 +638,14 @@ Add a new article:
 $ curl -X POST -H "Content-Type: application/json" -d '{
   "title": "Your Title",
   "content": "Your Content xxx"
-}' localhost:3000/api/articles
+}' localhost:3000/articles
 {"created_at":"...","updated_at":"...","id":2,"title":"Your Title","content":"Your Content xxx"}
 ```
 
 Get a list:
 
 ```sh
-$ curl localhost:3000/api/articles
+$ curl localhost:3000/articles
 [{"created_at":"...","updated_at":"...","id":1,"title":"how to build apps in 3 steps","content":"use Loco: https://loco.rs"},{"created_at":"...","updated_at":"...","id":2,"title":"Your Title","content":"Your Content xxx"}
 ```
 
@@ -752,14 +752,14 @@ Now let's add a comment to Article `1`:
 $ curl -X POST -H "Content-Type: application/json" -d '{
   "content": "this rocks",
   "article_id": 1
-}' localhost:3000/api/comments
+}' localhost:3000/comments
 {"created_at":"...","updated_at":"...","id":4,"content":"this rocks","article_id":1}
 ```
 
 And, fetch the relation:
 
 ```sh
-$ curl localhost:3000/api/articles/1/comments
+$ curl localhost:3000/articles/1/comments
 [{"created_at":"...","updated_at":"...","id":4,"content":"this rocks","article_id":1}]
 ```
 

--- a/docs-site/content/docs/getting-started/tour/index.md
+++ b/docs-site/content/docs/getting-started/tour/index.md
@@ -121,13 +121,13 @@ Next, try adding a `post` with `curl`:
 $ curl -X POST -H "Content-Type: application/json" -d '{
   "title": "Your Title",
   "content": "Your Content xxx"
-}' localhost:3000/api/posts
+}' localhost:3000/posts
 ```
 
 You can list your posts:
 
 ```sh
-$ curl localhost:3000/api/posts
+$ curl localhost:3000/posts
 ```
 
 For those counting -- the commands for creating a blog backend were:


### PR DESCRIPTION
This resolves some issues when following the guide:
* example code should specify response as `Result<Response>`
* generated controllers do not fall under `/api/*`
* manual controller example updated to align with generated controllers to be clearer.

See #533, this continues @chmelevskij's work :)