### PR TITLE
Provide good default PRAGMAS for SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 todo.txt
 examples/demo2
 *.sqlite
+*.sqlite-wal
+*.sqlite-shm
 
 # IDE config files
 .idea

--- a/src/db.rs
+++ b/src/db.rs
@@ -148,14 +148,14 @@ pub async fn connect(config: &config::Database) -> Result<DbConn, sea_orm::DbErr
     if db.get_database_backend() == DatabaseBackend::Sqlite {
         db.execute(Statement::from_string(
             DatabaseBackend::Sqlite,
-            r#"
+            "
             PRAGMA foreign_keys = ON;
             PRAGMA journal_mode = WAL;
             PRAGMA synchronous = NORMAL;
             PRAGMA mmap_size = 134217728;
             PRAGMA journal_size_limit = 67108864;
             PRAGMA cache_size = 2000;
-            "#,
+            ",
         ))
         .await?;
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -143,7 +143,24 @@ pub async fn connect(config: &config::Database) -> Result<DbConn, sea_orm::DbErr
         opt.acquire_timeout(Duration::from_millis(acquire_timeout));
     }
 
-    Database::connect(opt).await
+    let db = Database::connect(opt).await?;
+
+    if db.get_database_backend() == DatabaseBackend::Sqlite {
+        db.execute(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            r#"
+            PRAGMA foreign_keys = ON;
+            PRAGMA journal_mode = WAL;
+            PRAGMA synchronous = NORMAL;
+            PRAGMA mmap_size = 134217728;
+            PRAGMA journal_size_limit = 67108864;
+            PRAGMA cache_size = 2000;
+            "#,
+        ))
+        .await?;
+    }
+
+    Ok(db)
 }
 
 ///  Create a new database. This functionality is currently exclusive to Postgre


### PR DESCRIPTION
Addressing Issue https://github.com/loco-rs/loco/issues/773

### What has been done
Just a very basic way of setting PRAGMAS on connect.
Defaults inspired by the [official sqlite ruby adapter.](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb)

### Why
SQLite is very much a DB that can be used in production nowadays. Due to age and importance of compatibility those settings are not default. Especially `journal_mode = WAL` will improve the experience a lot by not be blocking on reads or writes anymore.

If there is anything missing from my PR or if there is any concerns or other opinions im happy to hear about it.