### PR TITLE
Cancellation tokens for other 2 bg workers

### DIFF
--- a/src/bgworker/mod.rs
+++ b/src/bgworker/mod.rs
@@ -75,6 +75,7 @@ pub enum Queue {
         pg::PgPool,
         std::sync::Arc<tokio::sync::Mutex<pg::JobRegistry>>,
         pg::RunOpts,
+        tokio_util::sync::CancellationToken,
     ),
     #[cfg(feature = "bg_sqlt")]
     Sqlite(
@@ -105,7 +106,7 @@ impl Queue {
                 skq::enqueue(pool, class, queue, args).await?;
             }
             #[cfg(feature = "bg_pg")]
-            Self::Postgres(pool, _, _) => {
+            Self::Postgres(pool, _, _, _) => {
                 pg::enqueue(
                     pool,
                     &class,
@@ -154,7 +155,7 @@ impl Queue {
                 p.register(skq::SidekiqBackgroundWorker::new(worker));
             }
             #[cfg(feature = "bg_pg")]
-            Self::Postgres(_, registry, _) => {
+            Self::Postgres(_, registry, _, _) => {
                 let mut r = registry.lock().await;
                 r.register_worker(W::class_name(), worker)?;
             }
@@ -181,12 +182,22 @@ impl Queue {
                 p.lock().await.clone().run().await;
             }
             #[cfg(feature = "bg_pg")]
-            Self::Postgres(pool, registry, run_opts) => {
+            Self::Postgres(pool, registry, run_opts, token) => {
                 //TODOQ: num workers to config
-                let handles = registry.lock().await.run(pool, run_opts);
+                let handles = registry.lock().await.run(pool, run_opts, &token.clone());
                 for handle in handles {
-                    handle.await?;
+                    if let Err(e) = handle.await {
+                        if e.is_cancelled() {
+                            tracing::debug!("Worker task cancelled during shutdown.");
+                        } else if e.is_panic() {
+                            std::panic::resume_unwind(e.into_panic());
+                        } else {
+                            tracing::error!("Worker task failed to join: {:?}", e);
+                            return Err(crate::Error::Worker(format!("Worker join error: {e}")));
+                        }
+                    }
                 }
+                tracing::debug!("all pg worker tasks finished");
             }
             #[cfg(feature = "bg_sqlt")]
             Self::Sqlite(pool, registry, run_opts) => {
@@ -217,7 +228,7 @@ impl Queue {
             #[cfg(feature = "bg_redis")]
             Self::Redis(_, _, _) => {}
             #[cfg(feature = "bg_pg")]
-            Self::Postgres(pool, _, _) => {
+            Self::Postgres(pool, _, _, _) => {
                 pg::initialize_database(pool).await.map_err(Box::from)?;
             }
             #[cfg(feature = "bg_sqlt")]
@@ -242,7 +253,7 @@ impl Queue {
                 skq::clear(pool).await?;
             }
             #[cfg(feature = "bg_pg")]
-            Self::Postgres(pool, _, _) => {
+            Self::Postgres(pool, _, _, _) => {
                 pg::clear(pool).await.map_err(Box::from)?;
             }
             #[cfg(feature = "bg_sqlt")]
@@ -267,7 +278,7 @@ impl Queue {
                 skq::ping(pool).await?;
             }
             #[cfg(feature = "bg_pg")]
-            Self::Postgres(pool, _, _) => {
+            Self::Postgres(pool, _, _, _) => {
                 pg::ping(pool).await.map_err(Box::from)?;
             }
             #[cfg(feature = "bg_sqlt")]
@@ -285,7 +296,7 @@ impl Queue {
             #[cfg(feature = "bg_redis")]
             Self::Redis(_, _, _) => "redis queue".to_string(),
             #[cfg(feature = "bg_pg")]
-            Self::Postgres(_, _, _) => "postgres queue".to_string(),
+            Self::Postgres(_, _, _, _) => "postgres queue".to_string(),
             #[cfg(feature = "bg_sqlt")]
             Self::Sqlite(_, _, _) => "sqlite queue".to_string(),
             _ => "no queue".to_string(),
@@ -301,6 +312,8 @@ impl Queue {
         match self {
             #[cfg(feature = "bg_redis")]
             Self::Redis(_, _, cancellation_token) => cancellation_token.cancel(),
+            #[cfg(feature = "bg_pg")]
+            Self::Postgres(_, _, _, cancellation_token) => cancellation_token.cancel(),
             _ => {}
         }
 
@@ -315,7 +328,7 @@ impl Queue {
         tracing::debug!(status = ?status, age_days = ?age_days, "getting jobs");
         match self {
             #[cfg(feature = "bg_pg")]
-            Self::Postgres(pool, _, _) => {
+            Self::Postgres(pool, _, _, _) => {
                 let jobs = pg::get_jobs(pool, status, age_days)
                     .await
                     .map_err(Box::from)?;
@@ -358,7 +371,7 @@ impl Queue {
 
         match self {
             #[cfg(feature = "bg_pg")]
-            Self::Postgres(pool, _, _) => pg::cancel_jobs_by_name(pool, job_name).await,
+            Self::Postgres(pool, _, _, _) => pg::cancel_jobs_by_name(pool, job_name).await,
             #[cfg(feature = "bg_sqlt")]
             Self::Sqlite(pool, _, _) => sqlt::cancel_jobs_by_name(pool, job_name).await,
             #[cfg(feature = "bg_redis")]
@@ -394,7 +407,7 @@ impl Queue {
 
         match self {
             #[cfg(feature = "bg_pg")]
-            Self::Postgres(pool, _, _) => {
+            Self::Postgres(pool, _, _, _) => {
                 pg::clear_jobs_older_than(pool, age_days, Some(status)).await
             }
             #[cfg(feature = "bg_sqlt")]
@@ -426,7 +439,7 @@ impl Queue {
         tracing::debug!(status = ?status, "clear jobs by status");
         match self {
             #[cfg(feature = "bg_pg")]
-            Self::Postgres(pool, _, _) => pg::clear_by_status(pool, status).await,
+            Self::Postgres(pool, _, _, _) => pg::clear_by_status(pool, status).await,
             #[cfg(feature = "bg_sqlt")]
             Self::Sqlite(pool, _, _) => sqlt::clear_by_status(pool, status).await,
             #[cfg(feature = "bg_redis")]
@@ -454,7 +467,7 @@ impl Queue {
         tracing::debug!(age_minutes = age_minutes, "requeue jobs");
         match self {
             #[cfg(feature = "bg_pg")]
-            Self::Postgres(pool, _, _) => pg::requeue(pool, age_minutes).await,
+            Self::Postgres(pool, _, _, _) => pg::requeue(pool, age_minutes).await,
             #[cfg(feature = "bg_sqlt")]
             Self::Sqlite(pool, _, _) => sqlt::requeue(pool, age_minutes).await,
             #[cfg(feature = "bg_redis")]
@@ -525,7 +538,7 @@ impl Queue {
 
         match &self {
             #[cfg(feature = "bg_pg")]
-            Self::Postgres(_, _, _) => {
+            Self::Postgres(_, _, _, _) => {
                 let jobs: Vec<pg::Job> = serde_yaml::from_reader(File::open(path)?)?;
                 for job in jobs {
                     self.enqueue(job.name.to_string(), None, job.data).await?;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -77,6 +77,9 @@ pub enum Error {
     #[error("Error sending email (smtp): '{0}'")]
     Smtp(#[from] smtp::Error),
 
+    #[error("Worker error: {0}")]
+    Worker(String),
+
     #[error(transparent)]
     IO(#[from] std::io::Error),
 


### PR DESCRIPTION
I've implemented cancellation tokens for the other two worker types. I'm using the pg worker myself and always had `waiting for running jobs to finish` even when the queue was empty. This solves it.

Please note that I have not tested this extensively, if you need that before merging, let me know and I will just include the pg worker for now and make sure I've tested several scenarios.