### PR TITLE
remove unused hyper dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,6 @@ jsonwebtoken = { version = "9.3.0", optional = true }
 validator = { version = "0.20.0", features = ["derive"] }
 futures-util = "0.3"
 tower = { workspace = true }
-hyper = "1.1"
 bytes = "1.1"
 ipnetwork = "0.20.0"
 semver = "1"

--- a/src/controller/middleware/static_assets_embedded.rs
+++ b/src/controller/middleware/static_assets_embedded.rs
@@ -13,10 +13,10 @@ use axum::Router as AXRouter;
 use axum::{
     body::Body,
     extract::{Path as AxumPath, Request},
+    http::StatusCode,
     response::{IntoResponse, Response},
     routing::get,
 };
-use hyper::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 


### PR DESCRIPTION
Remove unused hyper dependency

- Remove direct hyper dependency since all required HTTP types are available through axum
- Update static assets middleware to use StatusCode from axum instead of hyper
- No functional changes, just dependency cleanup
