### PR TITLE
fix: add missing closing div to htmx edit template

### DIFF
--- a/loco-gen/src/templates/scaffold/htmx/view_edit.t
+++ b/loco-gen/src/templates/scaffold/htmx/view_edit.t
@@ -46,6 +46,7 @@ Edit {{name}}: {% raw %}{{ item.id }}{% endraw %}
         {% endif -%} 
         </div>
     {% endfor -%}
+    </div>
     <div>
         <div class="mt-5">
             <button class=" text-xs py-3 px-6 rounded-lg bg-gray-900 text-white" type="submit">Submit</button>


### PR DESCRIPTION
This PR adds missing closing `</div>` for one that was opened above on line 17 in htmx `view_edit.t` template.