### PR TITLE
bump tree-fs and remove test crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,12 +185,7 @@ cargo_metadata = "0.18.1"
 loco-rs = { path = ".", features = ["testing"] }
 rstest = "0.21.0"
 insta = { version = "1.34.0", features = ["redactions", "yaml", "filters"] }
-tree-fs = { version = "0.1.0" }
+tree-fs = { version = "0.2.1" }
 reqwest = { version = "0.12.7" }
 serial_test = "3.1.1"
 tower = { workspace = true, features = ["util"] }
-
-# generator tests
-tempfile = "3"
-duct_sh = { version = "0.13.7" }
-syn = { version = "2", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,6 @@ features = [
 features = ["testing"]
 
 [dev-dependencies]
-cargo_metadata = "0.18.1"
 loco-rs = { path = ".", features = ["testing"] }
 rstest = "0.21.0"
 insta = { version = "1.34.0", features = ["redactions", "yaml", "filters"] }

--- a/loco-gen/Cargo.toml
+++ b/loco-gen/Cargo.toml
@@ -27,5 +27,5 @@ dialoguer = "0.11"
 duct = "0.13"
 
 [dev-dependencies]
-tempfile = "3"
+tree-fs = { version = "0.2.1" }
 syn = { version = "2", features = ["full"] }

--- a/loco-gen/src/testutil.rs
+++ b/loco-gen/src/testutil.rs
@@ -11,7 +11,6 @@ use std::{
 };
 
 use regex::Regex;
-use tempfile::tempdir;
 
 // Define the custom struct to encapsulate file content
 pub struct FileContent {
@@ -249,8 +248,8 @@ where
     let previous = env::current_dir()?; // Get the current directory
     println!("Current directory: {previous:?}");
 
-    let temp_dir = tempdir()?; // Create a temporary directory
-    let current = temp_dir.path();
+    let tree_fs = tree_fs::TreeBuilder::default().drop(true).create()?; // Create a temporary directory
+    let current = &tree_fs.root;
 
     println!("Temporary directory: {current:?}");
     env::set_current_dir(current)?; // Set the current directory to the temp directory

--- a/src/controller/format.rs
+++ b/src/controller/format.rs
@@ -452,6 +452,7 @@ mod tests {
     #[tokio::test]
     async fn view_response() {
         let yaml_content = r"
+        drop: true
         files:
         - path: template/test.html
           content: |-
@@ -459,7 +460,7 @@ mod tests {
         ";
 
         let tree_res = tree_fs::from_yaml_str(yaml_content).unwrap();
-        let v = TeraView::from_custom_dir(&tree_res).unwrap();
+        let v = TeraView::from_custom_dir(&tree_res.root).unwrap();
 
         assert_debug_snapshot!(view(&v, "template/none.html", serde_json::json!({})));
         let response = view(&v, "template/test.html", serde_json::json!({"foo": "loco"})).unwrap();
@@ -547,6 +548,7 @@ mod tests {
     #[tokio::test]
     async fn builder_view_response() {
         let yaml_content = r"
+        drop: true
         files:
         - path: template/test.html
           content: |-
@@ -554,7 +556,7 @@ mod tests {
         ";
 
         let tree_res = tree_fs::from_yaml_str(yaml_content).unwrap();
-        let v = TeraView::from_custom_dir(&tree_res).unwrap();
+        let v = TeraView::from_custom_dir(&tree_res.root).unwrap();
 
         assert_debug_snapshot!(view(&v, "template/none.html", serde_json::json!({})));
         let response = render()

--- a/src/controller/views/engines.rs
+++ b/src/controller/views/engines.rs
@@ -95,6 +95,7 @@ mod tests {
     #[test]
     fn can_render_view() {
         let yaml_content = r"
+        drop: true
         files:
         - path: template/test.html
           content: |-
@@ -105,7 +106,7 @@ mod tests {
         ";
 
         let tree_res = tree_fs::from_yaml_str(yaml_content).unwrap();
-        let v = TeraView::from_custom_dir(&tree_res).unwrap();
+        let v = TeraView::from_custom_dir(&tree_res.root).unwrap();
 
         assert_eq!(
             v.render("template/test.html", json!({"foo": "foo-txt"}))

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -453,21 +453,22 @@ mod tests {
     pub async fn can_run() {
         let mut scheduler = get_scheduler_from_config().unwrap();
 
-        let path = tree_fs::Tree::default()
+        let tree_fs = tree_fs::TreeBuilder::default()
+            .drop(true)
             .add("scheduler.txt", "")
             .add("scheduler2.txt", "")
             .create()
             .unwrap();
 
         assert_eq!(
-            std::fs::read_to_string(path.join("scheduler.txt"))
+            std::fs::read_to_string(tree_fs.root.join("scheduler.txt"))
                 .unwrap()
                 .lines()
                 .count(),
             0
         );
         assert_eq!(
-            std::fs::read_to_string(path.join("scheduler2.txt"))
+            std::fs::read_to_string(tree_fs.root.join("scheduler2.txt"))
                 .unwrap()
                 .lines()
                 .count(),
@@ -478,7 +479,10 @@ mod tests {
             (
                 "test".to_string(),
                 Job {
-                    run: format!("echo loco >> {}", path.join("scheduler.txt").display()),
+                    run: format!(
+                        "echo loco >> {}",
+                        tree_fs.root.join("scheduler.txt").display()
+                    ),
                     shell: true,
                     cron: "run every 1 second".to_string(),
                     tags: None,
@@ -488,7 +492,10 @@ mod tests {
             (
                 "test_2".to_string(),
                 Job {
-                    run: format!("echo loco >> {}", path.join("scheduler2.txt").display()),
+                    run: format!(
+                        "echo loco >> {}",
+                        tree_fs.root.join("scheduler2.txt").display()
+                    ),
                     shell: true,
                     cron: "* * * * * ? *".to_string(),
                     tags: None,
@@ -505,14 +512,14 @@ mod tests {
         handle.abort();
 
         assert!(
-            std::fs::read_to_string(path.join("scheduler.txt"))
+            std::fs::read_to_string(tree_fs.root.join("scheduler.txt"))
                 .unwrap()
                 .lines()
                 .count()
                 >= 4
         );
         assert!(
-            std::fs::read_to_string(path.join("scheduler2.txt"))
+            std::fs::read_to_string(tree_fs.root.join("scheduler2.txt"))
                 .unwrap()
                 .lines()
                 .count()


### PR DESCRIPTION
Remove unused test packages.
Migrate from `tempfile` to tree-fs, which is already in use.