### PR TITLE
fix: bump shuttle to 0.51.0

### DIFF
--- a/loco-gen/src/lib.rs
+++ b/loco-gen/src/lib.rs
@@ -31,7 +31,7 @@ pub struct GenerateResults {
     rrgen: Vec<rrgen::GenResult>,
     local_templates: Vec<PathBuf>,
 }
-const DEPLOYMENT_SHUTTLE_RUNTIME_VERSION: &str = "0.46.0";
+const DEPLOYMENT_SHUTTLE_RUNTIME_VERSION: &str = "0.51.0";
 
 const DEPLOYMENT_OPTIONS: &[(&str, DeploymentKind)] = &[
     ("Docker", DeploymentKind::Docker),

--- a/loco-gen/src/templates/deployment/shuttle/config.t
+++ b/loco-gen/src/templates/deployment/shuttle/config.t
@@ -2,4 +2,12 @@ to: "Shuttle.toml"
 skip_exists: true
 message: "Shuttle.toml file created successfully"
 ---
-name = "{{pkg_name}}"
+[deploy]
+include = [
+    "config/production.yaml"
+]
+
+[build]
+assets = [
+    "config/production.yaml"
+]

--- a/loco-gen/src/templates/deployment/shuttle/shuttle.t
+++ b/loco-gen/src/templates/deployment/shuttle/shuttle.t
@@ -39,7 +39,12 @@ async fn main(
         shuttle_runtime::Environment::Local => Environment::Development,
         shuttle_runtime::Environment::Deployment => Environment::Production,
     };
-    let boot_result = create_app::<App{% if with_db %}, Migrator{% endif %}>(StartMode::ServerOnly, &environment)
+
+     let config = environment
+        .load()
+        .expect("Failed to load configuration from the environment");
+    
+    let boot_result = create_app::<App{% if with_db %}, Migrator{% endif %}>(StartMode::ServerOnly, &environment, config)
         .await
         .unwrap();
 

--- a/loco-gen/src/templates/deployment/shuttle/shuttle.t
+++ b/loco-gen/src/templates/deployment/shuttle/shuttle.t
@@ -17,7 +17,7 @@ injections:
 - into: Cargo.toml
   after: \[dependencies\]
   content: |
-    shuttle-axum = "{{shuttle_runtime_version}}"
+    shuttle-axum = { version = "{{shuttle_runtime_version}}", default-features = false, features = ["axum-0-7"] }
     shuttle-runtime = { version = "{{shuttle_runtime_version}}", default-features = false }
     {% if with_db -%}
     shuttle-shared-db = { version = "{{shuttle_runtime_version}}", features = ["postgres"] }

--- a/loco-gen/src/templates/deployment/shuttle/shuttle.t
+++ b/loco-gen/src/templates/deployment/shuttle/shuttle.t
@@ -17,7 +17,7 @@ injections:
 - into: Cargo.toml
   after: \[dependencies\]
   content: |
-    shuttle-axum = { version = "{{shuttle_runtime_version}}", default-features = false, features = ["axum-0-7"] }
+    shuttle-axum = "{{shuttle_runtime_version}}"
     shuttle-runtime = { version = "{{shuttle_runtime_version}}", default-features = false }
     {% if with_db -%}
     shuttle-shared-db = { version = "{{shuttle_runtime_version}}", features = ["postgres"] }

--- a/loco-gen/tests/templates/snapshots/generate[shuttle.rs]@deployment.snap
+++ b/loco-gen/tests/templates/snapshots/generate[shuttle.rs]@deployment.snap
@@ -1,0 +1,32 @@
+---
+source: loco-gen/tests/templates/deployment.rs
+expression: "fs::read_to_string(tree_fs.root.join(\"src\").join(\"bin\").join(\"shuttle.rs\")).expect(\"shuttle rs missing\")"
+---
+use loco_rs::boot::{create_app, StartMode};
+use loco_rs::environment::Environment;
+use tester::app::App;
+use migration::Migrator;
+use shuttle_runtime::DeploymentMetadata;
+
+#[shuttle_runtime::main]
+async fn main(
+  #[shuttle_shared_db::Postgres] conn_str: String,
+  #[shuttle_runtime::Metadata] meta: DeploymentMetadata,
+) -> shuttle_axum::ShuttleAxum {
+    std::env::set_var("DATABASE_URL", conn_str);
+    let environment = match meta.env {
+        shuttle_runtime::Environment::Local => Environment::Development,
+        shuttle_runtime::Environment::Deployment => Environment::Production,
+    };
+
+     let config = environment
+        .load()
+        .expect("Failed to load configuration from the environment");
+    
+    let boot_result = create_app::<App, Migrator>(StartMode::ServerOnly, &environment, config)
+        .await
+        .unwrap();
+
+    let router = boot_result.router.unwrap();
+    Ok(router.into())
+}

--- a/loco-gen/tests/templates/snapshots/inject[.config_toml]@deployment.snap
+++ b/loco-gen/tests/templates/snapshots/inject[.config_toml]@deployment.snap
@@ -1,0 +1,9 @@
+---
+source: loco-gen/tests/templates/deployment.rs
+expression: "fs::read_to_string(tree_fs.root.join(\".cargo\").join(\"config.toml\")).expect(\".cargo/config.toml not exists\")"
+---
+[alias]
+loco = "run --bin tester-cli --"
+loco-tool = "run --"
+
+playground = "run --example playground"

--- a/loco-gen/tests/templates/snapshots/inject[cargo_toml]@deployment.snap
+++ b/loco-gen/tests/templates/snapshots/inject[cargo_toml]@deployment.snap
@@ -1,0 +1,15 @@
+---
+source: loco-gen/tests/templates/deployment.rs
+expression: "fs::read_to_string(tree_fs.root.join(\"Cargo.toml\")).expect(\"cargo.toml not exists\")"
+---
+[dependencies]
+shuttle-axum = "0.51.0"
+shuttle-runtime = { version = "0.51.0", default-features = false }
+shuttle-shared-db = { version = "0.51.0", features = ["postgres"] }
+
+
+[[bin]]
+name = "tester"
+path = "src/bin/shuttle.rs"
+
+[dev-dependencies]


### PR DESCRIPTION
- Bumps shuttle deps to latest version
- Updates Shuttle.toml configuration for shuttle.dev platform

Solves https://github.com/shuttle-hq/shuttle/issues/1937

Tested by doing `loco new`, `cargo loco generate deployment` (shuttle), applying the changes in this PR by hand, copying boilerplate from `development.yaml` to `production.yaml`, then `shuttle deploy`. `shuttle run` also works as expected.