### PR TITLE
fix: replace mentions of "tokyo" with "tokio"

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -63,7 +63,7 @@ Vous pouvez maintenant créer votre nouvelle application (choisissez "`SaaS` app
 ✔ ❯ App name? · myapp
 ✔ ❯ What would you like to build? · SaaS app (with DB and user auth)
 ✔ ❯ Select a DB Provider · Sqlite
-✔ ❯ Select your background worker type · Async (in-process tokyo async tasks)
+✔ ❯ Select your background worker type · Async (in-process tokio async tasks)
 ✔ ❯ Select an asset serving configuration · Client (configures assets for frontend serving)
 
 🚂 Loco app generated successfully in:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Now you can create your new app (choose "`SaaS` app").
 ✔ ❯ App name? · myapp
 ✔ ❯ What would you like to build? · SaaS app (with DB and user auth)
 ✔ ❯ Select a DB Provider · Sqlite
-✔ ❯ Select your background worker type · Async (in-process tokyo async tasks)
+✔ ❯ Select your background worker type · Async (in-process tokio async tasks)
 ✔ ❯ Select an asset serving configuration · Client (configures assets for frontend serving)
 
 🚂 Loco app generated successfully in:

--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -67,7 +67,7 @@ Now you can create your new app (choose "SaaS app" for built-in authentication).
 ✔ ❯ App name? · myapp
 ✔ ❯ What would you like to build? · SaaS app (with DB and user auth)
 ✔ ❯ Select a DB Provider · Sqlite
-✔ ❯ Select your background worker type · Async (in-process tokyo async tasks)
+✔ ❯ Select your background worker type · Async (in-process tokio async tasks)
 ✔ ❯ Select an asset serving configuration · Client (configures assets for frontend serving)
 
 🚂 Loco app generated successfully in:

--- a/docs-site/content/docs/getting-started/starters.md
+++ b/docs-site/content/docs/getting-started/starters.md
@@ -30,7 +30,7 @@ Create a starter:
 ✔ ❯ App name? · myapp
 ✔ ❯ What would you like to build? · SaaS app (with DB and user auth)
 ✔ ❯ Select a DB Provider · Sqlite
-✔ ❯ Select your background worker type · Async (in-process tokyo async tasks)
+✔ ❯ Select your background worker type · Async (in-process tokio async tasks)
 ✔ ❯ Select an asset serving configuration · Client (configures assets for frontend serving)
 
 🚂 Loco app generated successfully in:

--- a/docs-site/content/docs/getting-started/tour/index.md
+++ b/docs-site/content/docs/getting-started/tour/index.md
@@ -34,7 +34,7 @@ cargo install sea-orm-cli # Only when DB is needed
 ✔ ❯ App name? · myapp
 ✔ ❯ What would you like to build? · SaaS app (with DB and user auth)
 ✔ ❯ Select a DB Provider · Sqlite
-✔ ❯ Select your background worker type · Async (in-process tokyo async tasks)
+✔ ❯ Select your background worker type · Async (in-process tokio async tasks)
 ✔ ❯ Select an asset serving configuration · Client (configures assets for frontend serving)
 
  🚂 Loco app generated successfully in:

--- a/docs-site/content/docs/the-app/your-project.md
+++ b/docs-site/content/docs/the-app/your-project.md
@@ -25,7 +25,7 @@ Create your starter app:
 ✔ ❯ App name? · myapp
 ✔ ❯ What would you like to build? · SaaS app (with DB and user auth)
 ✔ ❯ Select a DB Provider · Sqlite
-✔ ❯ Select your background worker type · Async (in-process tokyo async tasks)
+✔ ❯ Select your background worker type · Async (in-process tokio async tasks)
 ✔ ❯ Select an asset serving configuration · Client (configures assets for frontend serving)
 
 🚂 Loco app generated successfully in:

--- a/loco-cli/src/generate.rs
+++ b/loco-cli/src/generate.rs
@@ -60,7 +60,7 @@ pub enum DBOption {
 )]
 pub enum BackgroundOption {
     #[default]
-    #[strum(to_string = "Async (in-process tokyo async tasks)")]
+    #[strum(to_string = "Async (in-process tokio async tasks)")]
     #[serde(rename = "async")]
     Async,
     #[strum(to_string = "Queue (standalone workers using Redis)")]

--- a/snipdoc.yml
+++ b/snipdoc.yml
@@ -22,7 +22,7 @@ snippets:
       ✔ ❯ App name? · myapp
       ✔ ❯ What would you like to build? · SaaS app (with DB and user auth)
       ✔ ❯ Select a DB Provider · Sqlite
-      ✔ ❯ Select your background worker type · Async (in-process tokyo async tasks)
+      ✔ ❯ Select your background worker type · Async (in-process tokio async tasks)
       ✔ ❯ Select an asset serving configuration · Client (configures assets for frontend serving)
 
       🚂 Loco app generated successfully in:


### PR DESCRIPTION
Hi,

The popular async crate is actually called `tokio`, not `tokyo`.
This PR replaces all occurrences of `tokyo` with `tokio`.