### PR TITLE
Remove query JWTs (breaking change)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -275,8 +275,6 @@ pub struct JWT {
 pub enum JWTLocation {
     /// Authenticate using a Bearer token.
     Bearer,
-    /// Authenticate using a token passed as a query parameter.
-    Query { name: String },
     /// Authenticate using a token stored in a cookie.
     Cookie { name: String },
 }

--- a/src/controller/middleware/snapshots/loco_rs__controller__middleware__auth__tests__extract_from_query.snap
+++ b/src/controller/middleware/snapshots/loco_rs__controller__middleware__auth__tests__extract_from_query.snap
@@ -1,7 +1,0 @@
----
-source: src/controller/middleware/auth.rs
-expression: "extract_token(&jwt_config, &parts)"
----
-Ok(
-    "query_token_value",
-)


### PR DESCRIPTION
Is there a good reason to need to support query JWTs at the framework level?

The reason why I ask is because I believe enabling query JWTs punches a small security hole into the framework, and by extension Loco's users.

Intermediate proxies log requests, the requirements for shipping/aggregating those is usually less secure than applications and surrounding infrastructure themselves. This can be further exacerbated by engineering and ops teams having access to production logs via their machines. Finally, end users can also accidentally end up sharing their tokens. All of those can lead to session stealing/hijacking/replays.

I realise a lot of these are self inflicted errors, and some of them can be worked around or diminished, but I don't expect everyone to be hyper-vigilant about security!

Lastly, I don't think it has a great cost-benefit ratio: the cost is very steep (potential security hole, which are nightmares on _multiple_ fronts: monetary, reputation, data loss), while the benefit is negligible: most anything sending a request can attach a header or a cookie already; usually attaching headers/cookies is also ergonomic than fiddling with query params.

Overall, I'd rather Loco errs on the side of providing only safe options out of the box, especially surrounding stuff like AuthN/AuthZ.

If users really want or need to implement something like this, they can shoot themselves in the foot on their own terms, but at least we've not given them the gun!

Hope I managed to get my thoughts across clearly. Also, I realise this might be a [Chesterton's fence](https://en.wikipedia.org/wiki/G._K._Chesterton#Chesterton's_fence) type of situation, though! So, I'm happy to discuss and even be convinced otherwise!