### PR TITLE
chore: update shuttle template to 0.56

### DIFF
--- a/loco-gen/src/lib.rs
+++ b/loco-gen/src/lib.rs
@@ -33,7 +33,7 @@ pub struct GenerateResults {
     rrgen: Vec<rrgen::GenResult>,
     local_templates: Vec<PathBuf>,
 }
-pub const DEPLOYMENT_SHUTTLE_RUNTIME_VERSION: &str = "0.55.0";
+pub const DEPLOYMENT_SHUTTLE_RUNTIME_VERSION: &str = "0.56.0";
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/loco-gen/src/templates/deployment/shuttle/shuttle.t
+++ b/loco-gen/src/templates/deployment/shuttle/shuttle.t
@@ -2,18 +2,6 @@ to: "src/bin/shuttle.rs"
 skip_exists: true
 message: "Shuttle deployment ready do use"
 injections:
-- into: .cargo/config.toml
-  remove_lines: "loco ="
-  content: ""
-- into: .cargo/config.toml
-  after: \[alias\]
-  content: "loco = \"run --bin {{pkg_name}}-cli --\""
-- into: Cargo.toml
-  before: \[dev-dependencies\]
-  content: |
-    [[bin]]
-    name = "{{pkg_name}}"
-    path = "src/bin/shuttle.rs"
 - into: Cargo.toml
   after: \[dependencies\]
   content: |
@@ -27,12 +15,11 @@ use loco_rs::boot::{create_app, StartMode};
 use loco_rs::environment::Environment;
 use {{pkg_name}}::app::App;
 {% if with_db %}use migration::Migrator;{% endif %}
-use shuttle_runtime::DeploymentMetadata;
 
 #[shuttle_runtime::main]
 async fn main(
   {% if with_db %}#[shuttle_shared_db::Postgres] conn_str: String,{% endif %}
-  #[shuttle_runtime::Metadata] meta: DeploymentMetadata,
+  #[shuttle_runtime::Metadata] meta: shuttle_runtime::DeploymentMetadata,
 ) -> shuttle_axum::ShuttleAxum {
     {% if with_db %}std::env::set_var("DATABASE_URL", conn_str);{% endif %}
     let environment = match meta.env {
@@ -40,10 +27,10 @@ async fn main(
         shuttle_runtime::Environment::Deployment => Environment::Production,
     };
 
-     let config = environment
+    let config = environment
         .load()
         .expect("Failed to load configuration from the environment");
-    
+
     let boot_result = create_app::<App{% if with_db %}, Migrator{% endif %}>(StartMode::ServerOnly, &environment, config)
         .await
         .unwrap();

--- a/loco-gen/tests/templates/snapshots/generate[shuttle.rs]@deployment.snap
+++ b/loco-gen/tests/templates/snapshots/generate[shuttle.rs]@deployment.snap
@@ -7,12 +7,11 @@ use loco_rs::boot::{create_app, StartMode};
 use loco_rs::environment::Environment;
 use tester::app::App;
 use migration::Migrator;
-use shuttle_runtime::DeploymentMetadata;
 
 #[shuttle_runtime::main]
 async fn main(
   #[shuttle_shared_db::Postgres] conn_str: String,
-  #[shuttle_runtime::Metadata] meta: DeploymentMetadata,
+  #[shuttle_runtime::Metadata] meta: shuttle_runtime::DeploymentMetadata,
 ) -> shuttle_axum::ShuttleAxum {
     std::env::set_var("DATABASE_URL", conn_str);
     let environment = match meta.env {
@@ -20,10 +19,10 @@ async fn main(
         shuttle_runtime::Environment::Deployment => Environment::Production,
     };
 
-     let config = environment
+    let config = environment
         .load()
         .expect("Failed to load configuration from the environment");
-    
+
     let boot_result = create_app::<App, Migrator>(StartMode::ServerOnly, &environment, config)
         .await
         .unwrap();

--- a/loco-gen/tests/templates/snapshots/inject[.config_toml]@deployment.snap
+++ b/loco-gen/tests/templates/snapshots/inject[.config_toml]@deployment.snap
@@ -3,7 +3,7 @@ source: loco-gen/tests/templates/deployment.rs
 expression: "fs::read_to_string(tree_fs.root.join(\".cargo\").join(\"config.toml\")).expect(\".cargo/config.toml not exists\")"
 ---
 [alias]
-loco = "run --bin tester-cli --"
+loco = "run --"
 loco-tool = "run --"
 
 playground = "run --example playground"

--- a/loco-gen/tests/templates/snapshots/inject[cargo_toml]@deployment.snap
+++ b/loco-gen/tests/templates/snapshots/inject[cargo_toml]@deployment.snap
@@ -9,8 +9,4 @@ shuttle-runtime = { version = "[SHUTTLE_RUNTIME_VERSION]", default-features = fa
 shuttle-shared-db = { version = "[SHUTTLE_RUNTIME_VERSION]", features = ["postgres"] }
 
 
-[[bin]]
-name = "tester"
-path = "src/bin/shuttle.rs"
-
 [dev-dependencies]


### PR DESCRIPTION
Shuttle CLI 0.56 no longer requires the binary name to match the package name, so the extra entires in cargo files are not needed.