### PR TITLE
fix tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,3 +174,4 @@ insta = { version = "1.34.0", features = ["redactions", "yaml", "filters"] }
 tree-fs = { version = "0.1.0" }
 reqwest = { version = "0.12.7" }
 serial_test = "3.1.1"
+tower = { workspace = true, features = ["util"]}


### PR DESCRIPTION
tower::ServiceExt is used in the tests, but it is behind the util feature flag, which is not enabled
