### PR TITLE
Remove version in compose.yaml file

### DIFF
--- a/starters/lightweight-service/.devcontainer/compose.yaml
+++ b/starters/lightweight-service/.devcontainer/compose.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   app:
     build:

--- a/starters/rest-api/.devcontainer/compose.yaml
+++ b/starters/rest-api/.devcontainer/compose.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   app:
     build:
@@ -43,6 +41,7 @@ services:
 
 volumes:
   postgres-data:
+
 
 networks:
   db:

--- a/starters/saas/.devcontainer/compose.yaml
+++ b/starters/saas/.devcontainer/compose.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   app:
     build:
@@ -43,6 +41,7 @@ services:
 
 volumes:
   postgres-data:
+
 
 networks:
   db:


### PR DESCRIPTION
The official docs says that `It is only informative you'll receive a warning message that it is obsolete if used.`
- ref
    - https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-and-name-top-level-elements