### PR TITLE
chore: add `publish = false` in the starter templates

### DIFF
--- a/starters/lightweight-service/Cargo.toml
+++ b/starters/lightweight-service/Cargo.toml
@@ -4,6 +4,7 @@
 name = "loco_starter_template"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/starters/rest-api/Cargo.toml
+++ b/starters/rest-api/Cargo.toml
@@ -4,6 +4,7 @@
 name = "loco_starter_template"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/starters/saas/Cargo.toml
+++ b/starters/saas/Cargo.toml
@@ -4,6 +4,7 @@
 name = "loco_starter_template"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
I personally will add  `publish = false` in case it is published with an incident.
It will be more suitable to set  `publish` defaults to `false` as the starter template's default.