### PR TITLE
fix: Make index creation example use raw sql instead of entity references. Remove advanced examples.

### DIFF
--- a/docs-site/content/docs/the-app/models.md
+++ b/docs-site/content/docs/the-app/models.md
@@ -453,46 +453,18 @@ impl MigrationTrait for Migration {
 
 Using the `manager` directly lets you access more advanced operations while authoring your migrations.
 
-**Add a column**
-
-```rust
-  manager
-    .alter_table(
-        Table::alter()
-            .table(Movies::Table)
-            .add_column_if_not_exists(integer(Movies::Rating))
-            .to_owned(),
-    )
-    .await
-```
-
-**Drop a column**
-
-```rust
-  manager
-    .alter_table(
-        Table::alter()
-            .table(Movies::Table)
-            .drop_column(Movies::Rating)
-            .to_owned(),
-    )
-    .await
-```
-
 **Add index**
 
 You can copy some of this code for adding an index
 
 ```rust
-  manager
-    .create_index(
-        Index::create()
-            .name("idx-movies-rating")
-            .table(Movies::Table)
-            .col(Movies::Rating)
-            .to_owned(),
-    )
-    .await;
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+        let _ = db
+            .execute_unprepared("CREATE INDEX idx-movies-rating ON movies (rating);")
+            .await?;
+        Ok(())
+    }
 ```
 
 **Create a data fix**


### PR DESCRIPTION
As [discussed here](https://github.com/loco-rs/loco/discussions/392), the documentation that recommends referencing entities in migrations is out of date. Out of date sections include the advanced migration examples for adding table columns, dropping table columns, and creating indexes.

Since adding and dropping table columns are already covered by the non-advanced examples, I decided to remove them. I've updated the suggested to code for index creation to use a raw sql command instead of referencing entities.