### PR TITLE
[docs] fix: return type

### DIFF
--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -594,7 +594,7 @@ pub async fn update(
     format::json(item)
 }
 
-pub async fn remove(Path(id): Path<i32>, State(ctx): State<AppContext>) -> Result<()> {
+pub async fn remove(Path(id): Path<i32>, State(ctx): State<AppContext>) -> Result<Response> {
     load_item(&ctx, id).await?.delete(&ctx.db).await?;
     format::empty()
 }


### PR DESCRIPTION
in `articles.rs` (chapter [Building a CRUD API](https://loco.rs/docs/getting-started/guide/#building-a-crud-api))

Note: From v0.8.1. `format::emtpy()` returns `Result<Response>` (check https://github.com/loco-rs/loco/commit/82b88507fde1123d164654ec88fd4662ff9b38b5#diff-c3d0905b8efe97ffe06f30894e44ff7a93d011c35176a2bf411fbe4eecbf8a3dL53-L54)