### PR TITLE
fix bug for release builds

### DIFF
--- a/src/controller/views/engine.rs
+++ b/src/controller/views/engine.rs
@@ -86,7 +86,7 @@ impl ViewRenderer for TeraView {
         }
 
         #[cfg(not(debug_assertions))]
-        Ok(self.tera.render(key, &context)?);
+        Ok(self.tera.render(key, &context)?)
     }
 }
 


### PR DESCRIPTION
Ran into this issue

```
error[E0308]: mismatched types
  --> /home/jouke/.cargo/git/checkouts/loco-9164a43cfccb6d87/c79a85b/src/controller/views/engines.rs:78:59
   |
78 |     fn render<S: Serialize>(&self, key: &str, data: S) -> Result<String> {
   |        ------                                             ^^^^^^^^^^^^^^ expected `Result<String, Error>`, found `()`
   |        |
   |        implicitly returns `()` as its body has no tail or `return` expression
...
89 |         Ok(self.tera.render(key, &context)?);
   |                                             - help: remove this semicolon to return this value
   |
   = note:   expected enum `std::result::Result<std::string::String, errors::Error>`
           found unit type `()`
```