### PR TITLE
Allow testing the endpoint by passing a cookie

### DIFF
--- a/src/testing/request.rs
+++ b/src/testing/request.rs
@@ -47,6 +47,89 @@ impl Drop for BootResultWrapper {
     }
 }
 
+/// Configuration for making requests in the test server.
+pub struct RequestConfig {
+    /// Determines whether cookies should be saved for future requests.
+    pub save_cookies: bool,
+    /// The default content type for all requests.
+    pub default_content_type: Option<String>,
+    /// The default scheme to use for requests (e.g., "http" or "https").
+    pub default_scheme: String,
+}
+
+impl Default for RequestConfig {
+    fn default() -> Self {
+        RequestConfigBuilder::new().build()
+    }
+}
+
+/// Builder pattern for constructing [`RequestConfig`] instances.
+pub struct RequestConfigBuilder {
+    save_cookies: bool,
+    default_content_type: Option<String>,
+    default_scheme: String,
+}
+
+impl RequestConfigBuilder {
+    /// Creates a new [`RequestConfigBuilder`] with default values.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            save_cookies: false,
+            default_content_type: Some("application/json".to_string()),
+            default_scheme: "http".to_string(),
+        }
+    }
+
+    /// Sets whether cookies should be saved for future requests.
+    #[must_use]
+    pub fn save_cookies(mut self, save: bool) -> Self {
+        self.save_cookies = save;
+        self
+    }
+
+    /// Sets the default content type for requests.
+    #[must_use]
+    pub fn default_content_type<S: Into<String>>(mut self, content_type: S) -> Self {
+        self.default_content_type = Some(content_type.into());
+        self
+    }
+
+    /// Sets the default scheme to use for requests.
+    #[must_use]
+    pub fn default_scheme<S: Into<String>>(mut self, scheme: S) -> Self {
+        self.default_scheme = scheme.into();
+        self
+    }
+
+    /// Builds and returns a `RequestConfig` instance.
+    #[must_use]
+    pub fn build(self) -> RequestConfig {
+        RequestConfig {
+            save_cookies: self.save_cookies,
+            default_content_type: self.default_content_type,
+            default_scheme: self.default_scheme,
+        }
+    }
+}
+
+impl Default for RequestConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// Implement the From trait for automatic conversion
+impl From<RequestConfig> for TestServerConfig {
+    fn from(request_config: RequestConfig) -> Self {
+        Self {
+            default_content_type: request_config.default_content_type,
+            save_cookies: request_config.save_cookies,
+            ..Default::default()
+        }
+    }
+}
+
 /// Bootstraps test application with test environment hard coded.
 ///
 /// # Example
@@ -109,20 +192,15 @@ pub async fn boot_test_with_create_db<H: Hooks>() -> Result<BootResultWrapper> {
 }
 
 #[allow(clippy::future_not_send)]
