### PR TITLE
test: remove serial_test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,7 +206,6 @@ rstest = "0.21.0"
 insta = { version = "1.34.0", features = ["redactions", "yaml", "filters"] }
 tree-fs = { version = "0.2.1" }
 reqwest = { version = "0.12.7" }
-serial_test = "3.1.1"
 tower = { workspace = true, features = ["util"] }
 sqlx = { version = "0.8.2", default-features = false, features = [
     "macros",

--- a/tests/controller/validation_extractor.rs
+++ b/tests/controller/validation_extractor.rs
@@ -1,6 +1,5 @@
 use loco_rs::{prelude::*, tests_cfg};
 use serde::{Deserialize, Serialize};
-use serial_test::serial;
 use validator::Validate;
 
 use crate::infra_cfg;
@@ -24,7 +23,6 @@ async fn simple_validation(JsonValidate(_params): JsonValidate<Data>) -> Result<
 }
 
 #[tokio::test]
-#[serial]
 async fn can_validation_with_response() {
     let ctx = tests_cfg::app::get_app_context().await;
 
@@ -60,7 +58,6 @@ async fn can_validation_with_response() {
 }
 
 #[tokio::test]
-#[serial]
 async fn can_validation_without_response() {
     let ctx = tests_cfg::app::get_app_context().await;
 


### PR DESCRIPTION
since #1204 and #1093 was merged, serial_test can be removed from ./Cargo.toml