### PR TITLE
(docs) add explanation for fallback page

### DIFF
--- a/docs-site/content/blog/frontend-website.md
+++ b/docs-site/content/blog/frontend-website.md
@@ -151,7 +151,16 @@ Now, run the Loco server again and you should see frontend app serving via Loco
 $ cargo loco start
 ```
 
-If you see the default fallback page, you have to disable the fallback middleware.
+If you see the default fallback page, you have to disable the fallback middleware. The default fallback takes priority over the static handler, so no static content will be served if it is enabled. You can disable it like so:
+
+```yaml
+server:
+  middlewares:
+    fallback:
+      enable: false
+    static:
+      ...
+```
 
 # Developing the UI
 

--- a/docs-site/content/blog/frontend-website.md
+++ b/docs-site/content/blog/frontend-website.md
@@ -151,6 +151,8 @@ Now, run the Loco server again and you should see frontend app serving via Loco
 $ cargo loco start
 ```
 
+If you see the default fallback page, you have to disable the fallback middleware.
+
 # Developing the UI
 
 Install `react-router-dom`, `react-query` and `axios`

--- a/docs-site/content/docs/getting-started/starters.md
+++ b/docs-site/content/docs/getting-started/starters.md
@@ -81,6 +81,8 @@ In your `config/development.yaml`, uncomment the server-side config, and comment
         uri: "/static"
         path: "assets/static"
       fallback: "assets/static/404.html"
+    fallback:
+      enable: false
     # client side app static config
     # static:
     #   enable: true
@@ -90,6 +92,8 @@ In your `config/development.yaml`, uncomment the server-side config, and comment
     #     uri: "/"
     #     path: "frontend/dist"
     #   fallback: "frontend/dist/index.html"
+    # fallback:
+    #   enable: false
 ```
 
 

--- a/docs-site/content/docs/the-app/controller.md
+++ b/docs-site/content/docs/the-app/controller.md
@@ -541,7 +541,7 @@ To disable the middleware edit the configuration as follows:
 
 ## Fallback
 
-When choosing the SaaS starter (or any starter that is not API-first), you get a default fallback behavior with the _Loco welcome screen_. This is a development-only mode where a `404` request shows you a nice and friendly page that tells you what happened and what to do next.
+When choosing the SaaS starter (or any starter that is not API-first), you get a default fallback behavior with the _Loco welcome screen_. This is a development-only mode where a `404` request shows you a nice and friendly page that tells you what happened and what to do next. This also takes preference over the static handler, so make sure to disable it if you want to have static content served.
 
 
 You can disable or customize this behavior in your `development.yaml` file. You can set a few options:

--- a/docs-site/content/docs/the-app/views.md
+++ b/docs-site/content/docs/the-app/views.md
@@ -230,6 +230,13 @@ In your templates you can refer to static resources in this way:
 <img src="/static/image.png"/>
 ```
 
+However, for the static middleware to work, ensure that the default fallback is disabled:
+
+```yaml
+fallback:
+  enable: false
+```
+
 
 ### Customizing the Tera view engine
 


### PR DESCRIPTION
Added some (hopefully) useful documentation for disabling the fallback page. As of version 0.14.0 the static handler does not take priority over the fallback handler, so the static handler is useless if the fallback is enabled. This relates to issue https://github.com/loco-rs/loco/issues/1175

Please treat this PR as a suggestion and do with it what you will :)