### PR TITLE
make "self" available to worker tags function

### DIFF
--- a/docs-site/content/docs/processing/workers.md
+++ b/docs-site/content/docs/processing/workers.md
@@ -161,7 +161,7 @@ When enqueueing a job, you can optionally assign tags to it. The job will then o
     #[async_trait]
     impl BackgroundWorker<DownloadWorkerArgs> for DownloadWorker {
         // Define tags for this worker
-        fn tags() -> Vec<String> {
+        fn tags(&self) -> Vec<String> {
             vec!["download".to_string(), "network".to_string()]
         }
 
@@ -192,7 +192,7 @@ impl BackgroundWorker<DownloadWorkerArgs> for DownloadWorker {
     }
 
     // Optional: Define tags for this worker
-    fn tags() -> Vec<String> {
+    fn tags(&self) -> Vec<String> {
         vec!["download".to_string()]
     }
 
@@ -229,7 +229,7 @@ The `BackgroundWorker` trait is the core interface for defining background worke
 - `build(ctx: &AppContext) -> Self`: Creates a new instance of the worker with the provided application context.
 - `perform(&self, args: A) -> Result<()>`: The main method that executes the job's logic with the provided arguments.
 - `queue() -> Option<String>`: Optional method to specify a custom queue for the worker (returns `None` by default).
-- `tags() -> Vec<String>`: Optional method to specify tags for this worker (returns an empty vector by default).
+- `tags(&self) -> Vec<String>`: Optional method to specify tags for this worker (returns an empty vector by default).
 - `class_name() -> String`: Returns the worker's class name (automatically derived from the struct name).
 - `perform_later(ctx: &AppContext, args: A) -> Result<()>`: Static method to enqueue a job to be performed later.
 

--- a/loco-gen/src/templates/worker/worker.t
+++ b/loco-gen/src/templates/worker/worker.t
@@ -45,7 +45,7 @@ impl BackgroundWorker<WorkerArgs> for Worker {
     /// 
     /// Tags can be used to filter which workers run during startup.
     /// The default implementation returns an empty vector (no tags).
-    fn tags() -> Vec<String> {
+    fn tags(&self) -> Vec<String> {
         Vec::new()
     }
     

--- a/loco-gen/tests/templates/snapshots/generate[controller_file]@worker.snap
+++ b/loco-gen/tests/templates/snapshots/generate[controller_file]@worker.snap
@@ -38,7 +38,7 @@ impl BackgroundWorker<WorkerArgs> for Worker {
     /// 
     /// Tags can be used to filter which workers run during startup.
     /// The default implementation returns an empty vector (no tags).
-    fn tags() -> Vec<String> {
+    fn tags(&self) -> Vec<String> {
         Vec::new()
     }
     

--- a/src/bgworker/mod.rs
+++ b/src/bgworker/mod.rs
@@ -600,7 +600,7 @@ pub trait BackgroundWorker<A: Send + Sync + serde::Serialize + 'static>: Send + 
     /// Specifies tags associated with this worker. Workers might only process jobs
     /// matching specific tags during startup.
     #[must_use]
-    fn tags() -> Vec<String> {
+    fn tags(&self) -> Vec<String> {
         Vec::new()
     }
 
@@ -622,7 +622,8 @@ pub trait BackgroundWorker<A: Send + Sync + serde::Serialize + 'static>: Send + 
         match &ctx.config.workers.mode {
             WorkerMode::BackgroundQueue => {
                 if let Some(p) = &ctx.queue_provider {
-                    let tags = Self::tags();
+                    let worker = Self::build(ctx);
+                    let tags = worker.tags();
                     let tags_option = if tags.is_empty() { None } else { Some(tags) };
                     p.enqueue(Self::class_name(), Self::queue(), args, tags_option)
                         .await?;


### PR DESCRIPTION
This way we can use runtime config changes for which worker to execute this task on. E.g. for development I want to use a single worker, but in production I want multiple separate ones.