### PR TITLE
Add missing UserReport struct in the documentation

### DIFF
--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -798,6 +798,8 @@ use loco_rs::task::Vars;
 
 use crate::models::users;
 
+pub struct UserReport;
+
 #[async_trait]
 impl Task for UserReport {
     fn task(&self) -> TaskInfo {


### PR DESCRIPTION
This PR add missing 
```rust
pub struct UserReport;
```
as this is missing and the document also suggests to replace the whole `src/tasks/user_report.rs` with the whole code.