### PR TITLE
allow dash in app-name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["macros", "xtask", "loco-extras"]
+members = ["macros", "xtask", "loco-extras", "loco-cli"]
 exclude = ["starters"]
 
 [workspace.package]

--- a/loco-cli/Cargo.toml
+++ b/loco-cli/Cargo.toml
@@ -1,5 +1,3 @@
-[workspace]
-
 [package]
 name = "loco-cli"
 version = "0.2.9"
@@ -48,6 +46,7 @@ cfg-if = "1.0.0"
 dunce = { version = "1.0.4" }
 strum = { version = "0.26", features = ["derive"] }
 colored = "2"
+heck = "0.5.0"
 
 [dev-dependencies]
 trycmd = "0.14.19"

--- a/loco-cli/src/bin/main.rs
+++ b/loco-cli/src/bin/main.rs
@@ -1,6 +1,7 @@
 use std::{env, path::PathBuf};
 
 use clap::{Parser, Subcommand};
+use heck::ToSnakeCase;
 use loco_cli::{
     generate::{self, AssetsOption, BackgroundOption, DBOption},
     git, prompt, CmdExit,
@@ -76,10 +77,11 @@ fn main() -> eyre::Result<()> {
                 prompt::warn_if_in_git_repo()?;
             }
 
-            let app = prompt::app_name(name)?;
-
+            let app_name = prompt::app_name(name)?;
+            let lib_name = app_name.to_snake_case();
             let args = generate::ArgsPlaceholder {
-                lib_name: app.to_string(),
+                app_name: app_name.clone(),
+                lib_name,
                 db,
                 bg,
                 assets,
@@ -87,7 +89,7 @@ fn main() -> eyre::Result<()> {
             };
 
             tracing::debug!(args = format!("{:?}", args), "generate template args");
-            match git::clone_template(path.as_path(), &app, &args) {
+            match git::clone_template(path.as_path(), &app_name, &args) {
                 Ok((path, messages)) => CmdExit::ok_with_message(&format!(
                     "\n🚂 Loco app generated successfully in:\n{}\n\n{}",
                     dunce::canonicalize(&path).unwrap_or(path).display(),

--- a/loco-cli/src/prompt.rs
+++ b/loco-cli/src/prompt.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 lazy_static! {
-    static ref VALIDATE_APP_NAME: Regex = Regex::new(r"^[a-zA-Z0-9_]+$").unwrap();
+    static ref VALIDATE_APP_NAME: Regex = Regex::new(r"^[a-zA-Z0-9_-]+$").unwrap();
 }
 
 /// Prompts the user to enter a valid application name for use with the Loco app

--- a/starters/lightweight-service/Cargo.lock
+++ b/starters/lightweight-service/Cargo.lock
@@ -1468,7 +1468,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "loco_starter_template"
+name = "loco-starter-template"
 version = "0.1.0"
 dependencies = [
  "async-trait",

--- a/starters/lightweight-service/Cargo.toml
+++ b/starters/lightweight-service/Cargo.toml
@@ -1,11 +1,11 @@
 [workspace]
 
 [package]
-name = "loco_starter_template"
+name = "loco-starter-template"
 version = "0.1.0"
 edition = "2021"
 publish = false
-default-run = "loco_starter_template-cli"
+default-run = "loco-starter-template-cli"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -23,7 +23,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }
 
 [[bin]]
-name = "loco_starter_template-cli"
+name = "loco-starter-template-cli"
 path = "src/bin/main.rs"
 required-features = []
 

--- a/starters/lightweight-service/generator.yaml
+++ b/starters/lightweight-service/generator.yaml
@@ -1,6 +1,12 @@
 ---
 description: lightweight-service (minimal, only controllers and views)
 rules:
+  - pattern: loco-starter-template
+    kind: AppName
+    file_patterns:
+      - rs
+      - toml
+      - trycmd
   - pattern: loco_starter_template
     kind: LibName
     file_patterns:

--- a/starters/rest-api/Cargo.lock
+++ b/starters/rest-api/Cargo.lock
@@ -2220,7 +2220,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "loco_starter_template"
+name = "loco-starter-template"
 version = "0.1.0"
 dependencies = [
  "async-trait",

--- a/starters/rest-api/Cargo.toml
+++ b/starters/rest-api/Cargo.toml
@@ -1,11 +1,11 @@
 [workspace]
 
 [package]
-name = "loco_starter_template"
+name = "loco-starter-template"
 version = "0.1.0"
 edition = "2021"
 publish = false
-default-run = "loco_starter_template-cli"
+default-run = "loco-starter-template-cli"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -34,7 +34,7 @@ uuid = { version = "1.6.0", features = ["v4"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }
 
 [[bin]]
-name = "loco_starter_template-cli"
+name = "loco-starter-template-cli"
 path = "src/bin/main.rs"
 required-features = []
 

--- a/starters/rest-api/generator.yaml
+++ b/starters/rest-api/generator.yaml
@@ -4,6 +4,12 @@ options:
   - db
   - bg
 rules:
+  - pattern: loco-starter-template
+    kind: AppName
+    file_patterns:
+      - rs
+      - toml
+      - trycmd
   - pattern: loco_starter_template
     kind: LibName
     file_patterns:

--- a/starters/saas/Cargo.lock
+++ b/starters/saas/Cargo.lock
@@ -2355,7 +2355,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "loco_starter_template"
+name = "loco-starter-template"
 version = "0.1.0"
 dependencies = [
  "async-trait",

--- a/starters/saas/Cargo.toml
+++ b/starters/saas/Cargo.toml
@@ -1,11 +1,11 @@
 [workspace]
 
 [package]
-name = "loco_starter_template"
+name = "loco-starter-template"
 version = "0.1.0"
 edition = "2021"
 publish = false
-default-run = "loco_starter_template-cli"
+default-run = "loco-starter-template-cli"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -39,7 +39,7 @@ unic-langid = "0.9.4"
 # /view engine
 
 [[bin]]
-name = "loco_starter_template-cli"
+name = "loco-starter-template-cli"
 path = "src/bin/main.rs"
 required-features = []
 

--- a/starters/saas/generator.yaml
+++ b/starters/saas/generator.yaml
@@ -5,6 +5,12 @@ options:
   - bg
   - assets
 rules:
+  - pattern: loco-starter-template
+    kind: AppName
+    file_patterns:
+      - rs
+      - toml
+      - trycmd
   - pattern: loco_starter_template
     kind: LibName
     file_patterns:


### PR DESCRIPTION
I like to have Rust projects that have dashes in their name and was annoyed that this was not possible.
This changes the lib name place holder to be snake case, and adds a new app name placeholder that is not modified.