-async fn request_internal<F, Fut>(callback: F, boot: &BootResult)
+async fn request_internal<F, Fut>(callback: F, boot: &BootResult, test_server_config: RequestConfig)
 where
     F: FnOnce(TestServer, AppContext) -> Fut,
     Fut: std::future::Future<Output = ()>,
 {
-    let config = TestServerConfig {
-        default_content_type: Some("application/json".to_string()),
-        ..Default::default()
-    };
-
     let routes = boot.router.clone().unwrap();
     let server = TestServer::new_with_config(
         routes.into_make_service_with_connect_info::<SocketAddr>(),
-        config,
+        test_server_config,
     )
     .unwrap();
 
@@ -162,10 +240,8 @@ where
     F: FnOnce(TestServer, AppContext) -> Fut,
     Fut: std::future::Future<Output = ()>,
 {
-    let boot: BootResult = boot_test::<H>().await.unwrap();
-    request_internal::<F, Fut>(callback, &boot).await;
+    request_with_config::<H, F, Fut>(RequestConfig::default(), callback).await;
 }
-
 /// Executes a test server request with a created database using the provided callback.
 ///
 /// This function will boot the test environment and create a new database for the test.
@@ -193,6 +269,57 @@ where
     F: FnOnce(TestServer, AppContext) -> Fut,
     Fut: std::future::Future<Output = ()>,
 {
+    request_config_with_create_db::<H, F, Fut>(RequestConfig::default(), callback).await;
+}
+
+/// Executes a test server request using a custom [`RequestConfig`].
+///
+/// This function will boot the test environment without creating a new database.
+/// It takes a `config` parameter to customize request settings and a `callback`
+/// function that is called with the test server and application context.
+///
+/// # Panics
+/// When the test request cannot be initialized, such as when the test app fails to start.
+///
+/// # Example
+/// ```rust,ignore
+/// let config = RequestConfigBuilder::new().save_cookies(true).build();
+/// request_with_config::<App, _, _>(config, |request, ctx| async move {
+///     let response = request.get("/endpoint").await;
+/// });
+/// ```
+pub async fn request_with_config<H: Hooks, F, Fut>(config: RequestConfig, callback: F)
+where
+    F: FnOnce(TestServer, AppContext) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    let boot: BootResult = boot_test::<H>().await.unwrap();
+    request_internal::<F, Fut>(callback, &boot, config).await;
+}
+
+/// Executes a test server request with a created database using a custom [`RequestConfig`].
+///
+/// This function initializes the test environment, sets up a fresh database, and then runs
+/// the provided callback function with the test server and application context.
+/// The test database will be cleaned up after the test completes.
+///
+/// # Panics
+/// When the test request cannot be initialized, such as when the test app fails to start.
+///
+/// # Example
+/// ```rust,ignore
+/// let config = RequestConfigBuilder::new().save_cookies(true).build();
+/// request_config_with_create_db::<App, _, _>(config, |request, ctx| async move {
+///     let response = request.get("/endpoint").await;
+/// });
+/// ```
+#[allow(clippy::future_not_send)]
+#[cfg(feature = "with-db")]
+pub async fn request_config_with_create_db<H: Hooks, F, Fut>(config: RequestConfig, callback: F)
+where
+    F: FnOnce(TestServer, AppContext) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
     let boot_wrapper: BootResultWrapper = boot_test_with_create_db::<H>().await.unwrap();
-    request_internal::<F, Fut>(callback, &boot_wrapper.inner).await;
+    request_internal::<F, Fut>(callback, &boot_wrapper.inner, config).await;
 }


### PR DESCRIPTION
The testing reqeust is designed for testing REST API controllers but does not currently support passing cookies. This PR supports users to test endpoints that require authentication via cookies.
Example: 
Auth register controller:
```rust
#[debug_handler]
async fn login(State(ctx): State<AppContext>, Json(params): Json<LoginParams>) -> Result<Response> {
    let user = users::Model::find_by_email(&ctx.db, &params.email).await?;
    let valid = user.verify_password(&params.password);
    if !valid {
        return unauthorized("unauthorized!");
    }

    let jwt_secret = ctx.config.get_jwt_config()?;

    let token = user
        .generate_jwt(&jwt_secret.secret, jwt_secret.expiration)
        .or_else(|_| unauthorized("unauthorized!"))?;

    format::render()
        .cookies(&[cookie::Cookie::new("token", &token)])?
        .etag("foobar")?
        .json(LoginResponse::new(&user, &token))

    // format::json(LoginResponse::new(&user, &token))
}
```

This controller returns the token in the cookie response. 

Then in test you can now append the cookies to the next requests:
```rust
#[tokio::test]
#[serial]
async fn can_get_game() {
    configure_insta!();

    let config = RequestConfigBuilder::new().save_cookies(true).build();

    request_with_config::<App, _, _>(config, |request, ctx| async move {
      .....
   })
    .await;

}
```