### PR TITLE
Delete reset tokens after use

### DIFF
--- a/examples/demo/src/models/users.rs
+++ b/examples/demo/src/models/users.rs
@@ -297,6 +297,8 @@ impl super::_entities::users::ActiveModel {
     ) -> ModelResult<Model> {
         self.password =
             ActiveValue::set(hash::hash_password(password).map_err(|e| ModelError::Any(e.into()))?);
+        self.reset_token = ActiveValue::Set(None);
+        self.reset_sent_at = ActiveValue::Set(None);
         Ok(self.update(db).await?)
     }
 }

--- a/examples/demo/tests/requests/auth.rs
+++ b/examples/demo/tests/requests/auth.rs
@@ -150,6 +150,7 @@ async fn can_reset_password() {
             .await
             .unwrap();
         assert!(user.reset_token.is_some());
+        assert!(user.reset_sent_at.is_some());
 
         let new_password = "new-password";
         let reset_payload = serde_json::json!({
@@ -162,7 +163,9 @@ async fn can_reset_password() {
         let user = users::Model::find_by_email(&ctx.db, &user.email)
             .await
             .unwrap();
-        assert!(user.reset_sent_at.is_some());
+
+        assert!(user.reset_token.is_none());
+        assert!(user.reset_sent_at.is_none());
 
         assert_debug_snapshot!((reset_response.status_code(), reset_response.text()));
 

--- a/starters/rest-api/src/models/users.rs
+++ b/starters/rest-api/src/models/users.rs
@@ -290,6 +290,8 @@ impl super::_entities::users::ActiveModel {
     ) -> ModelResult<Model> {
         self.password =
             ActiveValue::set(hash::hash_password(password).map_err(|e| ModelError::Any(e.into()))?);
+        self.reset_token = ActiveValue::Set(None);
+        self.reset_sent_at = ActiveValue::Set(None);
         Ok(self.update(db).await?)
     }
 }

--- a/starters/rest-api/tests/requests/auth.rs
+++ b/starters/rest-api/tests/requests/auth.rs
@@ -156,6 +156,7 @@ async fn can_reset_password() {
             .await
             .unwrap();
         assert!(user.reset_token.is_some());
+        assert!(user.reset_sent_at.is_some());
 
         let new_password = "new-password";
         let reset_payload = serde_json::json!({
@@ -168,7 +169,9 @@ async fn can_reset_password() {
         let user = users::Model::find_by_email(&ctx.db, &user.email)
             .await
             .unwrap();
-        assert!(user.reset_sent_at.is_some());
+
+        assert!(user.reset_token.is_none());
+        assert!(user.reset_sent_at.is_none());
 
         assert_debug_snapshot!((reset_response.status_code(), reset_response.text()));
 

--- a/starters/saas/src/models/users.rs
+++ b/starters/saas/src/models/users.rs
@@ -290,6 +290,8 @@ impl super::_entities::users::ActiveModel {
     ) -> ModelResult<Model> {
         self.password =
             ActiveValue::set(hash::hash_password(password).map_err(|e| ModelError::Any(e.into()))?);
+        self.reset_token = ActiveValue::Set(None);
+        self.reset_sent_at = ActiveValue::Set(None);
         Ok(self.update(db).await?)
     }
 }

--- a/starters/saas/tests/requests/auth.rs
+++ b/starters/saas/tests/requests/auth.rs
@@ -156,6 +156,7 @@ async fn can_reset_password() {
             .await
             .unwrap();
         assert!(user.reset_token.is_some());
+        assert!(user.reset_sent_at.is_some());
 
         let new_password = "new-password";
         let reset_payload = serde_json::json!({
@@ -168,7 +169,9 @@ async fn can_reset_password() {
         let user = users::Model::find_by_email(&ctx.db, &user.email)
             .await
             .unwrap();
-        assert!(user.reset_sent_at.is_some());
+
+        assert!(user.reset_token.is_none());
+        assert!(user.reset_sent_at.is_none());
 
         assert_debug_snapshot!((reset_response.status_code(), reset_response.text()));
 


### PR DESCRIPTION
Reset tokens should be deleted after use to avoid them being compromised later and reused. Also we might consider adding a time check on the reset function by default.