### PR TITLE
remove eyer lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,6 @@ storage_gcp = ["object_store/gcp"]
 cache_inmem = ["dep:moka"]
 
 [dependencies]
-
-eyre = "0.6"
 backtrace_printer = { version = "1.3.0" }
 
 # cli

--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -430,14 +430,13 @@ Let's fetch data using your models, using `playground.rs`:
 ```rust
 // located in examples/playground.rs
 // use this file to experiment with stuff
-use eyre::Context;
 use loco_rs::{cli::playground, prelude::*};
 // to refer to articles::ActiveModel, your imports should look like this:
 use myapp::{app::App, models::_entities::articles};
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
-    let ctx = playground::<App>().await.context("playground")?; // <- remove '_'
+async fn main() -> loco_rs::Result<()> {
+    let ctx = playground::<App>().await?;
 
     // add this:
     let res = articles::Entity::find().all(&ctx.db).await.unwrap();
@@ -468,8 +467,8 @@ $ cargo playground
 Now, let's insert one item:
 
 ```rust
-async fn main() -> eyre::Result<()> {
-    let ctx = playground::<App>().await.context("playground")?;
+async fn main() -> loco_re::Result<()> {
+    let ctx = playground::<App>().await?;
 
     // add this:
     let active_model: articles::ActiveModel = articles::ActiveModel {

--- a/examples/demo/Cargo.lock
+++ b/examples/demo/Cargo.lock
@@ -790,7 +790,6 @@ dependencies = [
  "axum-test",
  "axum_session",
  "chrono",
- "eyre",
  "fluent-templates",
  "futures-util",
  "include_dir",
@@ -1677,16 +1676,6 @@ checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
  "event-listener 5.3.1",
  "pin-project-lite",
-]
-
-[[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
 ]
 
 [[package]]
@@ -2621,12 +2610,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indenter"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2993,7 +2976,6 @@ dependencies = [
  "clap",
  "colored",
  "duct",
- "eyre",
  "fs-err",
  "futures-util",
  "hyper 1.3.1",

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -16,7 +16,6 @@ migration = { path = "migration" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-eyre = "0.6"
 tokio = { version = "1.33.0", features = ["full"] }
 async-trait = "0.1.74"
 tracing = "0.1.40"

--- a/examples/demo/examples/playground.rs
+++ b/examples/demo/examples/playground.rs
@@ -1,11 +1,10 @@
 use blo::app::App;
-use eyre::Context;
 #[allow(unused_imports)]
 use loco_rs::{cli::playground, prelude::*};
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
-    let _ctx = playground::<App>().await.context("playground")?;
+async fn main() -> loco_rs::Result<()> {
+    let _ctx = playground::<App>().await?;
 
     // let active_model: articles::ActiveModel = ActiveModel {
     //     title: Set(Some("how to build apps in 3 steps".to_string())),

--- a/examples/demo/examples/start.rs
+++ b/examples/demo/examples/start.rs
@@ -6,7 +6,7 @@ use loco_rs::{
 use migration::Migrator;
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
+async fn main() -> loco_rs::Result<()> {
     let environment: Environment = resolve_from_env().into();
 
     let boot_result = create_app::<App, Migrator>(StartMode::ServerAndWorker, &environment).await?;

--- a/examples/demo/examples/task.rs
+++ b/examples/demo/examples/task.rs
@@ -8,7 +8,7 @@ use loco_rs::{
 };
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
+async fn main() -> loco_rs::Result<()> {
     let environment: Environment = resolve_from_env().into();
 
     let args = env::args().collect::<Vec<_>>();

--- a/examples/demo/examples/workers.rs
+++ b/examples/demo/examples/workers.rs
@@ -6,7 +6,7 @@ use loco_rs::{
 use migration::Migrator;
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
+async fn main() -> loco_rs::Result<()> {
     let environment: Environment = resolve_from_env().into();
 
     let boot_result = create_app::<App, Migrator>(StartMode::WorkerOnly, &environment).await?;

--- a/examples/demo/src/bin/main.rs
+++ b/examples/demo/src/bin/main.rs
@@ -3,6 +3,6 @@ use loco_rs::cli;
 use migration::Migrator;
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
+async fn main() -> loco_rs::Result<()> {
     cli::main::<App, Migrator>().await
 }

--- a/examples/llm-candle-inference/Cargo.toml
+++ b/examples/llm-candle-inference/Cargo.toml
@@ -14,7 +14,6 @@ loco-rs = { version = "*", path = "../../", default-features = false, features =
 ] }
 serde = "1"
 serde_json = "1"
-eyre = "0.6.12"
 tokio = { version = "1.33.0", default-features = false }
 async-trait = "0.1.74"
 tracing = "0.1.40"

--- a/examples/llm-candle-inference/src/bin/main.rs
+++ b/examples/llm-candle-inference/src/bin/main.rs
@@ -2,6 +2,6 @@ use inference::app::App;
 use loco_rs::cli;
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
+async fn main() -> loco_rs::Result<()> {
     cli::main::<App>().await
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -290,7 +290,7 @@ pub async fn playground<H: Hooks>() -> crate::Result<AppContext> {
 /// }
 /// ```
 #[cfg(feature = "with-db")]
-pub async fn main<H: Hooks, M: MigratorTrait>() -> eyre::Result<()> {
+pub async fn main<H: Hooks, M: MigratorTrait>() -> crate::Result<()> {
     let cli: Cli = Cli::parse();
     let environment: Environment = cli.environment.unwrap_or_else(resolve_from_env).into();
 
@@ -367,7 +367,7 @@ pub async fn main<H: Hooks, M: MigratorTrait>() -> eyre::Result<()> {
 }
 
 #[cfg(not(feature = "with-db"))]
-pub async fn main<H: Hooks>() -> eyre::Result<()> {
+pub async fn main<H: Hooks>() -> crate::Result<()> {
     let cli = Cli::parse();
     let environment: Environment = cli.environment.unwrap_or_else(resolve_from_env).into();
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -126,9 +126,6 @@ pub enum Error {
 
     #[error(transparent)]
     Any(#[from] Box<dyn std::error::Error + Send + Sync>),
-
-    #[error(transparent)]
-    Anyhow(#[from] eyre::Report),
 }
 
 impl Error {

--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -290,7 +290,7 @@ fn collect_messages(results: Vec<GenResult>) -> String {
     messages
 }
 
-fn prompt_deployment_selection() -> eyre::Result<DeploymentKind> {
+fn prompt_deployment_selection() -> Result<DeploymentKind> {
     let options: Vec<String> = DEPLOYMENT_OPTIONS.iter().map(|t| t.0.to_string()).collect();
 
     let selection_options = requestty::Question::select("deployment")
@@ -298,11 +298,11 @@ fn prompt_deployment_selection() -> eyre::Result<DeploymentKind> {
         .choices(&options)
         .build();
 
-    let answer = requestty::prompt_one(selection_options)?;
+    let answer = requestty::prompt_one(selection_options).map_err(errors::Error::msg)?;
 
     let selection = answer
         .as_list_item()
-        .ok_or_else(|| eyre::eyre!("deployment selection it empty"))?;
+        .ok_or_else(|| errors::Error::string("deployment selection it empty"))?;
 
     Ok(DEPLOYMENT_OPTIONS[selection.index].1.clone())
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -150,9 +150,9 @@ pub async fn boot_test<H: Hooks>() -> Result<BootResult> {
 ///     assert!(false)
 /// }
 /// ```
-pub async fn seed<H: Hooks>(db: &DatabaseConnection) -> eyre::Result<()> {
+pub async fn seed<H: Hooks>(db: &DatabaseConnection) -> Result<()> {
     let path = std::path::Path::new("src/fixtures");
-    Ok(H::seed(db, path).await?)
+    H::seed(db, path).await
 }
 
 #[allow(clippy::future_not_send)]

--- a/starters/lightweight-service/Cargo.lock
+++ b/starters/lightweight-service/Cargo.lock
@@ -663,6 +663,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,16 +854,6 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
 ]
 
 [[package]]
@@ -1307,12 +1306,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indenter"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
-
-[[package]]
 name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,9 +1350,9 @@ checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1471,8 +1464,6 @@ dependencies = [
 [[package]]
 name = "loco-rs"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9efe4f4bb106b2616869c3efe06de22bb20594e9dec163768d0bceab4cad0aa5"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1489,7 +1480,6 @@ dependencies = [
  "clap",
  "colored",
  "duct",
- "eyre",
  "fs-err",
  "futures-util",
  "hyper",
@@ -1513,6 +1503,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "uuid",
  "validator",
@@ -1524,7 +1515,6 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
- "eyre",
  "insta",
  "loco-rs",
  "rstest",
@@ -1674,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.9.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8718f8b65fdf67a45108d1548347d4af7d71fb81ce727bbf9e3b2535e079db3"
+checksum = "e6da452820c715ce78221e8202ccc599b4a52f3e1eb3eedb487b680c81a8e3f3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2964,6 +2954,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/starters/lightweight-service/Cargo.toml
+++ b/starters/lightweight-service/Cargo.toml
@@ -15,10 +15,8 @@ loco-rs = { version = "*", path = "../../", default-features = false, features =
 ] }
 serde = "*"
 serde_json = "*"
-eyre = "*"
 tokio = { version = "1.33.0", default-features = false }
 async-trait = "0.1.74"
-
 axum = "0.7.5"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }

--- a/starters/lightweight-service/src/bin/main.rs
+++ b/starters/lightweight-service/src/bin/main.rs
@@ -2,6 +2,6 @@ use loco_rs::cli;
 use loco_starter_template::app::App;
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
+async fn main() -> loco_rs::Result<()> {
     cli::main::<App>().await
 }

--- a/starters/rest-api/Cargo.lock
+++ b/starters/rest-api/Cargo.lock
@@ -1307,16 +1307,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
-]
-
-[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,12 +1889,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indenter"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
-
-[[package]]
 name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2154,7 +2138,6 @@ dependencies = [
  "clap",
  "colored",
  "duct",
- "eyre",
  "fs-err",
  "futures-util",
  "hyper",
@@ -2195,7 +2178,6 @@ dependencies = [
  "async-trait",
  "axum",
  "chrono",
- "eyre",
  "include_dir",
  "insta",
  "loco-rs",

--- a/starters/rest-api/Cargo.toml
+++ b/starters/rest-api/Cargo.toml
@@ -15,7 +15,6 @@ migration = { path = "migration" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-eyre = "0.6"
 tokio = { version = "1.33.0", default-features = false }
 async-trait = "0.1.74"
 tracing = "0.1.40"

--- a/starters/rest-api/examples/playground.rs
+++ b/starters/rest-api/examples/playground.rs
@@ -1,11 +1,10 @@
-use eyre::Context;
 #[allow(unused_imports)]
 use loco_rs::{cli::playground, prelude::*};
 use loco_starter_template::app::App;
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
-    let _ctx = playground::<App>().await.context("playground")?;
+async fn main() -> loco_rs::Result<()> {
+    let _ctx = playground::<App>().await?;
 
     // let active_model: articles::ActiveModel = ActiveModel {
     //     title: Set(Some("how to build apps in 3 steps".to_string())),

--- a/starters/rest-api/src/bin/main.rs
+++ b/starters/rest-api/src/bin/main.rs
@@ -3,6 +3,6 @@ use loco_starter_template::app::App;
 use migration::Migrator;
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
+async fn main() -> loco_rs::Result<()> {
     cli::main::<App, Migrator>().await
 }

--- a/starters/saas/Cargo.lock
+++ b/starters/saas/Cargo.lock
@@ -1324,16 +1324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
-]
-
-[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,12 +1999,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indenter"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
-
-[[package]]
 name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2283,7 +2267,6 @@ dependencies = [
  "clap",
  "colored",
  "duct",
- "eyre",
  "fs-err",
  "futures-util",
  "hyper",
@@ -2324,7 +2307,6 @@ dependencies = [
  "async-trait",
  "axum",
  "chrono",
- "eyre",
  "fluent-templates",
  "include_dir",
  "insta",

--- a/starters/saas/Cargo.toml
+++ b/starters/saas/Cargo.toml
@@ -15,7 +15,6 @@ migration = { path = "migration" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-eyre = "0.6"
 tokio = { version = "1.33.0", default-features = false }
 async-trait = "0.1.74"
 tracing = "0.1.40"

--- a/starters/saas/examples/playground.rs
+++ b/starters/saas/examples/playground.rs
@@ -1,11 +1,10 @@
-use eyre::Context;
 #[allow(unused_imports)]
 use loco_rs::{cli::playground, prelude::*};
 use loco_starter_template::app::App;
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
-    let _ctx = playground::<App>().await.context("playground")?;
+async fn main() -> loco_rs::Result<()> {
+    let _ctx = playground::<App>().await?;
 
     // let active_model: articles::ActiveModel = ActiveModel {
     //     title: Set(Some("how to build apps in 3 steps".to_string())),

--- a/starters/saas/src/bin/main.rs
+++ b/starters/saas/src/bin/main.rs
@@ -3,6 +3,6 @@ use loco_starter_template::app::App;
 use migration::Migrator;
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
+async fn main() -> loco_rs::Result<()> {
     cli::main::<App, Migrator>().await
 }


### PR DESCRIPTION
Migrate eyer crate for error handling for loco::Result .

## Breaking Changes:

1. Update the Main Function in src/bin/main

   Replace the return type of the main function:

   **Before:**
   ```rust
   async fn main() -> eyre::Result<()>
   ```

   **After:**
   ```rust
   async fn main() -> loco_rs::Result<()>
   ```


2. Modify examples/playground.rs
   You need to apply two changes here:

     a. Update the Function Signature
     **Before:**
     ```rust
     async fn main() -> eyre::Result<()>
     ```

     **After:**
     ```rust
     async fn main() -> loco_rs::Result<()>
     ```

     b. Adjust the Context Handling
     **Before:**
     ```rust
     let _ctx = playground::<App>().await.context("playground")?;
     ```

     **After:**
     ```rust
     let _ctx = playground::<App>().await?;
     ```

Note, 
If you are using eyre in your project, you can continue to do so. We have only removed this crate from our base code dependencies.