### PR TITLE
Update cli message with correct command

### DIFF
--- a/loco-cli/src/messages.rs
+++ b/loco-cli/src/messages.rs
@@ -37,7 +37,7 @@ pub fn for_options(
     match assetopt {
         AssetsOption::Clientside => res.push(format!(
             "{}: You've selected `{}` for your asset serving configuration.\n\nNext step, build \
-             your frontend:\n  $ cd {}\n  $ npm install && npm build\n",
+             your frontend:\n  $ cd {}\n  $ npm install && npm run build\n",
             "assets".underline(),
             "clientside".yellow(),
             "frontend/".yellow()


### PR DESCRIPTION
With a fresh project, using SaaS template with frontend assets, the CLI instructs the user:
```
Next step, build your frontend:
  $ cd frontend/
  $ npm install && npm build
```

but this causes

```
Unknown command: "build"


Did you mean this?
  npm run build # run the "build" package script
To see a list of supported npm commands, run:
  npm help
```

The obvious fix is to print the proper message, `npm run build`.