### PR TITLE
docs: Upgrade guide for #1268

### DIFF
--- a/docs-site/content/docs/extras/upgrades.md
+++ b/docs-site/content/docs/extras/upgrades.md
@@ -162,3 +162,23 @@ The pagination response now includes the `total_items` field, providing the tota
 ```JSON
 {"results":[],"pagination":{"page":0,"page_size":0,"total_pages":0,"total_items":0}}
 ```
+
+### Explicit id in migrations
+
+PR: [#1268](https://github.com/loco-rs/loco/pull/1268)
+
+Migrations using `create_table` now require `("id", ColType::PkAuto)`, new migrations will have this field automatically added.
+
+```diff
+  async fn up(&self, m: &SchemaManager) -> Result<(), DbErr> {
+        create_table(m, "movies",
+            &[
++           ("id", ColType::PkAuto),
+            ("title", ColType::StringNull),
+            ],
+            &[
+            ("user", ""),
+            ]
+        ).await
+    }
+```


### PR DESCRIPTION
closes #1332
```
thread 'requests::auth::can_reset_password' panicked at /.cargo/git/checkouts/loco-e6151e5acfeb4e84/b1414a4/src/testing/request.rs:196:81:
called `Result::unwrap()` on an `Err` value: Message("Execution Error: error returned from database: column \"id\" referenced in foreign key constraint does not exist")
```