### PR TITLE
Fix documentation issue in scheduler.md

### DIFF
--- a/docs-site/content/docs/processing/scheduler.md
+++ b/docs-site/content/docs/processing/scheduler.md
@@ -109,7 +109,7 @@ After setting up your jobs, you can verify the configuration to ensure everythin
 Run the following command to list the jobs from your scheduler file:
 <!-- <snip id="scheduler-list-from-file-command" inject_from="yaml"  template="sh"> -->
 ```sh
-cargo loco scheduler --path config/scheduler.yaml --list
+cargo loco scheduler --config config/scheduler.yaml --list
 ```
 <!-- </snip> -->
 


### PR DESCRIPTION
This documentation seems to be outdated - a `--path` argument no longer exists on the scheduler. Looking at the output of `scheduler --help`, it would look like `--config` is the actual argument name