### PR TITLE
Update CHANGELOG.md with breaking change information and migration help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,19 @@
 * Add data subsystem. [https://github.com/loco-rs/loco/pull/1267](https://github.com/loco-rs/loco/pull/1267)
 * Add "endpoint" arg to azure storage builder.[https://github.com/loco-rs/loco/pull/1317](https://github.com/loco-rs/loco/pull/1317)
 * Improve readability and performance by using  map_err in Model. [https://github.com/loco-rs/loco/pull/1311](https://github.com/loco-rs/loco/pull/1311)
+### Breaking Changes
+In module `loco_rs::auth::jwt` in struct `JWT`, the impl method `generate_token` signature has changed. 
+Migration:
 
+Before
+```rust
+jwt.generate_token(&expiration, pid.clone(), None);
+```
+After
+```rust
+jwt.generate_token(expiration, pid.clone(), Map::new());
+//                 ^ no "&"                 ^ serde_json::map (doesn't allocate in constructor)
+```
 
 ## v0.14.1
 


### PR DESCRIPTION
https://github.com/loco-rs/loco/pull/1159 introduced a breaking change which was undocumented in `CHANGELOG.md`. This PR adds breaking change information. I don't know if there is more breaking changes in the version, this is just what I happened to run into while attempting to update.

A couple notes to accompany this PR:
1. This didn't need to be a breaking change. A new method on JWT struct could have been introduced that had the new behavior with the old method kept around either indefinitely or deprecated.
2. The version number increase properly indicated a breaking change, but there was nothing I could find that showed why without drilling down to individual PRs (this one happened to have the label for breaking change). It's scary doing a version update not knowing whether it was incremented because of substantial new functionality or a breaking change. If there is a PR review checklist let's make sure that breaking changes show up in changelog
3. Looking at the current signature for `generate_token`, it still isn't quite right. The `pid` param does not need to be a String since it is just stuffed into an object and serialized. An `&str` would be fine and avoid an allocation. If we fix this, though, let's do it without a breaking change!