### PR TITLE
chore(deps): bump socketioxide to v0.15.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ cfg-if = "1"
 uuid = { version = "1.10.0", features = ["v4", "fast-rng"] }
 
 # A socket.io server implementation
-socketioxide = { version = "0.14.0", features = ["state"], optional = true }
+socketioxide = { version = "0.15.1", features = ["state"], optional = true }
 
 
 # File Upload


### PR DESCRIPTION
## Bump socketioxide to v0.15.1
The new version contains multiple new features : 
* The socketio parser system has been reworked. Users can now directly embed binaries into the structs they are serializing/deserializing at any level.
* New custom compiler errors for bad user-provided handlers. It allows to have a more developer friendly experience with socketioxide.
* Fix some protocol minor issues.

Therefore the `parser` feature contain breaking change:
Here is a migration guide that you may give to loco users somewhere ? Or republish in your discussions.
https://github.com/Totodore/socketioxide/discussions/384

I will also propose a PR to update the https://github.com/loco-rs/chat-rooms example.
