### PR TITLE
Add "endpoint" arg to azure storage builder

### DIFF
--- a/src/storage/drivers/azure.rs
+++ b/src/storage/drivers/azure.rs
@@ -8,7 +8,7 @@ use crate::storage::{drivers::opendal_adapter::OpendalAdapter, StorageResult};
 /// # Examples
 ///```
 /// use loco_rs::storage::drivers::azure;
-/// let azure_driver = azure::new("name", "account_name", "access_key");
+/// let azure_driver = azure::new("name", "account_name", "access_key", "endpoint");
 /// ```
 ///
 /// # Errors
@@ -18,11 +18,13 @@ pub fn new(
     container_name: &str,
     account_name: &str,
     access_key: &str,
+    endpoint: &str,
 ) -> StorageResult<Box<dyn StoreDriver>> {
     let azure = Azblob::default()
         .container(container_name)
         .account_name(account_name)
-        .account_key(access_key);
+        .account_key(access_key)
+        .endpoint(endpoint);
 
     Ok(Box::new(OpendalAdapter::new(
         Operator::new(azure)?.finish(),


### PR DESCRIPTION
I was encountering the following bug when initialising the azure storage driver at `src/storage/drivers/azure.rs`

```sh
Error: Storage(Store(ConfigInvalid (permanent) at Builder::build => endpoint is empty

Context:
   service: azblob
```

Looking at the [opendal example](https://docs.rs/opendal/latest/opendal/services/struct.Azblob.html), I think we're missing the endpoint argument/build step.

This PR adds the endpoint argument.