### PR TITLE
Add anyhow error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,7 @@ rusty-sidekiq = { version = "0.11.0", default-features = false, optional = true 
 bb8 = { version = "0.8.1", optional = true }
 
 scraper = { version = "0.21.0", optional = true }
+anyhow = "1.0.95"
 
 [workspace.dependencies]
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -57,6 +57,9 @@ pub enum Error {
     Tera(#[from] tera::Error),
 
     #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+
+    #[error(transparent)]
     JSON(serde_json::Error),
 
     #[error(transparent)]


### PR DESCRIPTION
I'm working with a lot of libraries that are using `anyhow` and found adding anyhow error helps a lot