### PR TITLE
chore(deps): use reqwest with rustls rather than openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,13 @@ backtrace_printer = { version = "1.3.0" }
 # cli
 clap = { version = "4.4.7", features = ["derive"], optional = true }
 colored = "2"
-reqwest = { version = "0.12.7", features = ["json"] }
+reqwest = { version = "0.12.7", features = [
+    "charset",
+    "http2",
+    "json",
+    "macos-system-configuration",
+    "rustls-tls",
+], default-features = false }
 
 
 sea-orm = { version = "1.1.0", features = [


### PR DESCRIPTION
Sets `reqwest` to use the[ default features](https://docs.rs/crate/reqwest/latest/features), swapping `default-tls` for `rustls-tls`.

Fixes #1056 