### PR TITLE
feat(mailer): expose hello_name for SMTP client config

### DIFF
--- a/loco-new/base_template/config/development.yaml.t
+++ b/loco-new/base_template/config/development.yaml.t
@@ -22,8 +22,8 @@ server:
   host: http://localhost
   # Out of the box middleware configuration. to disable middleware you can changed the `enable` field to `false` of comment the middleware block
   middlewares:
-  {%- if settings.asset %}   
-    {%- if settings.asset.kind == "server" %} 
+  {%- if settings.asset %}
+    {%- if settings.asset.kind == "server" %}
     static:
       enable: true
       must_exist: true
@@ -32,7 +32,7 @@ server:
         uri: "/static"
         path: "assets/static"
       fallback: "assets/static/404.html"
-  {%- elif settings.asset.kind == "client" %} 
+  {%- elif settings.asset.kind == "client" %}
     static:
       enable: true
       must_exist: true
@@ -42,9 +42,9 @@ server:
         path: "frontend/dist"
       fallback: "frontend/dist/index.html"
   {%- endif -%}
-  
+
   {%- endif -%}
-   
+
 {%- if settings.background%}
 
 # Worker Configuration
@@ -83,6 +83,8 @@ mailer:
     # auth:
     #   user:
     #   password:
+    # Override the SMTP hello name (default is the machine's hostname)
+    # hello_name:
 {%- endif %}
 
 # Initializers Configuration

--- a/src/config.rs
+++ b/src/config.rs
@@ -500,6 +500,8 @@ pub struct SmtpMailer {
     pub secure: bool,
     /// Auth SMTP server
     pub auth: Option<MailerAuth>,
+    /// Optional EHLO client ID instead of hostname
+    pub hello_name: Option<String>,
 }
 
 /// Authentication details for the mailer

--- a/src/mailer/email_sender.rs
+++ b/src/mailer/email_sender.rs
@@ -3,8 +3,9 @@
 //! sending emails with options like sender, recipient, subject, and content.
 
 use lettre::{
-    message::MultiPart, transport::smtp::authentication::Credentials, AsyncTransport, Message,
-    Tokio1Executor, Transport,
+    message::MultiPart,
+    transport::smtp::{authentication::Credentials, extension::ClientId},
+    AsyncTransport, Message, Tokio1Executor, Transport,
 };
 use tracing::error;
 
@@ -58,6 +59,10 @@ impl EmailSender {
         if let Some(auth) = config.auth.as_ref() {
             email_builder = email_builder
                 .credentials(Credentials::new(auth.user.clone(), auth.password.clone()));
+        }
+
+        if let Some(hello_name) = config.hello_name.as_ref() {
+            email_builder = email_builder.hello_name(ClientId::Domain(hello_name.clone()));
         }
 
         Ok(Self {


### PR DESCRIPTION
Adds the ability to configure the `hello_name` for the mailer. This sets the name used in the SMTP client `EHLO` message.

This has been successfully tested with Google Cloud Run (which returns 'localhost' as a hostname) and `smtp-relay.gmail.com` which rejects `EHLO localhost`.

Fixes #1055 