### PR TITLE
test: bgworker parallel database

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,4 +210,5 @@ sqlx = { version = "0.8.2", default-features = false, features = [
     "postgres",
     "chrono",
     "sqlite",
+    "migrate",
 ] }


### PR DESCRIPTION
related #1121

after this and #1093 is merged, serial_test can be removed from `./Cargo.toml`
## before 
```
/loco/ > cargo nextest run --all-features --test-threads 1 bgworker::pg
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.15s
────────────
 Nextest run ID 8f912c7d-d8e4-4cac-bc6e-e6bc0a891059 with nextest profile: default
    Starting 13 tests across 2 binaries (219 tests skipped)
        PASS [   0.061s] loco-rs bgworker::pg::tests::can_cancel_job_by_name
        PASS [   0.056s] loco-rs bgworker::pg::tests::can_clear
        PASS [   0.054s] loco-rs bgworker::pg::tests::can_clear_by_status
        PASS [   0.047s] loco-rs bgworker::pg::tests::can_clear_jobs_older_than
        PASS [   0.047s] loco-rs bgworker::pg::tests::can_clear_jobs_older_than_with_status
        PASS [   1.094s] loco-rs bgworker::pg::tests::can_complete_job_with_interval
        PASS [   0.067s] loco-rs bgworker::pg::tests::can_complete_job_without_interval
        PASS [   1.073s] loco-rs bgworker::pg::tests::can_dequeue
        PASS [   0.069s] loco-rs bgworker::pg::tests::can_enqueue
        PASS [   1.101s] loco-rs bgworker::pg::tests::can_fail_job
        PASS [   0.069s] loco-rs bgworker::pg::tests::can_get_jobs
        PASS [   0.048s] loco-rs bgworker::pg::tests::can_get_jobs_with_age
        PASS [   0.064s] loco-rs bgworker::pg::tests::can_initialize_database
────────────
     Summary [   3.855s] 13 tests run: 13 passed, 219 skipped
```
## after 
```
/loco/ > cargo nextest run --all-features bgworker::pg
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.14s
────────────
 Nextest run ID 54338aa3-eebf-4b38-bf82-91d8cfd393c8 with nextest profile: default
    Starting 13 tests across 2 binaries (219 tests skipped)
        PASS [   0.354s] loco-rs bgworker::pg::tests::can_get_jobs
        PASS [   0.374s] loco-rs bgworker::pg::tests::can_cancel_job_by_name
        PASS [   0.381s] loco-rs bgworker::pg::tests::can_complete_job_without_interval
        PASS [   0.381s] loco-rs bgworker::pg::tests::can_enqueue
        PASS [   0.382s] loco-rs bgworker::pg::tests::can_clear_jobs_older_than
        PASS [   0.379s] loco-rs bgworker::pg::tests::can_get_jobs_with_age
        PASS [   0.383s] loco-rs bgworker::pg::tests::can_clear
        PASS [   0.383s] loco-rs bgworker::pg::tests::can_clear_jobs_older_than_with_status
        PASS [   0.383s] loco-rs bgworker::pg::tests::can_initialize_database
        PASS [   0.387s] loco-rs bgworker::pg::tests::can_clear_by_status
        PASS [   1.319s] loco-rs bgworker::pg::tests::can_fail_job
        PASS [   1.323s] loco-rs bgworker::pg::tests::can_dequeue
        PASS [   1.324s] loco-rs bgworker::pg::tests::can_complete_job_with_interval
────────────
     Summary [   1.324s] 13 tests run: 13 passed, 219 skipped
```