### PR TITLE
Extend truncate and seed hooks to accept app context 

### DIFF
--- a/docs-site/content/docs/the-app/models.md
+++ b/docs-site/content/docs/the-app/models.md
@@ -644,8 +644,8 @@ Integrate your seed into the app's Hook implementations by following these steps
 impl Hooks for App {
     // Other implementations...
 
-    async fn seed(db: &DatabaseConnection, base: &Path) -> Result<()> {
-        db::seed::<users::ActiveModel>(db, &base.join("users.yaml").display().to_string()).await?;
+    async fn seed(ctx: &AppContext, base: &Path) -> Result<()> {
+        db::seed::<users::ActiveModel>(&ctx.db, &base.join("users.yaml").display().to_string()).await?;
         Ok(())
     }
 }

--- a/docs-site/content/docs/the-app/models.md
+++ b/docs-site/content/docs/the-app/models.md
@@ -694,7 +694,7 @@ use loco_rs::testing::prelude::*;
 async fn handle_create_with_password_with_duplicate() {
 
     let boot = boot_test::<App, Migrator>().await;
-    seed::<App>(&boot.app_context.db).await.unwrap();
+    seed::<App>(&boot.app_context).await.unwrap();
     assert!(get_user_by_id(1).ok());
 }
 ```
@@ -818,7 +818,7 @@ async fn can_find_by_pid() {
     configure_insta!();
 
     let boot = boot_test::<App, Migrator>().await;
-    seed::<App>(&boot.app_context.db).await.unwrap();
+    seed::<App>(&boot.app_context).await.unwrap();
 
     let existing_user =
         Model::find_by_pid(&boot.app_context.db, "11111111-1111-1111-1111-111111111111").await;
@@ -855,8 +855,8 @@ pub struct App;
 #[async_trait]
 impl Hooks for App {
     //...
-    async fn truncate(db: &DatabaseConnection) -> Result<()> {
-        // truncate_table(db, users::Entity).await?;
+    async fn truncate(ctx: &AppContext) -> Result<()> {
+        // truncate_table(&ctx.db, users::Entity).await?;
         Ok(())
     }
 
@@ -874,7 +874,7 @@ async fn is_user_exists() {
     configure_insta!();
 
     let boot = boot_test::<App, Migrator>().await;
-    seed::<App>(&boot.app_context.db).await.unwrap();
+    seed::<App>(&boot.app_context).await.unwrap();
     assert!(get_user_by_id(1).ok());
 
 }

--- a/examples/demo/Cargo.lock
+++ b/examples/demo/Cargo.lock
@@ -508,8 +508,9 @@ dependencies = [
 
 [[package]]
 name = "axum-test"
-version = "17.0.0"
-source = "git+https://github.com/JosephLenton/axum-test?branch=feat-axum-8#dd7da71c4979317d603dc7dad9bacad46ec8377a"
+version = "17.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f1009889890a439cbf67a4071a2593d027c65209da4faeac5582f28ca9e6c3"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/examples/demo/src/app.rs
+++ b/examples/demo/src/app.rs
@@ -15,7 +15,6 @@ use loco_rs::{
     Result,
 };
 use migration::Migrator;
-use sea_orm::DatabaseConnection;
 
 use crate::{
     controllers::{self, middlewares},
@@ -106,17 +105,19 @@ impl Hooks for App {
         // tasks-inject (do not remove)
     }
 
-    async fn truncate(db: &DatabaseConnection) -> Result<()> {
-        truncate_table(db, users_roles::Entity).await?;
-        truncate_table(db, roles::Entity).await?;
-        truncate_table(db, users::Entity).await?;
-        truncate_table(db, notes::Entity).await?;
+    async fn truncate(ctx: &AppContext) -> Result<()> {
+        truncate_table(&ctx.db, users_roles::Entity).await?;
+        truncate_table(&ctx.db, roles::Entity).await?;
+        truncate_table(&ctx.db, users::Entity).await?;
+        truncate_table(&ctx.db, notes::Entity).await?;
         Ok(())
     }
 
-    async fn seed(db: &DatabaseConnection, base: &Path) -> Result<()> {
-        db::seed::<users::ActiveModel>(db, &base.join("users.yaml").display().to_string()).await?;
-        db::seed::<notes::ActiveModel>(db, &base.join("notes.yaml").display().to_string()).await?;
+    async fn seed(ctx: &AppContext, base: &Path) -> Result<()> {
+        db::seed::<users::ActiveModel>(&ctx.db, &base.join("users.yaml").display().to_string())
+            .await?;
+        db::seed::<notes::ActiveModel>(&ctx.db, &base.join("notes.yaml").display().to_string())
+            .await?;
         Ok(())
     }
 }

--- a/examples/demo/src/tasks/seed.rs
+++ b/examples/demo/src/tasks/seed.rs
@@ -36,7 +36,7 @@ impl Task for SeedData {
             db::reset::<Migrator>(&app_context.db).await?;
         }
         let path = std::path::Path::new("src/fixtures");
-        db::run_app_seed::<App>(&app_context.db, path).await?;
+        db::run_app_seed::<App>(&app_context, path).await?;
         Ok(())
     }
 }

--- a/examples/demo/tests/models/users.rs
+++ b/examples/demo/tests/models/users.rs
@@ -61,7 +61,7 @@ async fn handle_create_with_password_with_duplicate() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.unwrap();
-    seed::<App>(&boot.app_context.db).await.unwrap();
+    seed::<App>(&boot.app_context).await.unwrap();
 
     let new_user: Result<Model, ModelError> = Model::create_with_password(
         &boot.app_context.db,
@@ -81,7 +81,7 @@ async fn can_find_by_email() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.unwrap();
-    seed::<App>(&boot.app_context.db).await.unwrap();
+    seed::<App>(&boot.app_context).await.unwrap();
 
     let existing_user = Model::find_by_email(&boot.app_context.db, "user1@example.com").await;
     let non_existing_user_results =
@@ -97,7 +97,7 @@ async fn can_find_by_pid() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.unwrap();
-    seed::<App>(&boot.app_context.db).await.unwrap();
+    seed::<App>(&boot.app_context).await.unwrap();
 
     let existing_user =
         Model::find_by_pid(&boot.app_context.db, "11111111-1111-1111-1111-111111111111").await;
@@ -114,7 +114,7 @@ async fn can_verification_token() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.unwrap();
-    seed::<App>(&boot.app_context.db).await.unwrap();
+    seed::<App>(&boot.app_context).await.unwrap();
 
     let user = Model::find_by_pid(&boot.app_context.db, "11111111-1111-1111-1111-111111111111")
         .await
@@ -143,7 +143,7 @@ async fn can_set_forgot_password_sent() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.unwrap();
-    seed::<App>(&boot.app_context.db).await.unwrap();
+    seed::<App>(&boot.app_context).await.unwrap();
 
     let user = Model::find_by_pid(&boot.app_context.db, "11111111-1111-1111-1111-111111111111")
         .await
@@ -172,7 +172,7 @@ async fn can_verified() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.unwrap();
-    seed::<App>(&boot.app_context.db).await.unwrap();
+    seed::<App>(&boot.app_context).await.unwrap();
 
     let user = Model::find_by_pid(&boot.app_context.db, "11111111-1111-1111-1111-111111111111")
         .await
@@ -199,7 +199,7 @@ async fn can_reset_password() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.unwrap();
-    seed::<App>(&boot.app_context.db).await.unwrap();
+    seed::<App>(&boot.app_context).await.unwrap();
 
     let user = Model::find_by_pid(&boot.app_context.db, "11111111-1111-1111-1111-111111111111")
         .await

--- a/examples/demo/tests/requests/cache.rs
+++ b/examples/demo/tests/requests/cache.rs
@@ -37,7 +37,7 @@ async fn can_get_or_insert() {
     configure_insta!();
 
     request::<App, _, _>(|request, ctx| async move {
-        seed::<App>(&ctx.db).await.unwrap();
+        seed::<App>(&ctx).await.unwrap();
         let response = request.get("/cache/get_or_insert").await;
         assert_eq!(response.text(), "user1");
 

--- a/examples/demo/tests/requests/notes.rs
+++ b/examples/demo/tests/requests/notes.rs
@@ -27,7 +27,7 @@ async fn can_get_notes(#[case] test_name: &str, #[case] params: serde_json::Valu
     configure_insta!();
 
     request::<App, _, _>(|request, ctx| async move {
-        seed::<App>(&ctx.db).await.unwrap();
+        seed::<App>(&ctx).await.unwrap();
 
         let notes = request.get("notes").add_query_params(params).await;
 
@@ -80,7 +80,7 @@ async fn can_get_note() {
     configure_insta!();
 
     request::<App, _, _>(|request, ctx| async move {
-        seed::<App>(&ctx.db).await.unwrap();
+        seed::<App>(&ctx).await.unwrap();
 
         let add_note_request = request.get("/notes/1").await;
 
@@ -105,7 +105,7 @@ async fn can_delete_note() {
     configure_insta!();
 
     request::<App, _, _>(|request, ctx| async move {
-        seed::<App>(&ctx.db).await.unwrap();
+        seed::<App>(&ctx).await.unwrap();
 
         let count_before_delete = Entity::find().all(&ctx.db).await.unwrap().len();
         let delete_note_request = request.delete("/notes/1").await;

--- a/loco-gen/src/templates/model/test.t
+++ b/loco-gen/src/templates/model/test.t
@@ -26,7 +26,7 @@ async fn test_model() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.unwrap();
-    seed::<App>(&boot.app_context.db).await.unwrap();
+    seed::<App>(&boot.app_context).await.unwrap();
 
     // query your model, e.g.:
     //

--- a/loco-gen/tests/templates/snapshots/generate[test_model]@Api_scaffold.snap
+++ b/loco-gen/tests/templates/snapshots/generate[test_model]@Api_scaffold.snap
@@ -20,7 +20,7 @@ async fn test_model() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.unwrap();
-    seed::<App>(&boot.app_context.db).await.unwrap();
+    seed::<App>(&boot.app_context).await.unwrap();
 
     // query your model, e.g.:
     //

--- a/loco-gen/tests/templates/snapshots/generate[test_model]@Html_scaffold.snap
+++ b/loco-gen/tests/templates/snapshots/generate[test_model]@Html_scaffold.snap
@@ -20,7 +20,7 @@ async fn test_model() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.unwrap();
-    seed::<App>(&boot.app_context.db).await.unwrap();
+    seed::<App>(&boot.app_context).await.unwrap();
 
     // query your model, e.g.:
     //

--- a/loco-gen/tests/templates/snapshots/generate[test_model]@Htmx_scaffold.snap
+++ b/loco-gen/tests/templates/snapshots/generate[test_model]@Htmx_scaffold.snap
@@ -20,7 +20,7 @@ async fn test_model() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.unwrap();
-    seed::<App>(&boot.app_context.db).await.unwrap();
+    seed::<App>(&boot.app_context).await.unwrap();
 
     // query your model, e.g.:
     //

--- a/loco-gen/tests/templates/snapshots/generate[test_model]@model.snap
+++ b/loco-gen/tests/templates/snapshots/generate[test_model]@model.snap
@@ -20,7 +20,7 @@ async fn test_model() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.unwrap();
-    seed::<App>(&boot.app_context.db).await.unwrap();
+    seed::<App>(&boot.app_context).await.unwrap();
 
     // query your model, e.g.:
     //

--- a/loco-new/base_template/src/app.rs.t
+++ b/loco-new/base_template/src/app.rs.t
@@ -21,7 +21,6 @@ use loco_rs::{
 };
 {%- if settings.db %}
 use migration::Migrator;
-use sea_orm::DatabaseConnection;
 {%- endif %}
 
 #[allow(unused_imports)]
@@ -99,23 +98,23 @@ impl Hooks for App {
     {%- if settings.db %}
 
     {%- if settings.auth %}
-    async fn truncate(db: &DatabaseConnection) -> Result<()> {
+    async fn truncate(ctx: &AppContext) -> Result<()> {
     {%- else %}
-    async fn truncate(_db: &DatabaseConnection) -> Result<()> {
+    async fn truncate(_ctx: &AppContext) -> Result<()> {
     {%- endif %} 
         {%- if settings.auth %}
-        truncate_table(db, users::Entity).await?;
+        truncate_table(&ctx.db, users::Entity).await?;
         {%- endif %}
         Ok(())
     }
 
     {%- if settings.auth %}
-    async fn seed(db: &DatabaseConnection, base: &Path) -> Result<()> {
+    async fn seed(ctx: &AppContext, base: &Path) -> Result<()> {
     {%- else %} 
-    async fn seed(_db: &DatabaseConnection, _base: &Path) -> Result<()> {
+    async fn seed(_ctx: &AppContext, _base: &Path) -> Result<()> {
     {%- endif %} 
         {%- if settings.auth %}
-        db::seed::<users::ActiveModel>(db, &base.join("users.yaml").display().to_string()).await?;
+        db::seed::<users::ActiveModel>(&ctx.db, &base.join("users.yaml").display().to_string()).await?;
         {%- endif %}
         Ok(())
     }

--- a/loco-new/base_template/tests/models/users.rs.t
+++ b/loco-new/base_template/tests/models/users.rs.t
@@ -62,7 +62,7 @@ async fn handle_create_with_password_with_duplicate() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.expect("Failed to boot test application");
-    seed::<App>(&boot.app_context.db).await.expect("Failed to seed database");
+    seed::<App>(&boot.app_context).await.expect("Failed to seed database");
 
     let new_user = Model::create_with_password(
         &boot.app_context.db,
@@ -83,7 +83,7 @@ async fn can_find_by_email() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.expect("Failed to boot test application");
-    seed::<App>(&boot.app_context.db).await.expect("Failed to seed database");
+    seed::<App>(&boot.app_context).await.expect("Failed to seed database");
 
     let existing_user = Model::find_by_email(&boot.app_context.db, "user1@example.com").await;
     let non_existing_user_results = Model::find_by_email(&boot.app_context.db, "un@existing-email.com").await;
@@ -98,7 +98,7 @@ async fn can_find_by_pid() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.expect("Failed to boot test application");
-    seed::<App>(&boot.app_context.db).await.expect("Failed to seed database");
+    seed::<App>(&boot.app_context).await.expect("Failed to seed database");
 
     let existing_user = Model::find_by_pid(&boot.app_context.db, "11111111-1111-1111-1111-111111111111").await;
     let non_existing_user_results = Model::find_by_pid(&boot.app_context.db, "23232323-2323-2323-2323-232323232323").await;
@@ -113,7 +113,7 @@ async fn can_verification_token() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.expect("Failed to boot test application");
-    seed::<App>(&boot.app_context.db).await.expect("Failed to seed database");
+    seed::<App>(&boot.app_context).await.expect("Failed to seed database");
 
     let user = Model::find_by_pid(&boot.app_context.db, "11111111-1111-1111-1111-111111111111")
         .await
@@ -144,7 +144,7 @@ async fn can_set_forgot_password_sent() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.expect("Failed to boot test application");
-    seed::<App>(&boot.app_context.db).await.expect("Failed to seed database");
+    seed::<App>(&boot.app_context).await.expect("Failed to seed database");
 
     let user = Model::find_by_pid(&boot.app_context.db, "11111111-1111-1111-1111-111111111111")
         .await
@@ -175,7 +175,7 @@ async fn can_verified() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.expect("Failed to boot test application");
-    seed::<App>(&boot.app_context.db).await.expect("Failed to seed database");
+    seed::<App>(&boot.app_context).await.expect("Failed to seed database");
 
     let user = Model::find_by_pid(&boot.app_context.db, "11111111-1111-1111-1111-111111111111")
         .await
@@ -204,7 +204,7 @@ async fn can_reset_password() {
     configure_insta!();
 
     let boot = boot_test::<App>().await.expect("Failed to boot test application");
-    seed::<App>(&boot.app_context.db).await.expect("Failed to seed database");
+    seed::<App>(&boot.app_context).await.expect("Failed to seed database");
 
     let user = Model::find_by_pid(&boot.app_context.db, "11111111-1111-1111-1111-111111111111")
         .await
@@ -232,7 +232,7 @@ async fn can_reset_password() {
 #[serial]
 async fn magic_link() {
     let boot = boot_test::<App>().await.unwrap();
-    seed::<App>(&boot.app_context.db).await.unwrap();
+    seed::<App>(&boot.app_context).await.unwrap();
 
     let user = Model::find_by_pid(&boot.app_context.db, "11111111-1111-1111-1111-111111111111")
         .await

--- a/loco-new/base_template/tests/requests/auth.rs.t
+++ b/loco-new/base_template/tests/requests/auth.rs.t
@@ -248,7 +248,7 @@ async fn can_get_current_user() {
 async fn can_auth_with_magic_link() {
     configure_insta!();
     request::<App, _, _>(|request, ctx| async move {
-        seed::<App>(&ctx.db).await.unwrap();
+        seed::<App>(&ctx).await.unwrap();
 
         let payload = serde_json::json!({
             "email": "user1@example.com",
@@ -313,7 +313,7 @@ async fn can_reject_invalid_email() {
 async fn can_reject_invalid_magic_link_token() {
     configure_insta!();
     request::<App, _, _>(|request, ctx| async move {
-        seed::<App>(&ctx.db).await.unwrap();
+        seed::<App>(&ctx).await.unwrap();
 
         let magic_link_response = request.get("/api/auth/magic-link/invalid-token").await;
         assert_eq!(

--- a/loco-new/tests/templates/snapshots/r#mod__templates__auth__src_app_rs_auth_false_Sqlite.snap
+++ b/loco-new/tests/templates/snapshots/r#mod__templates__auth__src_app_rs_auth_false_Sqlite.snap
@@ -16,7 +16,6 @@ use loco_rs::{
     Result,
 };
 use migration::Migrator;
-use sea_orm::DatabaseConnection;
 
 #[allow(unused_imports)]
 use crate::{
@@ -61,10 +60,10 @@ impl Hooks for App {
     fn register_tasks(tasks: &mut Tasks) {
         // tasks-inject (do not remove)
     }
-    async fn truncate(_db: &DatabaseConnection) -> Result<()> {
+    async fn truncate(_ctx: &AppContext) -> Result<()> {
         Ok(())
     } 
-    async fn seed(_db: &DatabaseConnection, _base: &Path) -> Result<()> {
+    async fn seed(_ctx: &AppContext, _base: &Path) -> Result<()> {
         Ok(())
     }
 }

--- a/loco-new/tests/templates/snapshots/r#mod__templates__auth__src_app_rs_auth_true_Sqlite.snap
+++ b/loco-new/tests/templates/snapshots/r#mod__templates__auth__src_app_rs_auth_true_Sqlite.snap
@@ -17,7 +17,6 @@ use loco_rs::{
     Result,
 };
 use migration::Migrator;
-use sea_orm::DatabaseConnection;
 
 #[allow(unused_imports)]
 use crate::{
@@ -63,12 +62,12 @@ impl Hooks for App {
     fn register_tasks(tasks: &mut Tasks) {
         // tasks-inject (do not remove)
     }
-    async fn truncate(db: &DatabaseConnection) -> Result<()> {
-        truncate_table(db, users::Entity).await?;
+    async fn truncate(ctx: &AppContext) -> Result<()> {
+        truncate_table(&ctx.db, users::Entity).await?;
         Ok(())
     }
-    async fn seed(db: &DatabaseConnection, base: &Path) -> Result<()> {
-        db::seed::<users::ActiveModel>(db, &base.join("users.yaml").display().to_string()).await?;
+    async fn seed(ctx: &AppContext, base: &Path) -> Result<()> {
+        db::seed::<users::ActiveModel>(&ctx.db, &base.join("users.yaml").display().to_string()).await?;
         Ok(())
     }
 }

--- a/loco-new/tests/templates/snapshots/r#mod__templates__db__src_app_rs_Postgres.snap
+++ b/loco-new/tests/templates/snapshots/r#mod__templates__db__src_app_rs_Postgres.snap
@@ -16,7 +16,6 @@ use loco_rs::{
     Result,
 };
 use migration::Migrator;
-use sea_orm::DatabaseConnection;
 
 #[allow(unused_imports)]
 use crate::{
@@ -61,10 +60,10 @@ impl Hooks for App {
     fn register_tasks(tasks: &mut Tasks) {
         // tasks-inject (do not remove)
     }
-    async fn truncate(_db: &DatabaseConnection) -> Result<()> {
+    async fn truncate(_ctx: &AppContext) -> Result<()> {
         Ok(())
     } 
-    async fn seed(_db: &DatabaseConnection, _base: &Path) -> Result<()> {
+    async fn seed(_ctx: &AppContext, _base: &Path) -> Result<()> {
         Ok(())
     }
 }

--- a/loco-new/tests/templates/snapshots/r#mod__templates__db__src_app_rs_Sqlite.snap
+++ b/loco-new/tests/templates/snapshots/r#mod__templates__db__src_app_rs_Sqlite.snap
@@ -16,7 +16,6 @@ use loco_rs::{
     Result,
 };
 use migration::Migrator;
-use sea_orm::DatabaseConnection;
 
 #[allow(unused_imports)]
 use crate::{
@@ -61,10 +60,10 @@ impl Hooks for App {
     fn register_tasks(tasks: &mut Tasks) {
         // tasks-inject (do not remove)
     }
-    async fn truncate(_db: &DatabaseConnection) -> Result<()> {
+    async fn truncate(_ctx: &AppContext) -> Result<()> {
         Ok(())
     } 
-    async fn seed(_db: &DatabaseConnection, _base: &Path) -> Result<()> {
+    async fn seed(_ctx: &AppContext, _base: &Path) -> Result<()> {
         Ok(())
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -212,11 +212,11 @@ pub trait Hooks: Send {
     /// Truncate can be useful when you want to truncate the database before any
     /// test.
     #[cfg(feature = "with-db")]
-    async fn truncate(db: &DatabaseConnection) -> Result<()>;
+    async fn truncate(_ctx: &AppContext) -> Result<()>;
 
     /// Seeds the database with initial data.
     #[cfg(feature = "with-db")]
-    async fn seed(db: &DatabaseConnection, path: &Path) -> Result<()>;
+    async fn seed(_ctx: &AppContext, path: &Path) -> Result<()>;
 
     /// Called when the application is shutting down.
     /// This function allows users to perform any necessary cleanup or final

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -285,7 +285,7 @@ pub async fn run_db<H: Hooks, M: MigratorTrait>(
         }
         RunDbCommand::Truncate => {
             tracing::warn!("truncate:");
-            H::truncate(&app_context.db).await?;
+            H::truncate(app_context).await?;
         }
         RunDbCommand::Seed {
             reset,
@@ -301,7 +301,7 @@ pub async fn run_db<H: Hooks, M: MigratorTrait>(
                 if reset {
                     db::reset::<M>(&app_context.db).await?;
                 }
-                db::run_app_seed::<H>(&app_context.db, &from).await?;
+                db::run_app_seed::<H>(app_context, &from).await?;
             }
         }
         RunDbCommand::Schema => {
@@ -364,7 +364,7 @@ pub async fn create_app<H: Hooks, M: MigratorTrait>(
     config: Config,
 ) -> Result<BootResult> {
     let app_context = create_context::<H>(environment, config).await?;
-    db::converge::<H, M>(&app_context.db, &app_context.config.database).await?;
+    db::converge::<H, M>(&app_context, &app_context.config.database).await?;
 
     if let (Some(queue), Some(config)) = (&app_context.queue_provider, &app_context.config.queue) {
         bgworker::converge(queue, config).await?;

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -55,11 +55,11 @@
 //!
 //!     fn register_tasks(tasks: &mut Tasks) {}
 //!
-//!     async fn truncate(db: &DatabaseConnection) -> Result<()> {
+//!     async fn truncate(_ctx: &AppContext) -> Result<()> {
 //!         Ok(())
 //!     }
 //!
-//!     async fn seed(db: &DatabaseConnection, base: &Path) -> Result<()> {
+//!     async fn seed(_ctx: &AppContext, base: &Path) -> Result<()> {
 //!         Ok(())
 //!     }
 //! }

--- a/src/db.rs
+++ b/src/db.rs
@@ -106,23 +106,23 @@ pub async fn verify_access(db: &DatabaseConnection) -> AppResult<()> {
 /// return an `AppError` variant representing different database operation
 /// failures.
 pub async fn converge<H: Hooks, M: MigratorTrait>(
-    db: &DatabaseConnection,
+    ctx: &AppContext,
     config: &config::Database,
 ) -> AppResult<()> {
     if config.dangerously_recreate {
         info!("recreating schema");
-        reset::<M>(db).await?;
+        reset::<M>(&ctx.db).await?;
         return Ok(());
     }
 
     if config.auto_migrate {
         info!("auto migrating");
-        migrate::<M>(db).await?;
+        migrate::<M>(&ctx.db).await?;
     }
 
     if config.dangerously_truncate {
         info!("truncating tables");
-        H::truncate(db).await?;
+        H::truncate(ctx).await?;
     }
     Ok(())
 }
@@ -575,8 +575,8 @@ where
 /// # Errors
 ///
 /// when seed process is fails
-pub async fn run_app_seed<H: Hooks>(db: &DatabaseConnection, path: &Path) -> AppResult<()> {
-    H::seed(db, path).await
+pub async fn run_app_seed<H: Hooks>(ctx: &AppContext, path: &Path) -> AppResult<()> {
+    H::seed(ctx, path).await
 }
 
 /// Create a Postgres database from the given db name.

--- a/src/testing/db.rs
+++ b/src/testing/db.rs
@@ -1,6 +1,7 @@
-use sea_orm::DatabaseConnection;
-
-use crate::{app::Hooks, Result};
+use crate::{
+    app::{AppContext, Hooks},
+    Result,
+};
 
 /// Seeds data into the database.
 ///
@@ -27,7 +28,7 @@ use crate::{app::Hooks, Result};
 ///     assert!(false)
 /// }
 /// ```
-pub async fn seed<H: Hooks>(db: &DatabaseConnection) -> Result<()> {
+pub async fn seed<H: Hooks>(ctx: &AppContext) -> Result<()> {
     let path = std::path::Path::new("src/fixtures");
-    H::seed(db, path).await
+    H::seed(ctx, path).await
 }

--- a/src/testing/db.rs
+++ b/src/testing/db.rs
@@ -22,7 +22,7 @@ use crate::{
 /// #[tokio::test]
 /// async fn test_create_user() {
 ///     let boot = boot_test::<App, Migrator>().await;
-///     seed::<App>(&boot.app_context.db).await.unwrap();
+///     seed::<App>(&boot.app_context).await.unwrap();
 ///
 ///     /// .....
 ///     assert!(false)

--- a/src/tests_cfg/db.rs
+++ b/src/tests_cfg/db.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 
 use async_trait::async_trait;
-use sea_orm::DatabaseConnection;
 pub use sea_orm_migration::prelude::*;
 
 use crate::{
@@ -116,11 +115,11 @@ impl Hooks for AppHook {
         tasks.register(super::task::ParseArgs);
     }
 
-    async fn truncate(_db: &DatabaseConnection) -> Result<()> {
+    async fn truncate(_ctx: &AppContext) -> Result<()> {
         Ok(())
     }
 
-    async fn seed(_db: &DatabaseConnection, _base: &Path) -> Result<()> {
+    async fn seed(_ctx: &AppContext, _base: &Path) -> Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
Extend truncate and seed hooks to accept app context instead of DB context.

Relevant issue: #1060