### PR TITLE
fix: Remove unnecessary calls to 'register_tasks' functions in schedu…

### DIFF
--- a/src/boot.rs
+++ b/src/boot.rs
@@ -199,9 +199,6 @@ pub async fn run_scheduler<H: Hooks>(
     tag: Option<String>,
     list: bool,
 ) -> Result<()> {
-    let mut tasks = Tasks::default();
-    H::register_tasks(&mut tasks);
-
     let task_span = tracing::span!(tracing::Level::DEBUG, "scheduler_jobs");
     let _guard = task_span.enter();
 


### PR DESCRIPTION
The register_tasks function was called twice in scheduler mode, and it became clear that the first call was not necessary.