### PR TITLE
Add very permissive CORS setting

### DIFF
--- a/src/controller/middleware/cors.rs
+++ b/src/controller/middleware/cors.rs
@@ -33,9 +33,13 @@ pub struct Cors {
     pub allow_credentials: bool,
     /// Max age
     pub max_age: Option<u64>,
-    // Vary headers
+    /// Vary headers
     #[serde(default = "default_vary_headers")]
     pub vary: Vec<String>,
+    /// Very permissive policy that allows all origins, headers, and methods and can be used with credentials.
+    /// This policy is not recommended for production.
+    #[serde(default)]
+    pub permissive: bool,
 }
 
 fn default_allow_origins() -> Vec<String> {
@@ -131,11 +135,15 @@ impl Cors {
             cors = cors.vary(list);
         }
 
+        cors = cors.allow_credentials(self.allow_credentials);
+
+        if self.permissive {
+            cors = cors::CorsLayer::very_permissive();
+        }
+
         if let Some(max_age) = self.max_age {
             cors = cors.max_age(Duration::from_secs(max_age));
         }
-
-        cors = cors.allow_credentials(self.allow_credentials);
 
         Ok(cors)
     }

--- a/src/controller/middleware/cors.rs
+++ b/src/controller/middleware/cors.rs
@@ -133,19 +133,19 @@ impl Cors {
             }
         }
 
+        cors = cors.allow_credentials(self.allow_credentials);
+
+        if self.very_permissive {
+            warn!("Very permissive CORS policy is enabled, effectively bypassing CORS for all requests. (This is not recommended for production. disable with `server.middlewares.cors.very_permissive` in your config yaml)");
+            cors = cors::CorsLayer::very_permissive();
+        }
+
         let mut list = vec![];
         for v in &self.vary {
             list.push(v.parse()?);
         }
         if !list.is_empty() {
             cors = cors.vary(list);
-        }
-
-        cors = cors.allow_credentials(self.allow_credentials);
-
-        if self.very_permissive {
-            warn!("Very permissive CORS policy is enabled, effectively bypassing CORS for all requests. (This is not recommended for production. disable with `server.middlewares.cors.very_permissive` in your config yaml)");
-            cors = cors::CorsLayer::very_permissive();
         }
 
         if let Some(max_age) = self.max_age {


### PR DESCRIPTION
This PR adds a `permissive` configuration option for the `cors` middleware that essentially disables CORS by mirroring the headers sent in the request. This is useful in testing or with ephemeral/non-prod deployments.

https://docs.rs/tower-http/latest/tower_http/cors/struct.CorsLayer.html#method.very_permissive

```
cors:
  enable: true
  permissive: true
  max_age: 3600
```

Open to naming suggestions as well.  Fixes #1357 .