### PR TITLE
update playground.rs to align with docs [chore]

### DIFF
--- a/loco-new/base_template/examples/playground.rs.t
+++ b/loco-new/base_template/examples/playground.rs.t
@@ -6,7 +6,7 @@ use {{settings.module_name}}::app::App;
 async fn main() -> loco_rs::Result<()> {
     let _ctx = playground::<App>().await?;
 
-    // let active_model: articles::ActiveModel = ActiveModel {
+    // let active_model: articles::ActiveModel = articles::ActiveModel {
     //     title: Set(Some("how to build apps in 3 steps".to_string())),
     //     content: Set(Some("use Loco: https://loco.rs".to_string())),
     //     ..Default::default()


### PR DESCRIPTION
Fix bug

```
error[E0422]: cannot find struct, variant or union type `ActiveModel` in this scope
  --> examples/playground.rs:10:47
   |
10 |     let active_model: articles::ActiveModel = ActiveModel {
   |                                               ^^^^^^^^^^^ not found in this scope
   |
help: consider importing one of these structs
   |
1  + use crate::articles::ActiveModel;
   |
1  + use loco_rs::tests_cfg::db::test_db::ActiveModel;
   |
1  + use myapp_docs_demo::models::articles::ActiveModel;
   |
1  + use myapp_docs_demo::models::users::ActiveModel;
   |

For more information about this error, try `rustc --explain E0422`.
error: could not compile `myapp` (example "playground") due to 1 previous error
```