### PR TITLE
chore: fix generated testcase

### DIFF
--- a/loco-gen/src/templates/controller/api/test.t
+++ b/loco-gen/src/templates/controller/api/test.t
@@ -16,7 +16,7 @@ use serial_test::serial;
 #[serial]
 async fn can_get_{{ name | plural | snake_case }}() {
     testing::request::<App, _, _>(|request, _ctx| async move {
-        let res = request.get("/{{ name | plural | snake_case }}/").await;
+        let res = request.get("/api/{{ name | plural | snake_case }}/").await;
         assert_eq!(res.status_code(), 200);
 
         // you can assert content like this:

--- a/loco-gen/src/templates/scaffold/api/test.t
+++ b/loco-gen/src/templates/scaffold/api/test.t
@@ -16,7 +16,7 @@ use serial_test::serial;
 #[serial]
 async fn can_get_{{ name | plural | snake_case }}() {
     testing::request::<App, _, _>(|request, _ctx| async move {
-        let res = request.get("/{{ name | plural | snake_case }}/").await;
+        let res = request.get("/api/{{ name | plural | snake_case }}/").await;
         assert_eq!(res.status_code(), 200);
 
         // you can assert content like this:


### PR DESCRIPTION
Generated testcase is currently failed because the path is incorrect. This PR corrects the path.