### PR TITLE
update middleware::auth::Auth to middleware::auth::JWT in documentation

### DIFF
--- a/docs-site/content/docs/extras/authentication.md
+++ b/docs-site/content/docs/extras/authentication.md
@@ -161,7 +161,7 @@ use loco_rs::{
 };
 
 async fn current(
-    auth: middleware::auth::Auth,
+    auth: middleware::auth::JWT,
     State(ctx): State<AppContext>,
 ) -> Result<Response> {
     let user = users::Model::find_by_pid(&ctx.db, &auth.claims.pid).await?;


### PR DESCRIPTION
No idea if this is even correct. Just going through the getting started docs and noticed that `middleware::auth::Auth` doesn't seem to actually exist, but `middleware::auth::JWT` works as intended