### PR TITLE
Update the init_logger to use app_context instead of config

### DIFF
--- a/docs-site/content/docs/extras/upgrades.md
+++ b/docs-site/content/docs/extras/upgrades.md
@@ -35,6 +35,19 @@ These are the major ones:
 
 ## Upgrade from 0.15.x to 0.16.x
 
+### Use `AppContext` instead of `Config` in `init_logger` in the `Hooks` trait
+
+PR: [#1418](https://github.com/loco-rs/loco/pull/1418)
+
+If you are supplying an implementation of `init_logger` in your `impl` of the `Hooks` trait in order to set up your own logging, you will need to make the following change:
+
+```diff
+- fn init_logger(config: &config::Config, env: &Environment) -> Result<bool> {
++ fn init_logger(ctx: &AppContext, env: &Environment) -> Result<bool> {
+```
+
+Any code in your `init_logger` implementation that makes use of the `config` can access it through `ctx.config`. In addition, you will also be able to access anything else in the `AppContext`, such as the new `shared_store`.
+
 ### Swap to validators builtin email validation
 
 PR: [#1359](https://github.com/loco-rs/loco/pull/1359)

--- a/docs-site/content/docs/extras/upgrades.md
+++ b/docs-site/content/docs/extras/upgrades.md
@@ -43,10 +43,10 @@ If you are supplying an implementation of `init_logger` in your `impl` of the `H
 
 ```diff
 - fn init_logger(config: &config::Config, env: &Environment) -> Result<bool> {
-+ fn init_logger(ctx: &AppContext, env: &Environment) -> Result<bool> {
++ fn init_logger(ctx: &AppContext) -> Result<bool> {
 ```
 
-Any code in your `init_logger` implementation that makes use of the `config` can access it through `ctx.config`. In addition, you will also be able to access anything else in the `AppContext`, such as the new `shared_store`.
+Any code in your `init_logger` implementation that makes use of the `config` can access it through `ctx.config`. In addition, you will also be able to access anything else in the `AppContext`, such as the new `shared_store`. The `env` parameter is also removed, as that is accessible from the `AppContext` as `ctx.environment`.
 
 ### Swap to validators builtin email validation
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,7 +21,7 @@ use crate::{
     bgworker::{self, Queue},
     boot::{shutdown_signal, BootResult, ServeParams, StartMode},
     cache::{self},
-    config::{self, Config},
+    config::Config,
     controller::{
         middleware::{self, MiddlewareLayer},
         AppRoutes,
@@ -359,7 +359,7 @@ pub trait Hooks: Send {
     ///
     /// # Errors
     /// If fails returns an error
-    fn init_logger(_config: &config::Config, _env: &Environment) -> Result<bool> {
+    fn init_logger(_ctx: &AppContext, _env: &Environment) -> Result<bool> {
         Ok(false)
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -359,7 +359,7 @@ pub trait Hooks: Send {
     ///
     /// # Errors
     /// If fails returns an error
-    fn init_logger(_ctx: &AppContext, _env: &Environment) -> Result<bool> {
+    fn init_logger(_ctx: &AppContext) -> Result<bool> {
         Ok(false)
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -643,7 +643,7 @@ pub async fn playground<H: Hooks>() -> crate::Result<AppContext> {
     let config = H::load_config(&environment).await?;
     let app_context = create_context::<H>(&environment, config).await?;
 
-    if !H::init_logger(&app_context, &environment)? {
+    if !H::init_logger(&app_context)? {
         logger::init::<H>(&app_context.config.logger)?;
     }
 
@@ -684,7 +684,7 @@ pub async fn main<H: Hooks, M: MigratorTrait>() -> crate::Result<()> {
     let config = H::load_config(&environment).await?;
     let app_context = create_context::<H>(&environment, config).await?;
 
-    if !H::init_logger(&app_context, &environment)? {
+    if !H::init_logger(&app_context)? {
         logger::init::<H>(&app_context.config.logger)?;
     }
 
@@ -834,7 +834,7 @@ pub async fn main<H: Hooks>() -> crate::Result<()> {
     let config = H::load_config(&environment).await?;
     let app_context = create_context::<H>(&environment, config).await?;
 
-    if !H::init_logger(&app_context, &environment)? {
+    if !H::init_logger(&app_context)? {
         logger::init::<H>(&app_context.config.logger)?;
     }
 


### PR DESCRIPTION
Per discussion in #1404 and #1344, update the init_logger signature in the Hooks trait to accept AppContext instead of Config to allow access to the recently-added SharedStore.