### PR TITLE
chore: improve readability and performance by using  map_err in ModelResult usages

### DIFF
--- a/loco-new/base_template/src/models/users.rs
+++ b/loco-new/base_template/src/models/users.rs
@@ -260,7 +260,9 @@ impl Model {
     ///
     /// when could not convert user claims to jwt token
     pub fn generate_jwt(&self, secret: &str, expiration: u64) -> ModelResult<String> {
-        Ok(jwt::JWT::new(secret).generate_token(expiration, self.pid.to_string(), Map::new())?)
+        jwt::JWT::new(secret)
+            .generate_token(expiration, self.pid.to_string(), Map::new())
+            .map_err(ModelError::from)
     }
 }
 
@@ -280,7 +282,7 @@ impl ActiveModel {
     ) -> ModelResult<Model> {
         self.email_verification_sent_at = ActiveValue::set(Some(Local::now().into()));
         self.email_verification_token = ActiveValue::Set(Some(Uuid::new_v4().to_string()));
-        Ok(self.update(db).await?)
+        self.update(db).await.map_err(ModelError::from)
     }
 
     /// Sets the information for a reset password request,
@@ -298,7 +300,7 @@ impl ActiveModel {
     pub async fn set_forgot_password_sent(mut self, db: &DatabaseConnection) -> ModelResult<Model> {
         self.reset_sent_at = ActiveValue::set(Some(Local::now().into()));
         self.reset_token = ActiveValue::Set(Some(Uuid::new_v4().to_string()));
-        Ok(self.update(db).await?)
+        self.update(db).await.map_err(ModelError::from)
     }
 
     /// Records the verification time when a user verifies their
@@ -312,7 +314,7 @@ impl ActiveModel {
     /// when has DB query error
     pub async fn verified(mut self, db: &DatabaseConnection) -> ModelResult<Model> {
         self.email_verified_at = ActiveValue::set(Some(Local::now().into()));
-        Ok(self.update(db).await?)
+        self.update(db).await.map_err(ModelError::from)
     }
 
     /// Resets the current user password with a new password and
@@ -333,7 +335,7 @@ impl ActiveModel {
             ActiveValue::set(hash::hash_password(password).map_err(|e| ModelError::Any(e.into()))?);
         self.reset_token = ActiveValue::Set(None);
         self.reset_sent_at = ActiveValue::Set(None);
-        Ok(self.update(db).await?)
+        self.update(db).await.map_err(ModelError::from)
     }
 
     /// Creates a magic link token for passwordless authentication.
@@ -349,7 +351,7 @@ impl ActiveModel {
 
         self.magic_link_token = ActiveValue::set(Some(random_str));
         self.magic_link_expiration = ActiveValue::set(Some(expired.into()));
-        Ok(self.update(db).await?)
+        self.update(db).await.map_err(ModelError::from)
     }
 
     /// Verifies and invalidates the magic link after successful authentication.
@@ -362,6 +364,6 @@ impl ActiveModel {
     pub async fn clear_magic_link(mut self, db: &DatabaseConnection) -> ModelResult<Model> {
         self.magic_link_token = ActiveValue::set(None);
         self.magic_link_expiration = ActiveValue::set(None);
-        Ok(self.update(db).await?)
+        self.update(db).await.map_err(ModelError::from)
     }
 }


### PR DESCRIPTION
* improve readability and performance by using direct mapping to ModelError instead of using branching operator