### PR TITLE
Bump socketioxide to v0.13.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ uuid = { version = "1.6", features = ["v4"] }
 requestty = "0.5.0"
 
 # A socket.io server implementation
-socketioxide = { version = "0.10.0", features = ["state"], optional = true }
+socketioxide = { version = "0.13.1", features = ["state"], optional = true }
 
 
 # File Upload


### PR DESCRIPTION
The `channels` features of loco depends on socketioxide. However it currently depends on an old version of the crate. Bumping 
this deps imply breaking changes.

One of the main issue with this update is that starting from v0.12 socketioxide requires a MSRV of 0.75.

Therefore this will be mergeable only for the next loco version. The new version includes importants fixes and some new features:

If this gets accepted I'll also update the chat example https://github.com/loco-rs/chat-rooms.

# 0.13.1

## engineioxide
* Remove unnecessary panic when receiving unexpected websocket messages. This might happen with some specific socket.io clients.

# 0.13.0

## socketioxide
* fix: the `delete_ns` fn was deadlocking the entire server when called from inside a `disconnect_handler`.
* feat: the `delete_ns` is now gracefully closing the adapter as well as all its sockets before being removed.
* feat: the API use `Bytes` rather than `Vec<u8>` to represent binary payloads. This allow to avoid unnecessary copies.
* deps: use `futures-util` and `futures-core` rather than the whole `futures` crate.

## engineioxide
* feat: the API use `Bytes/Str` rather than `Vec<u8>` and `String` to represent payloads. This allow to avoid unnecessary copies.
* deps: use `futures-util` and `futures-core` rather than the whole `futures` crate.

# 0.12.0
**MSRV**: Minimum supported Rust version is now 1.75.

## socketioxide
* **(Breaking)**: Introduction of [connect middlewares](https://docs.rs/socketioxide/latest/socketioxide/#middlewares). It allows to execute code before the connection to the namespace is established. It is useful to check the request, to authenticate the user, to log the connection etc. It is possible to add multiple middlewares and to chain them.
* The `SocketRef` extractor is now `Clone`. Be careful to drop clones when the socket is disconnected to avoid any memory leak.

# 0.11.1
## socketioxide
* fix: under heavy traffic, the adjacent binary packet to the head packet requirement for engine.io was not respected. It was leading to a protocol error. 

# 0.11.0
## socketioxide
* fix: a panic was raised sometimes under heavy traffic with socketio v5 when the connect timeout handler is destroyed but that the chan sender is still alive.
* **(Breaking)**: Emit errors now contains the provided data if there is an issue with the internal channel (for example if it is full) or if the socket closed.
* **(Breaking)**: Operators are now splitted between `Operators` and `BroadcastOperators` in order to split logic and fn signatures between broadcast and non-broadcast operators.

## engineioxide
* fix: with engine.io v3, the message byte prefix `0x4` was not added to the binary payload with `ws` transport.
* bump dependency `base64` to 0.22.0.

