### PR TITLE
update object store to version that fixes advisory, update code to be compatible with new version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ socketioxide = { version = "0.13.1", features = ["state"], optional = true }
 
 
 # File Upload
-object_store = { version = "0.9.0", default-features = false }
+object_store = { version = "0.10.2", default-features = false }
 
 # cache
 moka = { version = "0.12.7", features = ["sync"], optional = true }

--- a/src/storage/drivers/object_store_adapter.rs
+++ b/src/storage/drivers/object_store_adapter.rs
@@ -29,7 +29,7 @@ impl StoreDriver for ObjectStoreAdapter {
     /// Returns a `StorageResult` with the result of the upload operation.
     async fn upload(&self, path: &Path, content: &Bytes) -> StorageResult<UploadResponse> {
         let path = object_store::path::Path::from(path.display().to_string());
-        let res = self.object_store_impl.put(&path, content.clone()).await?;
+        let res = self.object_store_impl.put(&path, content.clone().into()).await?;
         Ok(UploadResponse {
             e_tag: res.e_tag,
             version: res.version,

--- a/src/storage/drivers/object_store_adapter.rs
+++ b/src/storage/drivers/object_store_adapter.rs
@@ -29,7 +29,10 @@ impl StoreDriver for ObjectStoreAdapter {
     /// Returns a `StorageResult` with the result of the upload operation.
     async fn upload(&self, path: &Path, content: &Bytes) -> StorageResult<UploadResponse> {
         let path = object_store::path::Path::from(path.display().to_string());
-        let res = self.object_store_impl.put(&path, content.clone().into()).await?;
+        let res = self
+            .object_store_impl
+            .put(&path, content.clone().into())
+            .await?;
         Ok(UploadResponse {
             e_tag: res.e_tag,
             version: res.version,


### PR DESCRIPTION
This fixes cargo audit reporting `RUSTSEC-2024-0358` (https://rustsec.org/advisories/RUSTSEC-2024-0358).
```
Crate:     object_store
Version:   0.9.1
Title:     Apache Arrow Rust Object Store: AWS WebIdentityToken exposure in log files
Date:      2024-07-23
ID:        RUSTSEC-2024-0358
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0358
Severity:  3.8 (low)
Solution:  Upgrade to >=0.10.2
Dependency tree:
object_store 0.9.1
└── loco-rs 0.6.2
    ├── loco-rs 0.6.2
    └── loco-extras 0.4.0
```


There is still an unresolved issue with `rsa` crate that has been open for months now that is a dependency of `sqlx` which loco uses, but that is out of scope for this PR.
```
Crate:     rsa
Version:   0.9.6
Title:     Marvin Attack: potential key recovery through timing sidechannels
Date:      2023-11-22
ID:        RUSTSEC-2023-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2023-0071
Severity:  5.9 (medium)
Solution:  No fixed upgrade is available!
Dependency tree:
rsa 0.9.6
└── sqlx-mysql 0.7.4
    ├── sqlx-macros-core 0.7.4
    │   └── sqlx-macros 0.7.4
    │       └── sqlx 0.7.4
    │           ├── sea-query-binder 0.6.0-rc.4
    │           │   └── sea-orm 1.0.0-rc.7
    │           │       ├── sea-orm-migration 1.0.0-rc.7
    │           │       │   └── loco-rs 0.6.2
    │           │       │       ├── loco-rs 0.6.2
    │           │       │       └── loco-extras 0.4.0
    │           │       └── loco-rs 0.6.2
    │           └── sea-orm 1.0.0-rc.7
    └── sqlx 0.7.4
```