### PR TITLE
A series of small improvements to the docs and the docs site

### DIFF
--- a/docs-site/content/docs/getting-started/tour/index.md
+++ b/docs-site/content/docs/getting-started/tour/index.md
@@ -94,7 +94,7 @@ We have a base SaaS app with user authentication generated for us. Let's make it
 
 <div class="infobox">
 
-You can choose between generating an `api`, `html` or `htmx` scaffold using the required `-k` flag.
+You can choose between generating an `api`, `html` or `htmx` scaffold using the respective `-api`, `--html`, and `--htmx` flags.
 </div>
 
 ```sh
@@ -142,9 +142,9 @@ listening on port 5150
 
 <div class="infobox"> 
 
-Depending on which `-k` option you chose, the steps for creating a scaffolded resource will change. With the `api` flag or the `htmx` flag you can use the below example. But with the `html` flag, it is recommended you do the post creation steps in your browser.
+Depending on which scaffold template option you chose (`-api`, `--html`, `--htmx`), the steps for creating a scaffolded resource will change. With the `--api` flag or the `--htmx` flag you can use the below example. But with the `--html` flag, it is recommended you do the post creation steps in your browser.
   
-If you want to use `curl` to test the `html` scaffold, you will need to send your requests with the Content-Type `application/x-www-form-urlencoded` and the body as `title=Your+Title&content=Your+Content` by default. This can be changed to allow `application/json` as a `Content-Type` in the code if desired.
+If you want to use `curl` to test the `--html` scaffold, you will need to send your requests with the Content-Type `application/x-www-form-urlencoded` and the body as `title=Your+Title&content=Your+Content` by default. This can be changed to allow `application/json` as a `Content-Type` in the code if desired.
 
 </div>
 

--- a/docs-site/content/docs/resources/faq.md
+++ b/docs-site/content/docs/resources/faq.md
@@ -23,6 +23,12 @@ Try [cargo watch](https://crates.io/crates/cargo-watch):
 $ cargo-watch -x check  -s 'cargo loco start'
 ```
 
+Or [bacon](https://github.com/Canop/bacon)
+
+```
+$ bacon run
+```
+
 </details>
 <br/>
 <details>

--- a/docs-site/static/styles/styles.css
+++ b/docs-site/static/styles/styles.css
@@ -1005,7 +1005,7 @@ a.active {
   --tw-prose-body: var(--foreground);
   --tw-prose-headings: var(--foreground);
   --tw-prose-lead: #4b5563;
-  --tw-prose-links: #111827;
+  --tw-prose-links: var(--foreground);
   --tw-prose-bold: #111827;
   --tw-prose-counters: #6b7280;
   --tw-prose-bullets: #d1d5db;
@@ -1015,7 +1015,7 @@ a.active {
   --tw-prose-captions: #6b7280;
   --tw-prose-kbd: #111827;
   --tw-prose-kbd-shadows: 17 24 39;
-  --tw-prose-code: #111827;
+  --tw-prose-code: var(--foreground);
   --tw-prose-pre-code: #e5e7eb;
   --tw-prose-pre-bg: #1f2937;
   --tw-prose-th-borders: #d1d5db;

--- a/docs-site/static/styles/styles.css
+++ b/docs-site/static/styles/styles.css
@@ -618,33 +618,28 @@ a.active {
 
 @media (min-width: 640px) {
   .container {
-    max-width: 640px;
+    max-width: calc(640px - 1rem);
   }
 }
 
 @media (min-width: 768px) {
   .container {
-    max-width: 768px;
+    max-width: calc(768px - 2rem);
   }
 }
 
 @media (min-width: 1024px) {
   .container {
-    max-width: 1024px;
+    max-width: calc(1024px - 6rem);
   }
 }
 
 @media (min-width: 1280px) {
   .container {
-    max-width: 1280px;
+    max-width: calc(1280px - 8rem);
   }
 }
 
-@media (min-width: 1536px) {
-  .container {
-    max-width: 1536px;
-  }
-}
 
 .prose {
   color: var(--tw-prose-body);

--- a/docs-site/templates/docs/page.html
+++ b/docs-site/templates/docs/page.html
@@ -13,7 +13,7 @@
 {% block content %}
 <div role="document">
   <div class="bg-redrust text-background dark:bg-zinc-900">
-    <div class="container xl:max-w-[80rem] xl:mx-auto">
+    <div class="container">
       <aside class="w-full">
         {{ macros_sidebar::docs_sidebar(current_section=current_section) }}
       </aside>

--- a/docs-site/templates/macros/header.html
+++ b/docs-site/templates/macros/header.html
@@ -1,7 +1,7 @@
 {% macro header(current_section) %}
 <header
 	class=" sticky top-0 z-50 w-full border-border/40 backdrop-blur bg-background">
-	<div class="container relative flex h-14 md:grid md:grid-cols-[240px_minmax(0,1fr)]  xl:max-w-[80rem] xl:mx-auto">
+	<div class="container relative flex h-14 md:grid md:grid-cols-[240px_minmax(0,1fr)]">
 		<div class="mr-4 hidden sm:flex">
 			<a class="flex mr-4  items-center space-x-2" href="/">
 				<img src="/icon.svg" width="30px" />


### PR DESCRIPTION
### More Accurate Info
The docs mentioned the `-k` flag and were not updated since it was removed.

### Bacon Command
The `cargo-watch` maintainer recommends using bacon, so that was added to the `FAQ` page

### Dark Mode in the Blog
Dark mode in the blog would show code and links with light mode colors, so changed it to use display better
Before -> After
![Screenshot 2024-11-08 at 9 52 46 AM](https://github.com/user-attachments/assets/6377ffbe-2ea6-497b-b1c9-3eddf9e79b10) ![Screenshot 2024-11-08 at 9 52 57 AM](https://github.com/user-attachments/assets/6b124bd7-f8da-4193-bf3b-2816ab1c4798)

Before
![Screenshot 2024-11-08 at 9 53 10 AM](https://github.com/user-attachments/assets/038028b9-ebba-40b7-9a5a-c16bc252490b)
After
![Screenshot 2024-11-08 at 9 53 22 AM](https://github.com/user-attachments/assets/9a313ffd-d2a7-4db2-98e9-3346d1f06c10)

### Docs Site Width
The docs site breakpoints would leave no padding at the exact breakpoints of the width:
![Screenshot 2024-11-08 at 9 53 44 AM](https://github.com/user-attachments/assets/39aca034-5062-4bee-aefc-35f87266b675)

Adding a couple -rem` buffer improves the look at these points:
![Screenshot 2024-11-08 at 9 53 53 AM](https://github.com/user-attachments/assets/802aa257-b6e4-410a-a82e-fd9d786238d8)

These points being common device sizes means it would be run into often enough.