### PR TITLE
Named references

### DIFF
--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -635,6 +635,10 @@ Instead of coding the model and controller by hand, we're going to create a **co
 $ cargo loco generate scaffold comment content:text article:references --api
 ```
 
+<div class="infobox">
+The special <code>references:&lt;table&gt;</code> is also available. For when you want to have a different name for your column.
+</div>
+
 If you peek into the new migration, you'll discover a new database relation in the articles table:
 
 ```rust
@@ -652,6 +656,7 @@ If you peek into the new migration, you'll discover a new database relation in t
       ..
       ..
 ```
+
 
 Now, lets modify our API in the following way:
 

--- a/docs-site/content/docs/the-app/models.md
+++ b/docs-site/content/docs/the-app/models.md
@@ -124,7 +124,7 @@ When a model is added via migration, the following default fields are provided:
 - `created_at` (ts!): This is a timestamp indicating when your model was created.
 - `updated_at` (ts!): This is a timestamp indicating when your model was updated.
 
-These fields are ignored if you provide them in your migration command. In addition, `create_at` and `update_at` fields are also ignored if provided.
+These fields are ignored if you provide them in your migration command.
 
 For schema data types, you can use the following mapping to understand the schema:
 
@@ -172,6 +172,8 @@ For schema data types, you can use the following mapping to understand the schem
 ```
 
 Using `user:references` uses the special `references` type, which will create a relationship between a `post` and a `user`, adding a `user_id` reference field to the `posts` table.
+
+Using `aproved_by:references:users` uses the special `references:<table>` type, which will create a relationship between a `post` and a `user`, adding a `aproved_by` reference field to the `posts` table.
 
 You can generate an empty model:
 
@@ -228,20 +230,21 @@ cargo loco db down 2
 
 ### Verbs, singular and plural
 
-* **references**: use **singular** for the table name, and a `:references` type. `user:references` (references `Users`), `vote:references` (references `Votes`)
-* **column names**: anything you like. Prefer `snake_case`
+* **references**: use **singular** for the table name, and a `:references` type. `user:references` (references `Users`), `vote:references` (references `Votes`). `:references:<table>` is also available `departing_train:references:trains` (references `Trains`).
+* **column names**: anything you like. Prefer `snake_case`.
 * **table names**: **plural, snake case**. `users`, `draft_posts`.
-* **migration names**: anything that can be a file name, prefer snake case. `create_table_users`, `add_vote_id_to_movies`
-* **model names**: generated automatically for you. Usually the generated name is pascal case, plural. `Users`, `UsersVotes`
+* **migration names**: anything that can be a file name, prefer snake case. `create_table_users`, `add_vote_id_to_movies`.
+* **model names**: generated automatically for you. Usually the generated name is pascal case, plural. `Users`, `UsersVotes`.
  
 Here are some examples showcasing the naming conventions:
 
 ```sh
-$ cargo loco generate model movies long_title:string user:references
+$ cargo loco generate model movies long_title:string added_by:references:users director:references
 ```
 
 * model name in plural: `movies`
-* reference user is in singular: `user:references`
+* refecence director is in singular: `director:references`
+* reference added_by is in singular, the referenced model is a model and is plural: `added_by:references:users`
 * column name in snake case: `long_title:string`
 
 ### Naming migrations

--- a/loco-gen/src/model.rs
+++ b/loco-gen/src/model.rs
@@ -43,7 +43,11 @@ pub fn generate(
             let fkey = format!("{fname}_id");
             columns.push((fkey.clone(), "integer"));
             // user, user_id
-            references.push((fname, fkey));
+            references.push((fname.to_string(), fkey));
+        } else if ftype.starts_with("references:") {
+            let fkey = format!("{fname}_id");
+            columns.push((fkey.clone(), "integer"));
+            references.push((ftype["references:".len()..].to_string(), fkey));
         } else {
             let mappings = get_mappings();
             let schema_type = mappings.schema_field(ftype.as_str()).ok_or_else(|| {

--- a/loco-gen/src/scaffold.rs
+++ b/loco-gen/src/scaffold.rs
@@ -46,7 +46,7 @@ pub fn generate(
             );
             continue;
         }
-        if ftype != "references" {
+        if ftype != "references" && !ftype.starts_with("references:") {
             let schema_type = mappings.rust_field(ftype.as_str()).ok_or_else(|| {
                 Error::Message(format!(
                     "type: {} not found. try any of: {:?}",

--- a/loco-gen/src/templates/model.t
+++ b/loco-gen/src/templates/model.t
@@ -48,7 +48,7 @@ impl MigrationTrait for Migration {
                     {% for ref in references -%}
                     .foreign_key(
                         ForeignKey::create()
-                            .name("fk-{{plural_snake}}-{{ref.0 | plural}}")
+                            .name("fk-{{plural_snake}}-{{ref.1 | plural| snake_case}}")
                             .from({{model}}::Table, {{model}}::{{ref.1 | pascal_case}})
                             .to({{ref.0 | plural | pascal_case}}::Table, {{ref.0 | plural | pascal_case}}::Id)
                             .on_delete(ForeignKeyAction::Cascade)
@@ -78,8 +78,7 @@ enum {{model}} {
     {% endfor %}
 }
 
-
-{% for ref in references -%}
+{% for ref in references | unique(attribute="0") -%}
 #[derive(DeriveIden)]
 enum {{ref.0 | plural | pascal_case}} {
     Table,


### PR DESCRIPTION
Add the ability to generate references with custom column names by using `:references:<table>` as a type.

Also fixes generation to allow for multiple references to the same table as in
```
$ generate scaffold posts title:string! content:string! written_by:references:users approved_by:references:users
```

#949 (raised concerns, not the underlying issue)
Fixes #814 