### PR TITLE
fix: Bump shuttle version to 0.55.0  

### DIFF
--- a/loco-gen/src/lib.rs
+++ b/loco-gen/src/lib.rs
@@ -33,7 +33,7 @@ pub struct GenerateResults {
     rrgen: Vec<rrgen::GenResult>,
     local_templates: Vec<PathBuf>,
 }
-const DEPLOYMENT_SHUTTLE_RUNTIME_VERSION: &str = "0.55.0";
+pub const DEPLOYMENT_SHUTTLE_RUNTIME_VERSION: &str = "0.55.0";
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/loco-gen/src/lib.rs
+++ b/loco-gen/src/lib.rs
@@ -33,7 +33,7 @@ pub struct GenerateResults {
     rrgen: Vec<rrgen::GenResult>,
     local_templates: Vec<PathBuf>,
 }
-const DEPLOYMENT_SHUTTLE_RUNTIME_VERSION: &str = "0.51.0";
+const DEPLOYMENT_SHUTTLE_RUNTIME_VERSION: &str = "0.55.0";
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/loco-gen/tests/templates/deployment.rs
+++ b/loco-gen/tests/templates/deployment.rs
@@ -1,5 +1,5 @@
 use insta::assert_snapshot;
-use loco_gen::{collect_messages, generate, AppInfo, Component, DeploymentKind};
+use loco_gen::{collect_messages, generate, AppInfo, Component, DeploymentKind, DEPLOYMENT_SHUTTLE_RUNTIME_VERSION};
 use rrgen::RRgen;
 use std::{fs, path::PathBuf};
 
@@ -106,7 +106,8 @@ fn can_generate_shuttle() {
 
     let component = Component::Deployment {
         kind: DeploymentKind::Shuttle {
-            runttime_version: Some("0.1.1".to_string()),
+            //runttime_version: Some("0.50.0".to_string()),//should not be hard coded. get it from lib.rs?
+            runttime_version: Some(DEPLOYMENT_SHUTTLE_RUNTIME_VERSION.to_string()),
         },
     };
 

--- a/loco-gen/tests/templates/deployment.rs
+++ b/loco-gen/tests/templates/deployment.rs
@@ -1,5 +1,8 @@
 use insta::assert_snapshot;
-use loco_gen::{collect_messages, generate, AppInfo, Component, DeploymentKind, DEPLOYMENT_SHUTTLE_RUNTIME_VERSION};
+use loco_gen::{
+    collect_messages, generate, AppInfo, Component, DeploymentKind,
+    DEPLOYMENT_SHUTTLE_RUNTIME_VERSION,
+};
 use rrgen::RRgen;
 use std::{fs, path::PathBuf};
 
@@ -106,7 +109,6 @@ fn can_generate_shuttle() {
 
     let component = Component::Deployment {
         kind: DeploymentKind::Shuttle {
-            //runttime_version: Some("0.50.0".to_string()),//should not be hard coded. get it from lib.rs?
             runttime_version: Some(DEPLOYMENT_SHUTTLE_RUNTIME_VERSION.to_string()),
         },
     };
@@ -160,8 +162,14 @@ playground = "run --example playground"
         fs::read_to_string(tree_fs.root.join(".cargo").join("config.toml"))
             .expect(".cargo/config.toml not exists")
     );
-    assert_snapshot!(
-        "inject[cargo_toml]",
-        fs::read_to_string(tree_fs.root.join("Cargo.toml")).expect("cargo.toml not exists")
-    );
+    insta::with_settings!({
+        filters => vec![
+            (DEPLOYMENT_SHUTTLE_RUNTIME_VERSION, "[SHUTTLE_RUNTIME_VERSION]"),
+        ]
+    }, {
+        assert_snapshot!(
+            "inject[cargo_toml]",
+            fs::read_to_string(tree_fs.root.join("Cargo.toml")).expect("cargo.toml not exists")
+        );
+    });
 }

--- a/loco-gen/tests/templates/snapshots/generate[shuttle.rs]@deployment.snap
+++ b/loco-gen/tests/templates/snapshots/generate[shuttle.rs]@deployment.snap
@@ -1,19 +1,20 @@
 ---
 source: loco-gen/tests/templates/deployment.rs
 expression: "fs::read_to_string(tree_fs.root.join(\"src\").join(\"bin\").join(\"shuttle.rs\")).expect(\"shuttle rs missing\")"
