### PR TITLE
replace ci rust instllation

### DIFF
--- a/.github/workflows/ci-example.yml
+++ b/.github/workflows/ci-example.yml
@@ -21,11 +21,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
           components: rustfmt
       - run: cargo fmt --all -- --check
         working-directory: ./examples/demo
@@ -40,11 +38,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo clippy
@@ -86,11 +82,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Install seaorm cli

--- a/.github/workflows/ci-generators.yml
+++ b/.github/workflows/ci-generators.yml
@@ -45,11 +45,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
 
@@ -140,11 +138,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci-starter-lightweight-service.yml
+++ b/.github/workflows/ci-starter-lightweight-service.yml
@@ -25,11 +25,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
           components: rustfmt
       - run: cargo fmt --all -- --check
         working-directory: ./starters/lightweight-service
@@ -44,11 +42,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo clippy
@@ -65,11 +61,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo test
@@ -87,11 +81,9 @@ jobs:
   #   steps:
   #     - name: Checkout the code
   #       uses: actions/checkout@v4
-  #     - uses: actions-rs/toolchain@v1
+  #     - uses: dtolnay/rust-toolchain@stable
   #       with:
-  #         profile: ${{ env.TOOLCHAIN_PROFILE }}
   #         toolchain: ${{ env.RUST_TOOLCHAIN }}
-  #         override: true
   #     - name: Setup Rust cache
   #       uses: Swatinem/rust-cache@v2
   #     - name: Inject slug/short variables

--- a/.github/workflows/ci-starter-rest-api.yml
+++ b/.github/workflows/ci-starter-rest-api.yml
@@ -25,11 +25,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
           components: rustfmt
       - run: cargo fmt --all -- --check
         working-directory: ./starters/rest-api
@@ -44,11 +42,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo clippy
@@ -90,11 +86,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo test
@@ -115,11 +109,9 @@ jobs:
   #   steps:
   #     - name: Checkout the code
   #       uses: actions/checkout@v4
-  #     - uses: actions-rs/toolchain@v1
+  #     - uses: dtolnay/rust-toolchain@stable
   #       with:
-  #         profile: ${{ env.TOOLCHAIN_PROFILE }}
   #         toolchain: ${{ env.RUST_TOOLCHAIN }}
-  #         override: true
   #     - name: Setup Rust cache
   #       uses: Swatinem/rust-cache@v2
   #     - name: Inject slug/short variables

--- a/.github/workflows/ci-starter-saas.yml
+++ b/.github/workflows/ci-starter-saas.yml
@@ -25,11 +25,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
           components: rustfmt
       - run: cargo fmt --all -- --check
         working-directory: ./starters/saas
@@ -44,11 +42,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo clippy
@@ -90,11 +86,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo test
@@ -139,11 +133,9 @@ jobs:
   # steps:
   #   - name: Checkout the code
   #     uses: actions/checkout@v4
-  #   - uses: actions-rs/toolchain@v1
+  #   - uses: dtolnay/rust-toolchain@stable
   #     with:
-  #       profile: ${{ env.TOOLCHAIN_PROFILE }}
   #       toolchain: ${{ env.RUST_TOOLCHAIN }}
-  #       override: true
   #   - name: Setup Rust cache
   #     uses: Swatinem/rust-cache@v2
   #   - name: Inject slug/short variables

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
           components: rustfmt
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
@@ -43,11 +41,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo clippy
@@ -67,11 +63,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,12 +21,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
-          components: rustfmt
       - run: cargo install snipdoc --features exec
       - run: snipdoc check        
         env:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,10 +15,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
-          override: true
       - run: |
           cargo install loco-cli
           ALLOW_IN_GIT_REPO=true LOCO_APP_NAME=saas LOCO_TEMPLATE=saas loco new
@@ -36,10 +35,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
-          override: true
       - run: |
           cargo install loco-cli
           ALLOW_IN_GIT_REPO=true LOCO_APP_NAME=restapi LOCO_TEMPLATE=rest-api loco new
@@ -57,7 +55,7 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
           override: true

--- a/.github/workflows/loco-cli.yml
+++ b/.github/workflows/loco-cli.yml
@@ -21,11 +21,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
           components: rustfmt
       - run: cargo fmt --all -- --check
         working-directory: ./loco-cli
@@ -40,11 +38,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo clippy
@@ -66,11 +62,9 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2

--- a/starters/lightweight-service/.github/workflows/ci.yaml
+++ b/starters/lightweight-service/.github/workflows/ci.yaml
@@ -21,11 +21,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
           components: rustfmt
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
@@ -43,11 +41,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo clippy
@@ -66,11 +62,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo test

--- a/starters/rest-api/.github/workflows/ci.yaml
+++ b/starters/rest-api/.github/workflows/ci.yaml
@@ -21,11 +21,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
           components: rustfmt
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
@@ -43,11 +41,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo clippy
@@ -90,11 +86,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo test

--- a/starters/saas/.github/workflows/ci.yaml
+++ b/starters/saas/.github/workflows/ci.yaml
@@ -21,11 +21,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
           components: rustfmt
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
@@ -43,11 +41,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo clippy
@@ -90,11 +86,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo test


### PR DESCRIPTION
This pull request updates our GitHub Actions workflow to replace the deprecated actions-rs/toolchain@v1 with the actively maintained dtolnay/rust-toolchain.