### PR TITLE
return validation json response

### DIFF
--- a/src/controller/extractor/mod.rs
+++ b/src/controller/extractor/mod.rs
@@ -1,0 +1,1 @@
+pub mod validate;

--- a/src/controller/extractor/validate.rs
+++ b/src/controller/extractor/validate.rs
@@ -1,0 +1,38 @@
+use crate::Error;
+use axum::extract::{Form, FromRequest, Json, Request};
+use serde::de::DeserializeOwned;
+use validator::Validate;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct JsonValidate<T>(pub T);
+
+impl<T, S> FromRequest<S> for JsonValidate<T>
+where
+    T: DeserializeOwned + Validate,
+    S: Send + Sync,
+{
+    type Rejection = Error;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        let Json(value) = Json::<T>::from_request(req, state).await?;
+        value.validate()?;
+        Ok(Self(value))
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FormValidate<T>(pub T);
+
+impl<T, S> FromRequest<S> for FormValidate<T>
+where
+    T: DeserializeOwned + Validate,
+    S: Send + Sync,
+{
+    type Rejection = Error;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        let Form(value) = Form::<T>::from_request(req, state).await?;
+        value.validate()?;
+        Ok(Self(value))
+    }
+}

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -146,10 +146,11 @@ pub struct ErrorDetail {
 impl ErrorDetail {
     /// Create a new `ErrorDetail` with the specified error and description.
     #[must_use]
-    pub fn new<T: Into<String>>(error: T, description: T) -> Self {
+    pub fn new<T: Into<String> + AsRef<str>>(error: T, description: T) -> Self {
+        let description = (!description.as_ref().is_empty()).then(|| description.into());
         Self {
             error: Some(error.into()),
-            description: Some(description.into()),
+            description,
             errors: None,
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -156,6 +156,12 @@ pub enum Error {
 
     #[error(transparent)]
     Any(#[from] Box<dyn std::error::Error + Send + Sync>),
+
+    #[error(transparent)]
+    ValidationError(#[from] validator::ValidationErrors),
+
+    #[error(transparent)]
+    AxumFormRejection(#[from] axum::extract::rejection::FormRejection),
 }
 
 impl Error {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -19,7 +19,7 @@ pub use sea_orm::{
 // sugar for controller views to use `data!({"item": ..})` instead of `json!`
 pub use serde_json::json as data;
 
-pub use crate::controller::extractor::validate::JsonValidate;
+pub use crate::controller::extractor::validate::{JsonValidate, JsonValidateWithMessage};
 #[cfg(all(feature = "auth_jwt", feature = "with-db"))]
 pub use crate::controller::middleware::auth;
 #[cfg(feature = "with-db")]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -19,6 +19,7 @@ pub use sea_orm::{
 // sugar for controller views to use `data!({"item": ..})` instead of `json!`
 pub use serde_json::json as data;
 
+pub use crate::controller::extractor::validate::JsonValidate;
 #[cfg(all(feature = "auth_jwt", feature = "with-db"))]
 pub use crate::controller::middleware::auth;
 #[cfg(feature = "with-db")]

--- a/tests/controller/into_response.rs
+++ b/tests/controller/into_response.rs
@@ -139,6 +139,7 @@ async fn custom_error() {
             controller::ErrorDetail {
                 error: Some("Payload Too Large".to_string()),
                 description: Some("413 Payload Too Large".to_string()),
+                errors: None,
             },
         ))
     }

--- a/tests/controller/mod.rs
+++ b/tests/controller/mod.rs
@@ -1,2 +1,3 @@
 mod into_response;
 mod middlewares;
+mod validation_extractor;

--- a/tests/controller/validation_extractor.rs
+++ b/tests/controller/validation_extractor.rs
@@ -4,26 +4,31 @@ use serde::{Deserialize, Serialize};
 use serial_test::serial;
 use validator::Validate;
 
+#[derive(Debug, Deserialize, Serialize, Validate)]
+pub struct Data {
+    #[validate(length(min = 5, message = "message_str"))]
+    pub name: String,
+    #[validate(email)]
+    pub email: String,
+}
+
+async fn validation_with_response(
+    JsonValidateWithMessage(_params): JsonValidateWithMessage<Data>,
+) -> Result<Response> {
+    format::json(())
+}
+
+async fn simple_validation(JsonValidate(_params): JsonValidate<Data>) -> Result<Response> {
+    format::json(())
+}
+
 #[tokio::test]
 #[serial]
-async fn json_rejection() {
+async fn can_validation_with_response() {
     let ctx = tests_cfg::app::get_app_context().await;
 
-    #[allow(clippy::items_after_statements)]
-    #[derive(Debug, Deserialize, Serialize, Validate)]
-    pub struct Data {
-        #[validate(length(min = 5, message = "message_str"))]
-        pub name: String,
-        #[validate(email)]
-        pub email: String,
-    }
-
-    #[allow(clippy::items_after_statements)]
-    async fn action(JsonValidate(_params): JsonValidate<Data>) -> Result<Response> {
-        format::json(())
-    }
-
-    let handle = infra_cfg::server::start_with_route(ctx, "/", post(action)).await;
+    let handle =
+        infra_cfg::server::start_with_route(ctx, "/", post(validation_with_response)).await;
 
     let client = reqwest::Client::new();
     let res = client
@@ -45,6 +50,37 @@ async fn json_rejection() {
                 "name":[{"code":"length","message":"message_str","params":{"min":5,"value":"test"}}]
         }
     });
+
+    assert_eq!(res_json, expected_json);
+
+    handle.abort();
+}
+
+#[tokio::test]
+#[serial]
+async fn can_validation_without_response() {
+    let ctx = tests_cfg::app::get_app_context().await;
+
+    let handle = infra_cfg::server::start_with_route(ctx, "/", post(simple_validation)).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(infra_cfg::server::get_base_url())
+        .json(&serde_json::json!({"name": "test", "email": "invalid"}))
+        .send()
+        .await
+        .expect("Valid response");
+
+    assert_eq!(res.status(), 400);
+
+    let res_text = res.text().await.expect("response text");
+    let res_json: serde_json::Value = serde_json::from_str(&res_text).expect("Valid JSON response");
+
+    let expected_json = serde_json::json!(
+        {
+            "error": "Bad Request"
+        }
+    );
 
     assert_eq!(res_json, expected_json);
 

--- a/tests/controller/validation_extractor.rs
+++ b/tests/controller/validation_extractor.rs
@@ -1,0 +1,52 @@
+use crate::infra_cfg;
+use loco_rs::{prelude::*, tests_cfg};
+use serde::{Deserialize, Serialize};
+use serial_test::serial;
+use validator::Validate;
+
+#[tokio::test]
+#[serial]
+async fn json_rejection() {
+    let ctx = tests_cfg::app::get_app_context().await;
+
+    #[allow(clippy::items_after_statements)]
+    #[derive(Debug, Deserialize, Serialize, Validate)]
+    pub struct Data {
+        #[validate(length(min = 5, message = "message_str"))]
+        pub name: String,
+        #[validate(email)]
+        pub email: String,
+    }
+
+    #[allow(clippy::items_after_statements)]
+    async fn action(JsonValidate(_params): JsonValidate<Data>) -> Result<Response> {
+        format::json(())
+    }
+
+    let handle = infra_cfg::server::start_with_route(ctx, "/", post(action)).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(infra_cfg::server::get_base_url())
+        .json(&serde_json::json!({"name": "test", "email": "invalid"}))
+        .send()
+        .await
+        .expect("Valid response");
+
+    assert_eq!(res.status(), 400);
+
+    let res_text = res.text().await.expect("response text");
+    let res_json: serde_json::Value = serde_json::from_str(&res_text).expect("Valid JSON response");
+
+    let expected_json = serde_json::json!(
+        {
+            "errors":{
+                "email":[{"code":"email","message":null,"params":{"value":"invalid"}}],
+                "name":[{"code":"length","message":"message_str","params":{"min":5,"value":"test"}}]
+        }
+    });
+
+    assert_eq!(res_json, expected_json);
+
+    handle.abort();
+}


### PR DESCRIPTION
Previously, the controller did not support automatic validation of POST parameters. Validation was done manually after deserialization using the serde_json library. For instance, the developer would create a struct, add validation rules using the Validate trait, and manually handle the validation errors in the controller.
```rust
#[derive(Debug, Deserialize, Validate)]
pub struct DataParams {
    #[validate(length(min = 5, message = "message_str"))]
    pub name: String,
    #[validate(email)]
    pub email: String,
}

#[debug_handler]
pub async fn index(
    State(_ctx): State<AppContext>,
    Json(params): Json<DataParams>,
) -> Result<Response> {
    // Manual validation
    let validate_res = params.validate();
    if let Err(errors) = validate_res {
        // Handle errors manually
        return Err(errors.into());
    }

    // Continue processing if validation succeeds
    format::empty()
}
```

New Implementation:
The updated implementation introduces a `JsonValidate` and `FormValidate` and with messages response: `JsonValidateWithMessage` and `FormValidateWithMessage` extractors, which automatically handles validation and returns a JSON response for validation errors. This eliminates the need for manual validation logic in the controller.
```rust
#[derive(Debug, Deserialize, Validate)]
pub struct DataParams {
    #[validate(length(min = 5, message = "message_str"))]
    pub name: String,
    #[validate(email)]
    pub email: String,
}

#[debug_handler]
pub async fn index(
    State(_ctx): State<AppContext>,
    JsonValidate(params): JsonValidate<DataParams>,
) -> Result<Response> {
    // Validation is automatically handled by JsonValidate
    format::empty()
}
```

If validation fails, JsonValidate automatically returns a structured JSON response like the following:
```json
{
  "errors": {
    "email": [
      {
        "code": "email",
        "message": null,
        "params": { "value": "invalid" }
      }
    ],
    "name": [
      {
        "code": "length",
        "message": "message_str",
        "params": { "min": 5, "value": "test" }
      }
    ]
  }
}
```