### PR TITLE
fix: errors with custom messages are now properly handled

### DIFF
--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -193,6 +193,11 @@ impl IntoResponse for Error {
         }
 
         let public_facing_error = match self {
+            Self::BadRequest(msg) => (StatusCode::BAD_REQUEST, ErrorDetail::with_reason(msg)),
+            Self::Message(msg) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorDetail::with_reason(msg),
+            ),
             Self::NotFound => (
                 StatusCode::NOT_FOUND,
                 ErrorDetail::new("not_found", "Resource was not found"),


### PR DESCRIPTION
Fixes #1138 

Errors with custom messages are now properly handled.
I wasn't sure what status to return with the `Error::Message` variant, but I found `INTERNAL_SERVER_ERROR` fitting.