### PR TITLE
Fix path inside `create_file`:

### DIFF
--- a/loco-new/src/generator/executer/filesystem.rs
+++ b/loco-new/src/generator/executer/filesystem.rs
@@ -13,6 +13,12 @@ pub struct FileSystem {
     pub template_engine: generator::template::Template,
 }
 
+impl From<std::io::Error> for super::Error {
+    fn from(err: std::io::Error) -> Self {
+        super::Error::msg(err.to_string())
+    }
+}
+
 impl FileSystem {
     #[must_use]
     pub fn new(from: &Path, to: &Path) -> Self {
@@ -88,7 +94,7 @@ impl Executer for FileSystem {
     fn create_file(&self, path: &Path, content: String) -> super::Result<PathBuf> {
         let target_path = self.target_dir.join(path);
         if let Some(parent) = path.parent() {
-            fs_extra::dir::create_all(parent, false)?;
+            std::fs::create_dir_all(self.target_dir.join(parent))?;
         }
 
         let span = tracing::info_span!("create_file", target_path = %target_path.display());

--- a/loco-new/src/generator/executer/filesystem.rs
+++ b/loco-new/src/generator/executer/filesystem.rs
@@ -13,12 +13,6 @@ pub struct FileSystem {
     pub template_engine: generator::template::Template,
 }
 
-impl From<std::io::Error> for super::Error {
-    fn from(err: std::io::Error) -> Self {
-        super::Error::msg(err.to_string())
-    }
-}
-
 impl FileSystem {
     #[must_use]
     pub fn new(from: &Path, to: &Path) -> Self {
@@ -94,7 +88,7 @@ impl Executer for FileSystem {
     fn create_file(&self, path: &Path, content: String) -> super::Result<PathBuf> {
         let target_path = self.target_dir.join(path);
         if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(self.target_dir.join(parent))?;
+            fs_extra::dir::create_all(self.target_dir.join(parent), false)?;
         }
 
         let span = tracing::info_span!("create_file", target_path = %target_path.display());


### PR DESCRIPTION
This is based on the report in https://github.com/loco-rs/loco/issues/1127

I tested this by running the modified binary:

```
cd loco-new
cargo build -r
```

Then used the newly created binary to create a new app `loco new`