### PR TITLE
Fix boolean columns and unclosed div tag on HTMX Edit template scaffold

### DIFF
--- a/src/gen/templates/scaffold/htmx/view_edit.t
+++ b/src/gen/templates/scaffold/htmx/view_edit.t
@@ -49,11 +49,12 @@ message: "{{file_name}} edit view was added successfully."
         </div>
     {% endfor -%}
     <div>
-    <div class="mt-5">
+        <div class="mt-5">
             <button class=" text-xs py-3 px-6 rounded-lg bg-gray-900 text-white" type="submit">Submit</button>
             <button class="text-xs py-3 px-6 rounded-lg bg-red-600 text-white"
                         onclick="confirmDelete(event)">Delete</button>
         </div>
+    </div>
     </form>
     <div id="success-message" class="mt-4"></div>
     <br />

--- a/src/gen/templates/scaffold/htmx/view_edit.t
+++ b/src/gen/templates/scaffold/htmx/view_edit.t
@@ -30,9 +30,9 @@ message: "{{file_name}} edit view was added successfully."
         {% elif column.2 == "int" or column.2 == "int!" or column.2 == "int^"-%}
         <input id="{{column.0}}" name="{{column.0}}" type="number" required value="{% raw %}{{item.{% endraw %}{{column.0}}{% raw %}}}{% endraw %}"></input>
         {% elif column.2 == "bool"-%}
-        <input id="{{column.0}}" name="{{column.0}}" type="checkbox" value="true" {% raw %}{% if item.0 %}checked{%endif %}{% endraw %}></input>
+        <input id="{{column.0}}" name="{{column.0}}" type="checkbox" value="true" {% raw %}{% if item.{% endraw %}{{column.0}}{% raw %} %}checked{%endif %}{% endraw %}></input>
         {% elif column.2 == "bool!"-%}
-        <input id="{{column.0}}" name="{{column.0}}" type="checkbox" value="true" {% raw %}{% if item.0 %}checked{%endif %}{% endraw %} required></input>
+        <input id="{{column.0}}" name="{{column.0}}" type="checkbox" value="true" {% raw %}{% if item.{% endraw %}{{column.0}}{% raw %} %}checked{%endif %}{% endraw %} required></input>
         {% elif column.2 == "ts"-%}
         <input id="{{column.0}}" name="{{column.0}}" type="text" value="{% raw %}{{item.{% endraw %}{{column.0}}{% raw %}}}{% endraw %}"></input>
         {% elif column.2 == "ts!"-%}


### PR DESCRIPTION
## Description

This pull request addresses the issue [#691](https://github.com/loco-rs/loco/issues/691#issue-2454694067)

1. The `div` tag of the button group was not closed. 
   - **Reference:** [templates/scaffold/htmx/view_edit - Line 51](https://github.com/loco-rs/loco/blob/412ab9c4d4a759604a9212b9a8eb4247e4c41b48/src/gen/templates/scaffold/htmx/view_edit.t#L51)

2. The checkboxes generated from boolean fields were not in sync with the item field. 
   - **Reference:** [templates/scaffold/htmx/view_edit - Lines 33 and 35](https://github.com/loco-rs/loco/blob/412ab9c4d4a759604a9212b9a8eb4247e4c41b48/src/gen/templates/scaffold/htmx/view_edit.t#L33)
