### PR TITLE
feat(cli): pretty-print cargo loco routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* feat: `cargo loco routes` will now pretty-print routes
 * fix: guard jwt error behind feature flag. [https://github.com/loco-rs/loco/pull/1032](https://github.com/loco-rs/loco/pull/1032)
 * fix: logger file_appender not using the seperated format setting. [https://github.com/loco-rs/loco/pull/1036](https://github.com/loco-rs/loco/pull/1036)
 * seed cli command. [https://github.com/loco-rs/loco/pull/1046](https://github.com/loco-rs/loco/pull/1046)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,12 +54,19 @@ Just clone the project and run `cargo test`.
 You can see how we test in [.github/workflows](.github/workflows/)
 
 #### Snapshots
-To update/create a snapshots we are using [insta](https://github.com/mitsuhiko/insta). all you need to do is install insta (cargo install cargo-insta) and run the following command:
+We use [insta](https://github.com/mitsuhiko/insta) for snapshot testing, which helps us detect changes in output formats and behavior. To work with snapshots:
+
+1. Install the insta CLI tool:
+```sh
+cargo install cargo-insta
 ```
+
+2. Run tests and review/update snapshots:
+```sh
 cargo insta test --review
 ```
 
-In case of cli changes we snapshot the binary commands. in case of changes run the following command yo update the CLI snapshot
+For CLI-related changes, we maintain separate snapshots of binary command outputs. To update these CLI snapshots:
 ```sh
 LOCO_CI_MODE=true TRYCMD=overwrite cargo test
 ```

--- a/examples/demo/tests/cmd/cli.trycmd
+++ b/examples/demo/tests/cmd/cli.trycmd
@@ -87,43 +87,55 @@ user_report                   [output a user report]
 
 ```console
 $ demo_app-cli routes --environment test
-[GET] /_health
-[GET] /_ping
-[POST] /auth/forgot
-[POST] /auth/login
-[POST] /auth/register
-[POST] /auth/reset
-[POST] /auth/verify
-[GET] /cache
-[GET] /cache/get_or_insert
-[POST] /cache/insert
-[GET] /mylayer/admin
-[GET] /mylayer/echo
-[GET] /mylayer/user
-[GET] /mysession
-[GET] /notes
-[POST] /notes
-[GET] /notes/:id
-[DELETE] /notes/:id
-[POST] /notes/:id
-[GET] /response/album
-[GET] /response/empty
-[GET] /response/empty_json
-[GET] /response/etag
-[GET] /response/html
-[GET] /response/json
-[GET] /response/redirect
-[GET] /response/render_with_status_code
-[GET] /response/set_cookie
-[GET] /response/text
-[POST] /upload/file
-[POST] /user/convert/admin
-[POST] /user/convert/user
-[GET] /user/current
-[GET] /user/current_api_key
-[GET] /view-engine/hello
-[GET] /view-engine/home
-[GET] /view-engine/simple
+/_health
+  └─ GET	/_health
+/_ping
+  └─ GET	/_ping
+/auth
+  ├─ POST	/auth/forgot
+  ├─ POST	/auth/login
+  ├─ POST	/auth/register
+  ├─ POST	/auth/reset
+  └─ POST	/auth/verify
+/cache
+  ├─ GET	/cache
+  ├─ GET	/cache/get_or_insert
+  └─ POST	/cache/insert
+/mylayer
+  ├─ GET	/mylayer/admin
+  ├─ GET	/mylayer/echo
+  └─ GET	/mylayer/user
+/mysession
+  └─ GET	/mysession
+/notes
+  ├─ GET	/notes
+  │  POST	/notes
+  │
+  ├─ GET	/notes/:id
+  │  POST	/notes/:id
+  └─ DELETE	/notes/:id
+/response
+  ├─ GET	/response/album
+  ├─ GET	/response/empty
+  ├─ GET	/response/empty_json
+  ├─ GET	/response/etag
+  ├─ GET	/response/html
+  ├─ GET	/response/json
+  ├─ GET	/response/redirect
+  ├─ GET	/response/render_with_status_code
+  ├─ GET	/response/set_cookie
+  └─ GET	/response/text
+/upload
+  └─ POST	/upload/file
+/user
+  ├─ POST	/user/convert/admin
+  ├─ POST	/user/convert/user
+  ├─ GET	/user/current
+  └─ GET	/user/current_api_key
+/view-engine
+  ├─ GET	/view-engine/hello
+  ├─ GET	/view-engine/home
+  └─ GET	/view-engine/simple
 
 ```
 


### PR DESCRIPTION
This add cleaner formatting to the `cargo loco routes` command.

![image](https://github.com/user-attachments/assets/5c85e418-8872-4301-bffa-3f8cecf5b371)
