### PR TITLE
Added Di Container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Adding cache redis driver + configuration instead of enabling from code. [https://github.com/loco-rs/loco/pull/1389](https://github.com/loco-rs/loco/pull/1389)
 * Ability to configure pragma for SQLite. [https://github.com/loco-rs/loco/pull/1346](https://github.com/loco-rs/loco/pull/1346)
 * Optimize worker tag filtering string handling. [https://github.com/loco-rs/loco/pull/1396](https://github.com/loco-rs/loco/pull/1396)
+* Added DiContainer to manage instances via the `AppContext`. [https://github.com/loco-rs/loco/pull/1398](https://github.com/loco-rs/loco/pull/1398)
 
 
 ## v0.15.0
@@ -47,6 +48,7 @@
 * Add data subsystem. [https://github.com/loco-rs/loco/pull/1267](https://github.com/loco-rs/loco/pull/1267)
 * Add "endpoint" arg to azure storage builder.[https://github.com/loco-rs/loco/pull/1317](https://github.com/loco-rs/loco/pull/1317)
 * Improve readability and performance by using  map_err in Model. [https://github.com/loco-rs/loco/pull/1311](https://github.com/loco-rs/loco/pull/1311)
+
 ### Breaking Changes
 In module `loco_rs::auth::jwt` in struct `JWT`, the impl method `generate_token` signature has changed. 
 Migration:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,9 @@ redis = { version = "0.24.0", features = [
 
 scraper = { version = "0.21.0", features = ["deterministic"], optional = true }
 
+# DI System
+dashmap = "6"
+
 [workspace.dependencies]
 tera = { version = "1.19.1" }
 colored = { version = "2" }

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,6 +12,7 @@ use std::{net::SocketAddr, sync::Arc};
 use async_trait::async_trait;
 use axum::Router as AxumRouter;
 
+use crate::di::DiContainer;
 use crate::{
     bgworker::{self, Queue},
     boot::{shutdown_signal, BootResult, ServeParams, StartMode},
@@ -52,6 +53,8 @@ pub struct AppContext {
     pub storage: Arc<Storage>,
     // Cache instance for the application
     pub cache: Arc<cache::Cache>,
+    // Di Container
+    pub container: Arc<DiContainer>,
 }
 
 /// A trait that defines hooks for customizing and extending the behavior of a

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -1,19 +1,20 @@
 //! # Application Bootstrapping and Logic
 //! This module contains functions and structures for bootstrapping and running
 //! your application.
+use axum::Router;
+#[cfg(feature = "with-db")]
+use sea_orm_migration::MigratorTrait;
+use std::sync::Arc;
 use std::{
     env,
     path::{Path, PathBuf},
 };
-
-use axum::Router;
-#[cfg(feature = "with-db")]
-use sea_orm_migration::MigratorTrait;
 use tokio::{select, signal, task::JoinHandle};
 use tracing::{debug, error, info, warn};
 
 #[cfg(feature = "with-db")]
 use crate::db;
+use crate::di::DiContainer;
 use crate::{
     app::{AppContext, Hooks, Initializer},
     banner::print_banner,
@@ -389,6 +390,7 @@ pub async fn create_context<H: Hooks>(
         cache: cache::create_cache_provider(&config).await?,
         config,
         mailer,
+        container: Arc::new(DiContainer::default()),
     };
 
     H::after_context(ctx).await

--- a/src/di.rs
+++ b/src/di.rs
@@ -4,74 +4,55 @@ use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
 use dashmap::DashMap;
 use std::any::{Any, TypeId};
-use std::future::Future;
 
 /// A container that contains and manages instances.
 #[derive(Default)]
 pub struct DiContainer {
-    services: DashMap<(TypeId, Option<String>), Box<dyn Any + Send + Sync>>,
+    services: DashMap<TypeId, Box<dyn Any + Send + Sync>>,
 }
 
 impl DiContainer {
-    /// Adds a service instace to the container.
+    /// Adds a service instance to the container.
     ///
     /// # Arguments
     ///
     /// * `service`: The service that should be managed by the container.
-    /// * `qualifier`: If you have multiple services from the same type you can differentiate them by supplying a qualifier.
-    pub fn add<T: Any + Send + Sync + 'static>(&self, service: T, qualifier: Option<String>) {
-        self.services
-            .insert((TypeId::of::<T>(), qualifier), Box::new(service));
+    pub fn add<T: Any + Send + Sync + 'static>(&self, service: T) {
+        self.services.insert(TypeId::of::<T>(), Box::new(service));
     }
 
     /// Gets a cloned version of the instance.
     ///
-    /// # Arguments
-    ///
-    /// * `qualifier`: An optional qualifier that helps you differentiate multiple instance of the same type.
-    ///
     /// returns: Option<T>
     #[must_use]
-    pub fn get<T: Any + Clone + Send + Sync + 'static>(
-        &self,
-        qualifier: Option<String>,
-    ) -> Option<T> {
+    pub fn get<T: Any + Clone + Send + Sync + 'static>(&self) -> Option<T> {
         self.services
-            .get(&(TypeId::of::<T>(), qualifier))
+            .get(&TypeId::of::<T>())
             .and_then(|s| s.downcast_ref::<T>().cloned())
-    }
-
-    /// Checks if the container already manages a specific service with the given qualifier.
-    ///
-    /// # Arguments
-    ///
-    /// * `qualifier`: An optional qualifier that helps you differentiate multiple instance of the same type.
-    ///
-    /// returns: bool
-    #[must_use]
-    pub fn has<T: Any + Send + Sync + 'static>(&self, qualifier: Option<String>) -> bool {
-        self.services.contains_key(&(TypeId::of::<T>(), qualifier))
     }
 
     /// Removes a service from the container and returns you the original one.
     ///
-    /// # Arguments
-    ///
-    /// * `qualifier`: An optional qualifier that helps you differentiate multiple instance of the same type.
-    ///
     /// returns: Option<T>
     #[must_use]
-    pub fn remove<T: Any + Send + Sync + 'static>(&self, qualifier: Option<String>) -> Option<T> {
+    pub fn remove<T: Any + Send + Sync + 'static>(&self) -> Option<T> {
         self.services
-            .remove(&(TypeId::of::<T>(), qualifier))
+            .remove(&TypeId::of::<T>())
             .map(|f| f.1)
             .and_then(|any| any.downcast::<T>().ok())
             .map(|boxed| *boxed)
     }
+
+    /// Checks if the container already manages a specific service with the given qualifier.
+    ///
+    /// returns: bool
+    #[must_use]
+    pub fn has<T: Any + Send + Sync + 'static>(&self) -> bool {
+        self.services.contains_key(&TypeId::of::<T>())
+    }
 }
 
 /// An extractor that streamlines the process of getting static Data from the `DiContainer`.
-/// Keep in mind that these extractors use `None` as the qualifier.
 pub struct Data<T>(pub T);
 
 impl<T> FromRequestParts<AppContext> for Data<T>
@@ -86,55 +67,11 @@ where
     ) -> Result<Self, Self::Rejection> {
         let instance = state
             .container
-            .get::<T>(None)
+            .get::<T>()
             // TODO maybe introduce custom error?
             .ok_or(Error::Message("Could not find service".to_string()))?;
 
         Ok(Self(instance))
-    }
-}
-
-/// An extractor that streamlines the process of getting a `Service` from the `DiContainer`.
-/// Keep in mind that these extractors use `None` as the qualifier.
-pub struct Injectable<T: Service>(pub T);
-
-impl<T: Service> FromRequestParts<AppContext> for Injectable<T> {
-    type Rejection = Error;
-
-    async fn from_request_parts(
-        _: &mut Parts,
-        state: &AppContext,
-    ) -> Result<Self, Self::Rejection> {
-        let instance = T::get(state).await?;
-
-        Ok(Self(instance))
-    }
-}
-
-/// Defines a service which can be given and constructed with only the `AppContext`.
-pub trait Service: Sized + Clone + Send + Sync + 'static {
-    /// Builds a new instance of the service.
-    fn build(ctx: &AppContext) -> impl Future<Output = Result<Self, Error>> + Send;
-
-    /// Gets you an instance of the service from the `DiContainer`.
-    ///
-    /// If no instance exist it will create a new one and automatically adds it to the `DiContainer`.
-    #[must_use]
-    fn get(ctx: &AppContext) -> impl Future<Output = Result<Self, Error>> + Send {
-        async {
-            match ctx.container.get::<Self>(None) {
-                None => {
-                    let instance = Self::build(ctx).await?;
-
-                    ctx.container.add(instance, None);
-
-                    // We can safely unwrap() here has there is no chance that this service is going
-                    // to be removed before that
-                    Ok(ctx.container.get(None).unwrap())
-                }
-                Some(instance) => Ok(instance),
-            }
-        }
     }
 }
 
@@ -153,204 +90,84 @@ mod tests {
     }
 
     #[test]
-    fn test_add_and_get_without_qualifier() {
+    fn test_add_and_get() {
         let container = DiContainer::default();
         let service = TestService { id: 1 };
 
-        container.add(service, None);
+        container.add(service);
 
-        let retrieved: Option<TestService> = container.get(None);
+        let retrieved: Option<TestService> = container.get();
         assert!(retrieved.is_some());
         assert_eq!(retrieved.unwrap().id, 1);
     }
 
     #[test]
-    fn test_add_and_get_with_qualifier() {
-        let container = DiContainer::default();
-        let service = TestService { id: 1 };
-
-        container.add(service, Some("test".to_string()));
-
-        let retrieved: Option<TestService> = container.get(Some("test".to_string()));
-        assert!(retrieved.is_some());
-        assert_eq!(retrieved.unwrap().id, 1);
-    }
-
-    #[test]
-    fn test_multiple_services_with_different_qualifiers() {
+    fn test_multiple_services_of_different_types() {
         let container = DiContainer::default();
 
-        container.add(TestService { id: 1 }, Some("first".to_string()));
-        container.add(TestService { id: 2 }, Some("second".to_string()));
+        container.add(TestService { id: 1 });
+        container.add(AnotherService {
+            name: "test".to_string(),
+        });
 
-        let first: Option<TestService> = container.get(Some("first".to_string()));
-        let second: Option<TestService> = container.get(Some("second".to_string()));
+        let test_service: Option<TestService> = container.get();
+        let another_service: Option<AnotherService> = container.get();
 
-        assert_eq!(first.unwrap().id, 1);
-        assert_eq!(second.unwrap().id, 2);
+        assert_eq!(test_service.unwrap().id, 1);
+        assert_eq!(another_service.unwrap().name, "test");
     }
 
     #[test]
     fn test_has_service() {
         let container = DiContainer::default();
 
-        assert!(!container.has::<TestService>(None));
+        assert!(!container.has::<TestService>());
 
-        container.add(TestService { id: 1 }, None);
+        container.add(TestService { id: 1 });
 
-        assert!(container.has::<TestService>(None));
-        assert!(!container.has::<TestService>(Some("qualifier".to_string())));
+        assert!(container.has::<TestService>());
     }
 
     #[test]
     fn test_remove_service() {
         let container = DiContainer::default();
-        container.add(TestService { id: 1 }, None);
+        container.add(TestService { id: 1 });
 
-        let removed: Option<TestService> = container.remove(None);
+        let removed: Option<TestService> = container.remove();
         assert!(removed.is_some());
         assert_eq!(removed.unwrap().id, 1);
 
         // Service should no longer exist
-        assert!(!container.has::<TestService>(None));
+        assert!(!container.has::<TestService>());
+    }
+
+    #[test]
+    fn test_service_replacement() {
+        let container = DiContainer::default();
+
+        container.add(TestService { id: 1 });
+
+        // Add a new service of the same type
+        container.add(TestService { id: 2 });
+
+        // Should get the most recently added service
+        let service: Option<TestService> = container.get();
+        assert_eq!(service.unwrap().id, 2);
     }
 
     #[test]
     fn test_different_service_types() {
         let container = DiContainer::default();
 
-        container.add(TestService { id: 1 }, None);
-        container.add(
-            AnotherService {
-                name: "test".to_string(),
-            },
-            None,
-        );
+        container.add(TestService { id: 1 });
+        container.add(AnotherService {
+            name: "test".to_string(),
+        });
 
-        let service1: Option<TestService> = container.get(None);
-        let service2: Option<AnotherService> = container.get(None);
+        let service1: Option<TestService> = container.get();
+        let service2: Option<AnotherService> = container.get();
 
         assert_eq!(service1.unwrap().id, 1);
         assert_eq!(service2.unwrap().name, "test");
-    }
-
-    mod service_tests {
-        use super::*;
-        use crate::tests_cfg;
-        use futures_util::future::join_all;
-
-        #[derive(Clone, Debug, PartialEq)]
-        struct MockService {
-            id: u32,
-        }
-
-        impl Service for MockService {
-            async fn build(_ctx: &AppContext) -> Result<Self, Error> {
-                Ok(MockService { id: 42 })
-            }
-        }
-
-        #[derive(Clone, Debug, PartialEq)]
-        struct ErrorService;
-
-        impl Service for ErrorService {
-            async fn build(_ctx: &AppContext) -> Result<Self, Error> {
-                Err(Error::Message("Test build error".to_string()))
-            }
-        }
-
-        #[tokio::test]
-        async fn test_service_build() {
-            let app_context = tests_cfg::app::get_app_context().await;
-
-            let service = MockService::build(&app_context).await;
-            assert!(service.is_ok());
-            assert_eq!(service.unwrap().id, 42);
-        }
-
-        #[tokio::test]
-        async fn test_service_get_builds_new_instance() {
-            let app_context = tests_cfg::app::get_app_context().await;
-
-            // Ensure service doesn't exist before test
-            assert!(!app_context.container.has::<MockService>(None));
-
-            // First call should build a new instance
-            let service = MockService::get(&app_context).await;
-            assert!(service.is_ok());
-            assert_eq!(service.unwrap().id, 42);
-
-            // Service should now exist in container
-            assert!(app_context.container.has::<MockService>(None));
-        }
-
-        #[tokio::test]
-        async fn test_service_get_returns_existing_instance() {
-            let app_context = tests_cfg::app::get_app_context().await;
-
-            // Add a service with a custom ID directly to the container
-            let existing = MockService { id: 100 };
-            app_context.container.add(existing, None);
-
-            // Get should return the existing instance (with ID 100) instead of building a new one (which would have ID 42)
-            let service = MockService::get(&app_context).await;
-            assert!(service.is_ok());
-            assert_eq!(service.unwrap().id, 100);
-        }
-
-        #[tokio::test]
-        async fn test_service_build_error() {
-            let app_context = tests_cfg::app::get_app_context().await;
-
-            let result = ErrorService::get(&app_context).await;
-            assert!(result.is_err());
-
-            if let Err(Error::Message(msg)) = result {
-                assert_eq!(msg, "Test build error");
-            } else {
-                panic!("Expected Error::Message variant");
-            }
-
-            // Service should not be added to container after build error
-            assert!(!app_context.container.has::<ErrorService>(None));
-        }
-
-        #[tokio::test]
-        async fn test_injectable_struct() {
-            let app_context = tests_cfg::app::get_app_context().await;
-
-            // Add a service to the container
-            app_context.container.add(MockService { id: 42 }, None);
-
-            // Manually simulate what the extractor would do
-            let instance = MockService::get(&app_context).await.unwrap();
-            let injectable = Injectable(instance);
-
-            assert_eq!(injectable.0.id, 42);
-        }
-
-        #[tokio::test]
-        async fn test_service_singleton_behavior() {
-            let app_context = tests_cfg::app::get_app_context().await;
-
-            // Run multiple concurrent get() calls
-            let futures = (0..10).map(|_| MockService::get(&app_context));
-            let results = join_all(futures).await;
-
-            // All should succeed
-            for result in &results {
-                assert!(result.is_ok());
-            }
-
-            // Container should have exactly one instance
-            let instance = app_context.container.get::<MockService>(None);
-            assert!(instance.is_some());
-
-            // All returned instances should be identical
-            let first = &results[0].as_ref().unwrap();
-            for result in &results {
-                assert_eq!(&result.as_ref().unwrap(), first);
-            }
-        }
     }
 }

--- a/src/di.rs
+++ b/src/di.rs
@@ -31,6 +31,7 @@ impl DiContainer {
     /// * `qualifier`: An optional qualifier that helps you differentiate multiple instance of the same type.
     ///
     /// returns: Option<T>
+    #[must_use]
     pub fn get<T: Any + Clone + Send + Sync + 'static>(
         &self,
         qualifier: Option<String>,
@@ -47,6 +48,7 @@ impl DiContainer {
     /// * `qualifier`: An optional qualifier that helps you differentiate multiple instance of the same type.
     ///
     /// returns: bool
+    #[must_use]
     pub fn has<T: Any + Send + Sync + 'static>(&self, qualifier: Option<String>) -> bool {
         self.services.contains_key(&(TypeId::of::<T>(), qualifier))
     }
@@ -58,6 +60,7 @@ impl DiContainer {
     /// * `qualifier`: An optional qualifier that helps you differentiate multiple instance of the same type.
     ///
     /// returns: Option<T>
+    #[must_use]
     pub fn remove<T: Any + Send + Sync + 'static>(&self, qualifier: Option<String>) -> Option<T> {
         self.services
             .remove(&(TypeId::of::<T>(), qualifier))
@@ -105,14 +108,15 @@ impl<T: Service> FromRequestParts<AppContext> for Injectable<T> {
     }
 }
 
-/// Defines a service which can be given and constructed with only the AppContext.
+/// Defines a service which can be given and constructed with only the `AppContext`.
 pub trait Service: Sized + Clone + Send + Sync + 'static {
     /// Builds a new instance of the service.
     fn build(ctx: &AppContext) -> impl Future<Output = Result<Self, Error>> + Send;
 
-    /// Gets you an instance of the service from the DiContainer.
+    /// Gets you an instance of the service from the `DiContainer`.
     ///
-    /// If no instance exist it will create a new one and automatically adds it to the DiContainer.
+    /// If no instance exist it will create a new one and automatically adds it to the `DiContainer`.
+    #[must_use]
     fn get(ctx: &AppContext) -> impl Future<Output = Result<Self, Error>> + Send {
         async {
             match ctx.container.get::<Self>(None) {

--- a/src/di.rs
+++ b/src/di.rs
@@ -71,6 +71,7 @@ impl DiContainer {
 }
 
 /// An extractor that streamlines the process of getting static Data from the `DiContainer`.
+/// Keep in mind that these extractors use `None` as the qualifier.
 pub struct Data<T>(pub T);
 
 impl<T> FromRequestParts<AppContext> for Data<T>
@@ -93,6 +94,8 @@ where
     }
 }
 
+/// An extractor that streamlines the process of getting a `Service` from the `DiContainer`.
+/// Keep in mind that these extractors use `None` as the qualifier.
 pub struct Injectable<T: Service>(pub T);
 
 impl<T: Service> FromRequestParts<AppContext> for Injectable<T> {

--- a/src/di.rs
+++ b/src/di.rs
@@ -1,0 +1,187 @@
+use crate::prelude::AppContext;
+use crate::Error;
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use dashmap::DashMap;
+use std::any::{Any, TypeId};
+
+/// A container that contains and manages instances.
+#[derive(Default)]
+pub struct DiContainer {
+    services: DashMap<(TypeId, Option<String>), Box<dyn Any + Send + Sync>>,
+}
+
+impl DiContainer {
+    /// Adds a service instace to the container.
+    ///
+    /// # Arguments
+    ///
+    /// * `service`: The service that should be managed by the container.
+    /// * `qualifier`: If you have multiple services from the same type you can differentiate them by supplying a qualifier.
+    pub fn add<T: Any + Send + Sync + 'static>(&self, service: T, qualifier: Option<String>) {
+        self.services
+            .insert((TypeId::of::<T>(), qualifier), Box::new(service));
+    }
+
+    /// Gets a cloned version of the instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `qualifier`: An optional qualifier that helps you differentiate multiple instance of the same type.
+    ///
+    /// returns: Option<T>
+    pub fn get<T: Any + Clone + Send + Sync + 'static>(
+        &self,
+        qualifier: Option<String>,
+    ) -> Option<T> {
+        self.services
+            .get(&(TypeId::of::<T>(), qualifier))
+            .and_then(|s| s.downcast_ref::<T>().cloned())
+    }
+
+    /// Checks if the container already manages a specific service with the given qualifier.
+    ///
+    /// # Arguments
+    ///
+    /// * `qualifier`: An optional qualifier that helps you differentiate multiple instance of the same type.
+    ///
+    /// returns: bool
+    pub fn has<T: Any + Send + Sync + 'static>(&self, qualifier: Option<String>) -> bool {
+        self.services.contains_key(&(TypeId::of::<T>(), qualifier))
+    }
+
+    /// Removes a service from the container and returns you the original one.
+    ///
+    /// # Arguments
+    ///
+    /// * `qualifier`: An optional qualifier that helps you differentiate multiple instance of the same type.
+    ///
+    /// returns: Option<T>
+    pub fn remove<T: Any + Send + Sync + 'static>(&self, qualifier: Option<String>) -> Option<T> {
+        self.services
+            .remove(&(TypeId::of::<T>(), qualifier))
+            .map(|f| f.1)
+            .and_then(|any| any.downcast::<T>().ok())
+            .map(|boxed| *boxed)
+    }
+}
+
+/// An extractor that streamlines the process of getting a service from the `DiContainer`.
+pub struct Injectable<T>(pub T);
+
+impl<T> FromRequestParts<AppContext> for Injectable<T>
+where
+    T: Any + Clone + Send + Sync + 'static,
+{
+    type Rejection = Error;
+
+    async fn from_request_parts(
+        _: &mut Parts,
+        state: &AppContext,
+    ) -> Result<Self, Self::Rejection> {
+        let instance = state
+            .container
+            .get::<T>(None)
+            // TODO maybe introduce custom error?
+            .ok_or(Error::Message("Could not find service".to_string()))?;
+
+        Ok(Injectable(instance))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct TestService {
+        id: u32,
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct AnotherService {
+        name: String,
+    }
+
+    #[test]
+    fn test_add_and_get_without_qualifier() {
+        let container = DiContainer::default();
+        let service = TestService { id: 1 };
+
+        container.add(service, None);
+
+        let retrieved: Option<TestService> = container.get(None);
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().id, 1);
+    }
+
+    #[test]
+    fn test_add_and_get_with_qualifier() {
+        let container = DiContainer::default();
+        let service = TestService { id: 1 };
+
+        container.add(service, Some("test".to_string()));
+
+        let retrieved: Option<TestService> = container.get(Some("test".to_string()));
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().id, 1);
+    }
+
+    #[test]
+    fn test_multiple_services_with_different_qualifiers() {
+        let container = DiContainer::default();
+
+        container.add(TestService { id: 1 }, Some("first".to_string()));
+        container.add(TestService { id: 2 }, Some("second".to_string()));
+
+        let first: Option<TestService> = container.get(Some("first".to_string()));
+        let second: Option<TestService> = container.get(Some("second".to_string()));
+
+        assert_eq!(first.unwrap().id, 1);
+        assert_eq!(second.unwrap().id, 2);
+    }
+
+    #[test]
+    fn test_has_service() {
+        let container = DiContainer::default();
+
+        assert!(!container.has::<TestService>(None));
+
+        container.add(TestService { id: 1 }, None);
+
+        assert!(container.has::<TestService>(None));
+        assert!(!container.has::<TestService>(Some("qualifier".to_string())));
+    }
+
+    #[test]
+    fn test_remove_service() {
+        let container = DiContainer::default();
+        container.add(TestService { id: 1 }, None);
+
+        let removed: Option<TestService> = container.remove(None);
+        assert!(removed.is_some());
+        assert_eq!(removed.unwrap().id, 1);
+
+        // Service should no longer exist
+        assert!(!container.has::<TestService>(None));
+    }
+
+    #[test]
+    fn test_different_service_types() {
+        let container = DiContainer::default();
+
+        container.add(TestService { id: 1 }, None);
+        container.add(
+            AnotherService {
+                name: "test".to_string(),
+            },
+            None,
+        );
+
+        let service1: Option<TestService> = container.get(None);
+        let service2: Option<AnotherService> = container.get(None);
+
+        assert_eq!(service1.unwrap().id, 1);
+        assert_eq!(service2.unwrap().name, "test");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,12 @@ pub mod task;
 pub mod testing;
 #[cfg(feature = "testing")]
 pub use axum_test::TestServer;
+pub mod di;
 pub mod storage;
 #[cfg(feature = "testing")]
 pub mod tests_cfg;
 pub mod validation;
+
 pub use validator;
 
 /// Application results options list

--- a/src/tests_cfg/app.rs
+++ b/src/tests_cfg/app.rs
@@ -1,3 +1,4 @@
+use crate::di::DiContainer;
 use crate::{
     app::AppContext,
     cache,
@@ -27,6 +28,6 @@ pub async fn get_app_context() -> AppContext {
         mailer: None,
         storage: Storage::single(storage::drivers::mem::new()).into(),
         cache: cache.into(),
-        container: Arc::new(Default::default()),
+        container: Arc::new(DiContainer::default()),
     }
 }

--- a/src/tests_cfg/app.rs
+++ b/src/tests_cfg/app.rs
@@ -5,6 +5,7 @@ use crate::{
     storage::{self, Storage},
     tests_cfg::config::test_config,
 };
+use std::sync::Arc;
 
 pub async fn get_app_context() -> AppContext {
     // Always use in-memory cache for tests if feature is available, otherwise fall back to null
@@ -26,5 +27,6 @@ pub async fn get_app_context() -> AppContext {
         mailer: None,
         storage: Storage::single(storage::drivers::mem::new()).into(),
         cache: cache.into(),
+        container: Arc::new(Default::default()),
     }
 }


### PR DESCRIPTION
This is my approach to https://github.com/loco-rs/loco/pull/1376

It is independent from the `http` crate while still achieving good performance by utilizing `DashMap`.
I've also added support for an Axum extractor.

TODO:

- [x] update `Changelog.md`
- [x] add docs section

<details>
<summary>Old</summary>

This is my approach to https://github.com/loco-rs/loco/pull/1376

This would allow the add multiple instances of the same type.

Also I plan to add a LazyService trait which allows for lazy initialization.
Will do that later today.

TODOs:

- [x] add a Data and Service system
- [x] add documentation
- [x] add tests
- [ ] add custom error? (do we want this)
- [ ]  ~add the ability to get a ref~ No I think using Arc<> is the easier and better approach
    - had some issues with that
    - maybe return the `Ref` type provided by DashMap?
    - Returning plain `Option<&T>` is not possible
    - current drawback: user has manually wrap the service in `Arc` if its not clonable (not a huge deal imo)
</details>