### PR TITLE
don't return 401 for system errors in auth checks

### DIFF
--- a/docs-site/content/docs/extras/upgrades.md
+++ b/docs-site/content/docs/extras/upgrades.md
@@ -168,6 +168,20 @@ struct MyType {
 }
 ```
 
+### Authentication Error Handling
+
+Authentication error handling has been improved to better distinguish between actual authorization failures and system errors:
+
+1. **System errors now return 500**: Database errors during authentication now return Internal Server Error (500) instead of Unauthorized (401)
+2. **Improved error logging**: Authentication errors are now logged with detailed messages using `tracing::error`
+3. **Message changes**: Generic error messages have been updated from "other error: '{e}'" to "could not authorize"
+
+#### Migration Guide:
+
+If you have code that relies on database errors during authentication returning 401 status codes, you'll need to update your error handling. Any code expecting a 401 for database connectivity issues should now handle 500 responses as well.
+
+Client applications should be prepared to handle both 401 and 500 status codes during authentication failures, with 401 indicating authorization problems and 500 indicating system errors.
+
 ## Upgrade from 0.14.x to 0.15.x
 
 ### Upgrade validator crate

--- a/src/controller/extractor/auth.rs
+++ b/src/controller/extractor/auth.rs
@@ -81,7 +81,7 @@ where
                                 Error::Unauthorized("not found".to_string())
                             }
                             ModelError::DbErr(_) => Error::InternalServerError, // don't show 401 for system errors
-                            _ => Error::Unauthorized(format!("other error: '{}'", e)),
+                            _ => Error::Unauthorized(format!("other error: '{e}'")),
                         }
                     })?;
                 Ok(Self {
@@ -243,7 +243,7 @@ where
             match e {
                 ModelError::EntityNotFound => Error::Unauthorized("not found".to_string()),
                 ModelError::DbErr(_) => Error::InternalServerError, // don't show 401 for system errors
-                _ => Error::Unauthorized(format!("other error: '{}'", e)),
+                _ => Error::Unauthorized(format!("other error: '{e}'")),
             }
         })?;
 


### PR DESCRIPTION
If you hammer the database with requests, you sometimes get a ConnectionPool error. In that case, we should return 500 and not 401.

In my client, I forced a log-out and redirect to sign-in when I got a 401, that's how I found this problem.

Not 100% sure about the text of the error messages. Feel free to change those a bit :)