+snapshot_kind: text
 ---
 use loco_rs::boot::{create_app, StartMode};
 use loco_rs::environment::Environment;
 use tester::app::App;
-
+use migration::Migrator;
 use shuttle_runtime::DeploymentMetadata;
 
 #[shuttle_runtime::main]
 async fn main(
-  
+  #[shuttle_shared_db::Postgres] conn_str: String,
   #[shuttle_runtime::Metadata] meta: DeploymentMetadata,
 ) -> shuttle_axum::ShuttleAxum {
-    
+    std::env::set_var("DATABASE_URL", conn_str);
     let environment = match meta.env {
         shuttle_runtime::Environment::Local => Environment::Development,
         shuttle_runtime::Environment::Deployment => Environment::Production,
@@ -23,7 +24,7 @@ async fn main(
         .load()
         .expect("Failed to load configuration from the environment");
     
-    let boot_result = create_app::<App>(StartMode::ServerOnly, &environment, config)
+    let boot_result = create_app::<App, Migrator>(StartMode::ServerOnly, &environment, config)
         .await
         .unwrap();
 

--- a/loco-gen/tests/templates/snapshots/generate[shuttle.rs]@deployment.snap
+++ b/loco-gen/tests/templates/snapshots/generate[shuttle.rs]@deployment.snap
@@ -5,15 +5,15 @@ expression: "fs::read_to_string(tree_fs.root.join(\"src\").join(\"bin\").join(\"
 use loco_rs::boot::{create_app, StartMode};
 use loco_rs::environment::Environment;
 use tester::app::App;
-use migration::Migrator;
+
 use shuttle_runtime::DeploymentMetadata;
 
 #[shuttle_runtime::main]
 async fn main(
-  #[shuttle_shared_db::Postgres] conn_str: String,
+  
   #[shuttle_runtime::Metadata] meta: DeploymentMetadata,
 ) -> shuttle_axum::ShuttleAxum {
-    std::env::set_var("DATABASE_URL", conn_str);
+    
     let environment = match meta.env {
         shuttle_runtime::Environment::Local => Environment::Development,
         shuttle_runtime::Environment::Deployment => Environment::Production,
@@ -23,7 +23,7 @@ async fn main(
         .load()
         .expect("Failed to load configuration from the environment");
     
-    let boot_result = create_app::<App, Migrator>(StartMode::ServerOnly, &environment, config)
+    let boot_result = create_app::<App>(StartMode::ServerOnly, &environment, config)
         .await
         .unwrap();
 

--- a/loco-gen/tests/templates/snapshots/inject[cargo_toml]@deployment.snap
+++ b/loco-gen/tests/templates/snapshots/inject[cargo_toml]@deployment.snap
@@ -3,9 +3,8 @@ source: loco-gen/tests/templates/deployment.rs
 expression: "fs::read_to_string(tree_fs.root.join(\"Cargo.toml\")).expect(\"cargo.toml not exists\")"
 ---
 [dependencies]
-shuttle-axum = "0.1.1"
-shuttle-runtime = { version = "0.1.1", default-features = false }
-shuttle-shared-db = { version = "0.1.1", features = ["postgres"] }
+shuttle-axum = "0.55.0"
+shuttle-runtime = { version = "0.55.0", default-features = false }
 
 
 [[bin]]

--- a/loco-gen/tests/templates/snapshots/inject[cargo_toml]@deployment.snap
+++ b/loco-gen/tests/templates/snapshots/inject[cargo_toml]@deployment.snap
@@ -1,10 +1,12 @@
 ---
 source: loco-gen/tests/templates/deployment.rs
 expression: "fs::read_to_string(tree_fs.root.join(\"Cargo.toml\")).expect(\"cargo.toml not exists\")"
+snapshot_kind: text
 ---
 [dependencies]
-shuttle-axum = "0.55.0"
-shuttle-runtime = { version = "0.55.0", default-features = false }
+shuttle-axum = "[SHUTTLE_RUNTIME_VERSION]"
+shuttle-runtime = { version = "[SHUTTLE_RUNTIME_VERSION]", default-features = false }
+shuttle-shared-db = { version = "[SHUTTLE_RUNTIME_VERSION]", features = ["postgres"] }
 
 
 [[bin]]


### PR DESCRIPTION
Older versions such as 0.51.0 does not play well with shuttle.dev
User must also update de shuttle-cli 

doc: https://docs.shuttle.dev/guides/upgrade