### PR TITLE
Update docs site to work with zola 0.19.2

### DIFF
--- a/docs-site/config.toml
+++ b/docs-site/config.toml
@@ -8,7 +8,7 @@ description = "Loco is a productivity-first web and service framework in Rust"
 compile_sass = true
 
 # Whether to generate a feed file for the site
-generate_feed = true
+generate_feeds = true
 
 # When set to "true", the generated HTML files are minified.
 minify_html = false

--- a/docs-site/content/authors/_index.md
+++ b/docs-site/content/authors/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Authors"
 description = "The authurs of the blog articles."
-date = 2021-04-01T08:00:00+00:00
-updated = 2021-04-01T08:00:00+00:00
 draft = false
 
 # If add a new author page in this section, please add a new item,

--- a/docs-site/content/docs/_index.md
+++ b/docs-site/content/docs/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Docs"
 description = "Docs for loco"
-date = 2025-05-01T08:00:00+00:00
-updated = 2021-05-01T08:00:00+00:00
 sort_by = "weight"
 weight = 1
 template = "docs/section.html"

--- a/docs-site/content/docs/extras/_index.md
+++ b/docs-site/content/docs/extras/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Extras"
 description = ""
-date = 2025-05-01T18:00:00+00:00
-updated = 2021-05-01T18:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 5

--- a/docs-site/content/docs/getting-started/_index.md
+++ b/docs-site/content/docs/getting-started/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Getting Started"
 description = ""
-date = 2025-05-01T08:00:00+00:00
-updated = 2021-05-01T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 1

--- a/docs-site/content/docs/infrastructure/_index.md
+++ b/docs-site/content/docs/infrastructure/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Infrastructure"
 description = ""
-date = 2025-05-01T18:00:00+00:00
-updated = 2021-05-01T18:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 4

--- a/docs-site/content/docs/processing/_index.md
+++ b/docs-site/content/docs/processing/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Processing"
 description = ""
-date = 2025-05-01T18:00:00+00:00
-updated = 2021-05-01T18:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 3

--- a/docs-site/content/docs/resources/_index.md
+++ b/docs-site/content/docs/resources/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Resources"
 description = ""
-date = 2025-05-01T19:00:00+00:00
-updated = 2021-05-01T19:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 6

--- a/docs-site/content/docs/the-app/_index.md
+++ b/docs-site/content/docs/the-app/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "The App"
 description = ""
-date = 2025-05-01T18:00:00+00:00
-updated = 2021-05-01T18:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 2

--- a/docs-site/content/privacy-policy/_index.md
+++ b/docs-site/content/privacy-policy/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Privacy Policy"
 description = "We do not use cookies and we do not collect any personal data."
-date = 2021-05-01T08:00:00+00:00
-updated = 2020-05-01T08:00:00+00:00
 draft = false
 
 [extra]


### PR DESCRIPTION
Encountered that the `date` and `update` fields in the `./docs-site/content/*/**/_index.md` prematter were causing errors in the newest zola version (`0.19.2`). Removing them and changing `generate_feed` -> `generate_feeds` in the `config.toml` allowed the site to be rendered through zola.