### PR TITLE
Minor: Make info banner on health route less specific

### DIFF
--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -131,7 +131,7 @@ $ curl localhost:5150/_health
 ```
 
 <div class="infobox">
-The built in <code>_health</code> route will tell you that you have configured your app properly: it can establish a connection to your Postgres and Redis instances successfully.
+The built in <code>_health</code> route will tell you that you have configured your app properly: it can establish a connection to your Database and Redis instances successfully.
 </div>
 
 ### Say "Hello", Loco


### PR DESCRIPTION
<img width="1512" alt="Screenshot 2024-10-15 at 11 10 20 AM" src="https://github.com/user-attachments/assets/4d37abcd-9d20-4d19-89b5-1fd82b18cc0a">

It should actually be generic and say "Database" instead. Read in [doc](https://loco.rs/docs/getting-started/guide/#:~:text=connection%20to%20your-,Postgres,-and%20Redis%20instances).

Reasons:

- In code, we are pinging the configured db and redis to check health. It's not specific to postgres.
- Context in the guide is explained setting sqlite as db provider. So it will be weird to see "Postgres" for readers who chose sqlite while they read through.

<img width="1512" alt="Screenshot 2024-10-15 at 11 17 30 AM" src="https://github.com/user-attachments/assets/d5924f84-f5b6-40c2-812c-2ec7d20e6250">


