### PR TITLE
Use a single loco-rs dep for a whole project

### DIFF
--- a/starters/lightweight-service/Cargo.lock
+++ b/starters/lightweight-service/Cargo.lock
@@ -1388,6 +1388,8 @@ dependencies = [
 [[package]]
 name = "loco-gen"
 version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1815e1bd51c41fceb096b27cf98b52ab23d272025337ef5106e549e697e8ee9f"
 dependencies = [
  "chrono",
  "clap",
@@ -1405,6 +1407,8 @@ dependencies = [
 [[package]]
 name = "loco-rs"
 version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa14998bbea030a703e8017a5a86c368b022c74b6848f5c16f07adfbc3b98b3"
 dependencies = [
  "argon2",
  "async-trait",

--- a/starters/lightweight-service/Cargo.toml
+++ b/starters/lightweight-service/Cargo.toml
@@ -10,11 +10,11 @@ default-run = "loco_starter_template-cli"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace.dependencies]
-loco-rs = { version = "0.12.0" }
+loco-rs = { version = "0.12.0", default-features = false }
 
 [dependencies]
 
-loco-rs = { workspace = true, default-features = false, features = ["cli"] }
+loco-rs = { workspace = true, features = ["cli"] }
 serde = "1"
 serde_json = "1"
 tokio = { version = "1.33.0", default-features = false, features = [
@@ -38,8 +38,5 @@ required-features = []
 [dev-dependencies]
 serial_test = "3.1.1"
 rstest = "0.21.0"
-loco-rs = { workspace = true, default-features = false, features = [
-  "testing",
-  "cli",
-] }
+loco-rs = { workspace = true, features = ["testing", "cli"] }
 insta = { version = "*", features = ["redactions", "yaml", "filters"] }

--- a/starters/lightweight-service/Cargo.toml
+++ b/starters/lightweight-service/Cargo.toml
@@ -9,9 +9,12 @@ default-run = "loco_starter_template-cli"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[workspace.dependencies]
+loco-rs = { version = "0.12.0" }
+
 [dependencies]
 
-loco-rs = { version = "0.12.0", default-features = false, features = ["cli"] }
+loco-rs = { workspace = true, default-features = false, features = ["cli"] }
 serde = "1"
 serde_json = "1"
 tokio = { version = "1.33.0", default-features = false, features = [
@@ -35,7 +38,7 @@ required-features = []
 [dev-dependencies]
 serial_test = "3.1.1"
 rstest = "0.21.0"
-loco-rs = { version = "0.12.0", default-features = false, features = [
+loco-rs = { workspace = true, default-features = false, features = [
   "testing",
   "cli",
 ] }

--- a/starters/rest-api/Cargo.toml
+++ b/starters/rest-api/Cargo.toml
@@ -9,9 +9,12 @@ default-run = "loco_starter_template-cli"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[workspace.dependencies]
+loco-rs = { version = "0.12.0" }
+
 [dependencies]
 
-loco-rs = { version = "0.12.0" }
+loco-rs = { workspace = true }
 migration = { path = "migration" }
 
 serde = { version = "1", features = ["derive"] }
@@ -46,5 +49,5 @@ required-features = []
 [dev-dependencies]
 serial_test = "3.1.1"
 rstest = "0.21.0"
-loco-rs = { version = "0.12.0", features = ["testing"] }
+loco-rs = { workspace = true, features = ["testing"] }
 insta = { version = "1.34.0", features = ["redactions", "yaml", "filters"] }

--- a/starters/rest-api/migration/Cargo.toml
+++ b/starters/rest-api/migration/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/lib.rs"
 
 [dependencies]
 async-std = { version = "1", features = ["attributes", "tokio1"] }
-loco-rs = { version = "0.12.0" }
+loco-rs = { workspace = true }
 
 [dependencies.sea-orm-migration]
 version = "1.1.0"

--- a/starters/saas/Cargo.toml
+++ b/starters/saas/Cargo.toml
@@ -9,9 +9,12 @@ default-run = "loco_starter_template-cli"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[workspace.dependencies]
+loco-rs = { version = "0.12.0" }
+
 [dependencies]
 
-loco-rs = { version = "0.12.0" }
+loco-rs = { workspace = true }
 migration = { path = "migration" }
 
 serde = { version = "1", features = ["derive"] }
@@ -51,5 +54,5 @@ required-features = []
 [dev-dependencies]
 serial_test = "3.1.1"
 rstest = "0.21.0"
-loco-rs = { version = "0.12.0", features = ["testing"] }
+loco-rs = { workspace = true, features = ["testing"] }
 insta = { version = "1.34.0", features = ["redactions", "yaml", "filters"] }

--- a/starters/saas/migration/Cargo.toml
+++ b/starters/saas/migration/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/lib.rs"
 
 [dependencies]
 async-std = { version = "1", features = ["attributes", "tokio1"] }
-loco-rs = { version = "0.12.0" }
+loco-rs = { workspace = true }
 
 [dependencies.sea-orm-migration]
 version = "1.1.0"


### PR DESCRIPTION
With this change, users would only need to update the `loco-rs` dep in a single place versus to up to three previously for the saas and rest-api starters.