### PR TITLE
docs: update /api/user/current -> /api/auth...

### DIFF
--- a/docs-site/content/docs/extras/authentication.md
+++ b/docs-site/content/docs/extras/authentication.md
@@ -39,7 +39,7 @@ $ cargo loco routes
 [POST] /api/auth/register
 [POST] /api/auth/reset
 [POST] /api/auth/verify
-[GET] /api/user/current
+[GET] /api/auth/current
  .
  .
  .
@@ -144,7 +144,7 @@ curl --location '127.0.0.1:5150/api/auth/reset' \
 This endpoint is protected by auth middleware.
 
 ```sh
-curl --location --request GET '127.0.0.1:5150/api/user/current' \
+curl --location --request GET '127.0.0.1:5150/api/auth/current' \
      --header 'Content-Type: application/json' \
      --header 'Authorization: Bearer TOKEN'
 ```
@@ -196,7 +196,7 @@ $ cargo loco routes
 [POST] /api/auth/register
 [POST] /api/auth/reset
 [POST] /api/auth/verify
-[GET] /api/user/current
+[GET] /api/auth/current
  .
  .
  .

--- a/docs-site/translations/tour-fr.md
+++ b/docs-site/translations/tour-fr.md
@@ -205,7 +205,7 @@ Dans votre application côté client, vous enregistrez ce jeton JWT et effectuez
 Ce point de terminaison est protégé par un middleware d'authentification. Nous utiliserons le jeton que nous avons obtenu précédemment pour effectuer une requête avec la technique _bearer token_ (remplacez `TOKEN` par le jeton JWT que vous avez obtenu précédemment):
 
 ```sh
-$ curl --location --request GET '127.0.0.1:5150/api/user/current' \
+$ curl --location --request GET '127.0.0.1:5150/api/auth/current' \
      --header 'Content-Type: application/json' \
      --header 'Authorization: Bearer TOKEN'
 ```


### PR DESCRIPTION
The starter app generated by loco cli does not have /api/user, only /api/auth so the docs should use this for a streamlined onboarding.

The starter example app does use /api/user, so as a follow up, that could be unified. Not touching that for now.

P.S. awesome framework!