### PR TITLE
Make internal server error new fallback error type

### DIFF
--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -198,10 +198,6 @@ impl IntoResponse for Error {
                 StatusCode::NOT_FOUND,
                 ErrorDetail::new("not_found", "Resource was not found"),
             ),
-            Self::InternalServerError => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                ErrorDetail::new("internal_server_error", "Internal Server Error"),
-            ),
             Self::Unauthorized(err) => {
                 tracing::warn!(err);
                 (
@@ -221,9 +217,13 @@ impl IntoResponse for Error {
                     ErrorDetail::with_reason("Bad Request"),
                 )
             }
-            _ => (
+            Self::BadRequest(err) => (
                 StatusCode::BAD_REQUEST,
-                ErrorDetail::with_reason("Bad Request"),
+                ErrorDetail::new("Bad Request", &err),
+            ),
+            _ => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorDetail::new("internal_server_error", "Internal Server Error"),
             ),
         };
 

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -223,7 +223,7 @@ impl IntoResponse for Error {
             ),
             _ => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                ErrorDetail::new("internal_server_error", "Internal Server Error"),
+                ErrorDetail::with_reason("Internal Server Error"),
             ),
         };
 

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -223,7 +223,7 @@ impl IntoResponse for Error {
             ),
             _ => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                ErrorDetail::with_reason("Internal Server Error"),
+                ErrorDetail::new("internal_server_error", "Internal Server Error"),
             ),
         };
 

--- a/tests/controller/into_response.rs
+++ b/tests/controller/into_response.rs
@@ -55,8 +55,7 @@ async fn internal_server_error() {
     let res_json: serde_json::Value = serde_json::from_str(&res_text).expect("Valid JSON response");
 
     let expected_json = serde_json::json!({
-        "error": "internal_server_error",
-        "description": "Internal Server Error"
+        "error": "Internal Server Error",
     });
 
     assert_eq!(res_json, expected_json);

--- a/tests/controller/into_response.rs
+++ b/tests/controller/into_response.rs
@@ -111,13 +111,13 @@ async fn fallback() {
         .await
         .expect("Valid response");
 
-    assert_eq!(res.status(), 400);
+    assert_eq!(res.status(), 500);
 
     let res_text = res.text().await.expect("response text");
     let res_json: serde_json::Value = serde_json::from_str(&res_text).expect("Valid JSON response");
 
     let expected_json = serde_json::json!({
-        "error": "Bad Request",
+        "error": "Internal Server Error",
     });
 
     assert_eq!(res_json, expected_json);

--- a/tests/controller/into_response.rs
+++ b/tests/controller/into_response.rs
@@ -55,7 +55,8 @@ async fn internal_server_error() {
     let res_json: serde_json::Value = serde_json::from_str(&res_text).expect("Valid JSON response");
 
     let expected_json = serde_json::json!({
-        "error": "Internal Server Error",
+        "error": "internal_server_error",
+        "description": "Internal Server Error",
     });
 
     assert_eq!(res_json, expected_json);
@@ -116,7 +117,8 @@ async fn fallback() {
     let res_json: serde_json::Value = serde_json::from_str(&res_text).expect("Valid JSON response");
 
     let expected_json = serde_json::json!({
-        "error": "Internal Server Error",
+        "error": "internal_server_error",
+        "description": "Internal Server Error",
     });
 
     assert_eq!(res_json, expected_json);

--- a/tests/controller/snapshots/panic@middlewares.snap
+++ b/tests/controller/snapshots/panic@middlewares.snap
@@ -5,6 +5,6 @@ expression: "(res.status().to_string(), res.text().await)"
 (
     "500 Internal Server Error",
     Ok(
-        "{\"error\":\"internal_server_error\",\"description\":\"Internal Server Error\"}",
+        "{\"error\":\"Internal Server Error\"}",
     ),
 )

--- a/tests/controller/snapshots/panic@middlewares.snap
+++ b/tests/controller/snapshots/panic@middlewares.snap
@@ -5,6 +5,6 @@ expression: "(res.status().to_string(), res.text().await)"
 (
     "500 Internal Server Error",
     Ok(
-        "{\"error\":\"Internal Server Error\"}",
+        "{\"error\":\"internal_server_error\",\"description\":\"Internal Server Error\"}",
     ),
 )


### PR DESCRIPTION
Currently, all errors become a 400 Bad Request, unless an explicit error type is set. This is not ideal, as a bad request [should not be retried](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400) by a client since it's the client that is at fault (as is for al 4xx codes). A better generic 'fallback' error would be a 500 internal server error, as i[t indicates](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) _something_ went wrong, and sending another attempt might very well succeed.

This pull requests changes the currenty behaviour by returning a 500 on all non-explicit errors.