### PR TITLE
Fix tests being generated with wrong endpoints.

### DIFF
--- a/loco-gen/src/templates/controller/api/test.t
+++ b/loco-gen/src/templates/controller/api/test.t
@@ -12,6 +12,19 @@ use {{pkg_name}}::app::App;
 use loco_rs::testing;
 use serial_test::serial;
 
+#[tokio::test]
+#[serial]
+async fn can_get_{{ name | plural | snake_case }}() {
+    testing::request::<App, _, _>(|request, _ctx| async move {
+        let res = request.get("/{{ name | plural | snake_case }}/").await;
+        assert_eq!(res.status_code(), 200);
+
+        // you can assert content like this:
+        // assert_eq!(res.text(), "content");
+    })
+    .await;
+}
+
 {% for action in actions -%}
 #[tokio::test]
 #[serial]

--- a/loco-gen/src/templates/controller/api/test.t
+++ b/loco-gen/src/templates/controller/api/test.t
@@ -17,7 +17,7 @@ use serial_test::serial;
 #[serial]
 async fn can_get_{{action}}() {
     testing::request::<App, _, _>(|request, _ctx| async move {
-        let res = request.get("/{{ name | snake_case }}/{{action}}").await;
+        let res = request.get("/{{ name | plural | snake_case }}/{{action}}").await;
         assert_eq!(res.status_code(), 200);
     })
     .await;

--- a/loco-gen/src/templates/scaffold/api/test.t
+++ b/loco-gen/src/templates/scaffold/api/test.t
@@ -14,9 +14,9 @@ use serial_test::serial;
 
 #[tokio::test]
 #[serial]
-async fn can_list() {
+async fn can_get_{{ name | plural | snake_case }}() {
     testing::request::<App, _, _>(|request, _ctx| async move {
-        let res = request.get("/{{ name | snake_case }}/").await;
+        let res = request.get("/{{ name | plural | snake_case }}/").await;
         assert_eq!(res.status_code(), 200);
 
         // you can assert content like this:


### PR DESCRIPTION
Because both [loco-gen/src/templates/controller/api/controller.t](https://github.com/loco-rs/loco/blob/master/loco-gen/src/templates/controller/api/controller.t) and [loco-gen/src/templates/scaffold/api/controller.t](https://github.com/loco-rs/loco/blob/master/loco-gen/src/templates/scaffold/api/controller.t) generate the routes as plural, the generated tests should reflect that. 
([loco-gen/src/templates/controller.t](https://github.com/loco-rs/loco/blob/master/loco-gen/src/templates/controller.t) however, does not for some reason? Maybe because that not necessarily reflects an 'entity')

Also, I'm not sure why these duplicate files exist. 
Could both the controller and test templates (/templates/controller, /templates/scaffold & /templates) not be combined into single files?
Currently they do the something similar but they are generated with slightly different code.

I'm very new to Loco, so please verify I haven't done something wrong here.