### PR TITLE
Add relevant meta tags for better defaults

### DIFF
--- a/loco-gen/src/templates/scaffold/html/base.t
+++ b/loco-gen/src/templates/scaffold/html/base.t
@@ -7,6 +7,8 @@ message: "Base template was added successfully."
 <html lang="en">
 
 <head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{% raw %}{% block title %}{% endblock title %}{% endraw %}</title>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio,line-clamp"></script>
   {% raw %}{% block head %}{% endraw %}

--- a/loco-gen/src/templates/scaffold/htmx/base.t
+++ b/loco-gen/src/templates/scaffold/htmx/base.t
@@ -7,6 +7,8 @@ message: "Base template was added successfully."
 <html lang="en">
 
 <head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{% raw %}{% block title %}{% endblock title %}{% endraw %}</title>
 
   <script src="https://unpkg.com/htmx.org@2.0.0/dist/htmx.min.js"></script>


### PR DESCRIPTION
I think we can add the following two meta tags to the base html templates as a better default over the starting templates.

- charset utf-8: I think it's good practice to define the charset, at least that's what [w3](https://www.w3.org/International/questions/qa-html-encoding-declarations#nutshell) recommends as well.
- viewport: Based on [mdn](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag), this tag is used by browsers to scale webpages for non-mobile optimised pages. I think that designing websites to account for mobile should be pretty common given the widespread use of mobile devices, so adding this tag to start should be better than not having it. (I was confused about the appearance of my website not scaling as I expected when developing, which led me to the discovery of this tag.) 