### PR TITLE
fix: fix method action regex to extract Route MethodRouter

### DIFF
--- a/src/controller/describe.rs
+++ b/src/controller/describe.rs
@@ -8,7 +8,7 @@ use crate::app::AppContext;
 static DESCRIBE_METHOD_ACTION: OnceLock<Regex> = OnceLock::new();
 
 fn get_describe_method_action() -> &'static Regex {
-    DESCRIBE_METHOD_ACTION.get_or_init(|| Regex::new(r"\b(\w+):\s*BoxedHandler\b").unwrap())
+    DESCRIBE_METHOD_ACTION.get_or_init(|| Regex::new(r"\b(\w+):\s*(BoxedHandler|Route)\b").unwrap())
 }
 
 /// Extract the allow list method actions from [`MethodRouter`].


### PR DESCRIPTION
![screenshot-before](https://github.com/user-attachments/assets/5101afb0-c09d-4f7a-be99-0d1eb7685a27)

When added a `MethodRouter` created by axum's `post_service` to the routes in a controller of `loco-rs`, it failed to correctly extract that it was a `POST` method. The scenario can be seen here: [an axum post_service use case](https://github.com/dumtruck/konobangu/blob/8f76e928042f68dc8d0a8cc0848574aae21a612d/apps/recorder/src/controllers/graphql.rs#L23).

```rust
use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
use async_graphql_axum::GraphQL;
use axum::{
    response::{Html, IntoResponse},
    routing::{get, post_service},
};
use loco_rs::prelude::Routes;

use crate::graphql::service::AppGraphQLService;

pub async fn graphql_playground() -> impl IntoResponse {
    Html(playground_source(GraphQLPlaygroundConfig::new(
        "/api/graphql",
    )))
}

pub fn routes(graphql_service: &AppGraphQLService) -> Routes {
    Routes::new()
        .prefix("/graphql")
        .add("/playground", get(graphql_playground))
        .add(
            "/",
            post_service(GraphQL::new(graphql_service.schema.clone())),
        )
}
```

The issue originates from the regex here: [source code](https://github.com/loco-rs/loco/blob/6fe90eab338faec071b8151023f2de2765957a82/src/controller/describe.rs#L11):

```rust
fn get_describe_method_action() -> &'static Regex {
    DESCRIBE_METHOD_ACTION.get_or_init(|| Regex::new(r"\b(\w+):\s*BoxedHandler\b").unwrap())
}
```

Which does not account for the match cases of MethodEndpoint::Route created by the {method}_service series of functions: [MethodEndpoint::Route](https://github.com/tokio-rs/axum/blob/f84105ae8b078109987b089c47febc3b544e6b80/axum/src/routing/method_routing.rs#L816).

```rust
    pub fn on_service<T>(self, filter: MethodFilter, svc: T) -> Self
    where
        T: Service<Request, Error = E> + Clone + Send + Sync + 'static,
        T::Response: IntoResponse + 'static,
        T::Future: Send + 'static,
    {
        self.on_endpoint(filter, MethodEndpoint::Route(Route::new(svc)))
    }
```

To address this issue, I updated the regular expression to include this case. Below is the behavior before and after the modification.

```rust
Regex::new(r"\b(\w+):\s*(BoxedHandler|Route)\b")
```

After fixed: 

![screenshot-after](https://github.com/user-attachments/assets/b9dd1446-e7cd-473e-acd0-2ecc6cb7e467)

