### PR TITLE
Bump version 0.14.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 
 [package]
 name = "loco-rs"
-version = "0.14.0"
+version = "0.14.1"
 description = "The one-person framework for Rust"
 homepage = "https://loco.rs/"
 documentation = "https://docs.rs/loco-rs"
@@ -49,7 +49,7 @@ bg_sqlt = ["dep:sqlx", "dep:ulid"]
 integration_test = []
 
 [dependencies]
-loco-gen = { version = "0.14.0", path = "./loco-gen" }
+loco-gen = { version = "0.14.1", path = "./loco-gen" }
 backtrace_printer = { version = "1.3.0" }
 
 # cli

--- a/loco-gen/Cargo.toml
+++ b/loco-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loco-gen"
-version = "0.14.0"
+version = "0.14.1"
 description = "Loco generators"
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Bump version 0.14.1

- Fix: bump shuttle to 0.51.0. https://github.com/loco-rs/loco/pull/1169
- Return 422 status code for JSON rejection errors. https://github.com/loco-rs/loco/pull/1173
- Address clippy warnings for Rust stable 1.84. https://github.com/loco-rs/loco/pull/1168
- Bump shuttle to 0.51.0. https://github.com/loco-rs/loco/pull/1169
- Return 422 status code for JSON rejection errors. https://github.com/loco-rs/loco/pull/1173
- Return json validation details response. https://github.com/loco-rs/loco/pull/1174
- Fix example command after generating schedule. https://github.com/loco-rs/loco/pull/1176
- Fixed independent features. https://github.com/loco-rs/loco/pull/1177
- Custom response header for redirect. https://github.com/loco-rs/loco/pull/1186
- Added run_on_start feature to the scheduler. https://github.com/loco-rs/loco/pull/1184
- feat: public jwt extractor from non-mutable reference to parts. https://github.com/loco-rs/loco/pull/1190