### PR TITLE
fix wrong injection in migration/lib.rs

### DIFF
--- a/loco-gen/src/templates/model.t
+++ b/loco-gen/src/templates/model.t
@@ -7,7 +7,7 @@ skip_glob: "migration/src/*_{{plural_snake}}.rs"
 message: "Migration for `{{name}}` added! You can now apply it with `$ cargo loco db migrate`."
 injections:
 - into: "migration/src/lib.rs"
-  after: "inject-below"
+  before_last: "\\]"
   content: "            Box::new({{module_name}}::Migration),"
 - into: "migration/src/lib.rs"
   before: "pub struct Migrator"

--- a/starters/rest-api/migration/src/lib.rs
+++ b/starters/rest-api/migration/src/lib.rs
@@ -9,6 +9,9 @@ pub struct Migrator;
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(m20220101_000001_users::Migration)]
+        vec![
+            //
+            Box::new(m20220101_000001_users::Migration),
+        ]
     }
 }

--- a/starters/saas/migration/src/lib.rs
+++ b/starters/saas/migration/src/lib.rs
@@ -9,6 +9,9 @@ pub struct Migrator;
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(m20220101_000001_users::Migration)]
+        vec![
+            //
+            Box::new(m20220101_000001_users::Migration),
+        ]
     }
 }


### PR DESCRIPTION
Following the changes in https://github.com/loco-rs/loco/pull/887, the migration was not correctly injected into migration/lib.rs. 
See error example here: https://github.com/loco-rs/loco/actions/runs/11548816568/job/32140819625

To fix this fast, I updated the injection rule by moving it above the current injection point and added a newline comment (//) as a marker for the injection rule.