### PR TITLE
fix: codegen generating migrations that apply backwards

### DIFF
--- a/examples/demo/Cargo.lock
+++ b/examples/demo/Cargo.lock
@@ -2663,6 +2663,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-cron-scheduler",
+ "tokio-util",
  "toml",
  "tower 0.4.13",
  "tower-http",

--- a/examples/demo/migration/src/lib.rs
+++ b/examples/demo/migration/src/lib.rs
@@ -2,9 +2,7 @@ pub use sea_orm_migration::prelude::*;
 
 mod m20220101_000001_users;
 mod m20231103_114510_notes;
-
 mod m20240416_071825_roles;
-
 mod m20240416_082115_users_roles;
 pub struct Migrator;
 
@@ -12,11 +10,11 @@ pub struct Migrator;
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         vec![
-            // inject-below (do not remove this comment)
             Box::new(m20220101_000001_users::Migration),
             Box::new(m20231103_114510_notes::Migration),
             Box::new(m20240416_071825_roles::Migration),
             Box::new(m20240416_082115_users_roles::Migration),
+            // inject-above (do not remove this comment)
         ]
     }
 }

--- a/examples/demo/src/controllers/cache.rs
+++ b/examples/demo/src/controllers/cache.rs
@@ -1,6 +1,7 @@
-use crate::models::users;
 use loco_rs::prelude::*;
 use serde::{Deserialize, Serialize};
+
+use crate::models::users;
 #[derive(Serialize, Deserialize)]
 pub struct CacheResponse {
     value: Option<String>,

--- a/loco-gen/src/templates/migration.t
+++ b/loco-gen/src/templates/migration.t
@@ -6,7 +6,7 @@ skip_glob: "migration/src/*_{{mig_name}}.rs"
 message: "Migration for `{{name}}` added! You can now apply it with `$ cargo loco db migrate`."
 injections:
 - into: "migration/src/lib.rs"
-  after: "inject-below"
+  before: "inject-above"
   content: "            Box::new({{module_name}}::Migration),"
 - into: "migration/src/lib.rs"
   before: "pub struct Migrator"

--- a/loco-gen/src/templates/model.t
+++ b/loco-gen/src/templates/model.t
@@ -7,7 +7,7 @@ skip_glob: "migration/src/*_{{plural_snake}}.rs"
 message: "Migration for `{{name}}` added! You can now apply it with `$ cargo loco db migrate`."
 injections:
 - into: "migration/src/lib.rs"
-  after: "inject-below"
+  before: "inject-above"
   content: "            Box::new({{module_name}}::Migration),"
 - into: "migration/src/lib.rs"
   before: "pub struct Migrator"

--- a/starters/rest-api/migration/src/lib.rs
+++ b/starters/rest-api/migration/src/lib.rs
@@ -10,8 +10,9 @@ pub struct Migrator;
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         vec![
+            // inject-below (do not remove this comment)
             Box::new(m20220101_000001_users::Migration),
-            // inject-above
+            // inject-above (do not remove this comment)
         ]
     }
 }

--- a/starters/rest-api/migration/src/lib.rs
+++ b/starters/rest-api/migration/src/lib.rs
@@ -10,8 +10,8 @@ pub struct Migrator;
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         vec![
-            // inject-below
             Box::new(m20220101_000001_users::Migration),
+            // inject-above
         ]
     }
 }

--- a/starters/saas/migration/src/lib.rs
+++ b/starters/saas/migration/src/lib.rs
@@ -10,8 +10,9 @@ pub struct Migrator;
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         vec![
+            // inject-below (do not remove this comment)
             Box::new(m20220101_000001_users::Migration),
-            // inject-above
+            // inject-above (do not remove this comment)
         ]
     }
 }

--- a/starters/saas/migration/src/lib.rs
+++ b/starters/saas/migration/src/lib.rs
@@ -10,8 +10,8 @@ pub struct Migrator;
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         vec![
-            // inject-below
             Box::new(m20220101_000001_users::Migration),
+            // inject-above
         ]
     }
 }


### PR DESCRIPTION
Fixes #949 

BREAKING CHANGE: requires inject comment in `migration/src/lib.rs` to now be `inject-above` (and be moved to be after last item)