### PR TITLE
feat: add blog rss feed

### DIFF
--- a/docs-site/config.toml
+++ b/docs-site/config.toml
@@ -10,6 +10,8 @@ compile_sass = true
 # Whether to generate a feed file for the site
 generate_feeds = true
 
+feed_filenames = ["blog/atom.xml", "blog/rss.xml"]
+
 # When set to "true", the generated HTML files are minified.
 minify_html = false
 

--- a/docs-site/templates/blog/atom.xml
+++ b/docs-site/templates/blog/atom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="{{ lang }}">
+    <title>{{ config.title }}
+    {%- if term %} - {{ term.name }}
+    {%- elif section.title %} - {{ section.title }}
+    {%- endif -%}
+    </title>
+    {%- if config.description %}
+    <subtitle>{{ config.description }}</subtitle>
+    {%- endif %}
+    <link rel="self" type="application/atom+xml" href="{{ feed_url | safe }}"/>
+    <link rel="alternate" type="text/html" href="
+      {%- if section -%}
+        {{ section.permalink | escape_xml | safe }}
+      {%- else -%}
+        {{ config.base_url | escape_xml | safe }}
+      {%- endif -%}
+    "/>
+    <generator uri="https://www.getzola.org/">Zola</generator>
+    <updated>{{ last_updated | date(format="%+") }}</updated>
+    <id>{{ feed_url | safe }}</id>
+    {%- for page in pages %}
+    {% if page.permalink is starting_with("https://loco.rs/blog/") or page.permalink is starting_with("http://127.0.0.1:1111/blog/") %}
+    <entry xml:lang="{{ page.lang }}">
+        <title>{{ page.title }}</title>
+        <published>{{ page.date | date(format="%+") }}</published>
+        <updated>{{ page.updated | default(value=page.date) | date(format="%+") }}</updated>
+        {% for author in page.authors %}
+        <author>
+          <name>
+            {{ author }}
+          </name>
+        </author>
+        {% else %}
+        <author>
+          <name>
+            {%- if config.author -%}
+              {{ config.author }}
+            {%- else -%}
+              Unknown
+            {%- endif -%}
+          </name>
+        </author>
+        {% endfor %}
+        <link rel="alternate" type="text/html" href="{{ page.permalink | safe }}"/>
+        <id>{{ page.permalink | safe }}</id>
+        {% if page.summary %}
+        <summary type="html">{{ page.summary }}</summary>
+        {% else %}
+        <content type="html" xml:base="{{ page.permalink | escape_xml | safe }}">{{ page.content }}</content>
+        {% endif %}
+    </entry>
+    {%- endif -%}
+    {%- endfor %}
+</feed>

--- a/docs-site/templates/blog/rss.xml
+++ b/docs-site/templates/blog/rss.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+    <channel>
+      <title>{{ config.title }}
+        {%- if term %} - {{ term.name }}
+        {%- elif section.title %} - {{ section.title }}
+        {%- endif -%}
+      </title>
+      <link>
+        {%- if section -%}
+          {{ section.permalink | escape_xml | safe }}
+        {%- else -%}
+          {{ config.base_url | escape_xml | safe }}
+        {%- endif -%}
+      </link>
+      <description>{{ config.description }}</description>
+      <generator>Zola</generator>
+      <language>{{ lang }}</language>
+      <atom:link href="{{ feed_url | safe }}" rel="self" type="application/rss+xml"/>
+      <lastBuildDate>{{ last_updated | date(format="%a, %d %b %Y %H:%M:%S %z") }}</lastBuildDate>
+      {%- for page in pages %}
+      {% if page.permalink is starting_with("https://loco.rs/blog/") or page.permalink is starting_with("http://127.0.0.1:1111/blog/") %}
+      <item>
+          <title>{{ page.title }}</title>
+          <pubDate>{{ page.date | date(format="%a, %d %b %Y %H:%M:%S %z") }}</pubDate>
+          <author>
+            {%- if page.authors -%}
+              {{ page.authors[0] }}
+            {%- elif config.author -%}
+              {{ config.author }}
+            {%- else -%}
+              Unknown
+            {%- endif -%}
+          </author>
+          <link>{{ page.permalink | escape_xml | safe }}</link>
+          <guid>{{ page.permalink | escape_xml | safe }}</guid>
+          <description xml:base="{{ page.permalink | escape_xml | safe }}">{% if page.summary %}{{ page.summary }}{% else %}{{ page.content }}{% endif %}</description>
+      </item>
+      {%- endif -%}
+      {%- endfor %}
+    </channel>
+</rss>


### PR DESCRIPTION
- closes #1392

This PR adds `/blog/atom.xml` (Atom 1.0 format) and `/blog/rss.xml` (RSS 2.0 format). The code was mostly copied from zola's [`atom.xml template`](https://github.com/getzola/zola/blob/459d95acd418fd94f8c25e3aa984b8e7c93428c9/components/templates/src/builtins/atom.xml) and [`rss.xml template`](https://github.com/getzola/zola/blob/459d95acd418fd94f8c25e3aa984b8e7c93428c9/components/templates/src/builtins/rss.xml).