### PR TITLE
adding to ci cargo build --release

### DIFF
--- a/.github/workflows/loco-rs-ci-sanity.yml
+++ b/.github/workflows/loco-rs-ci-sanity.yml
@@ -18,13 +18,6 @@ on:
   push:
     branches:
       - master
-    paths-ignore: 
-      - "loco-gen/**"
-      - "loco-new/**"
-  pull_request:
-    paths-ignore: 
-      - "loco-gen/**"
-      - "loco-new/**"
 
 env:
   RUST_TOOLCHAIN: stable
@@ -55,6 +48,7 @@ jobs:
           loco new -n myappdb --db sqlite --bg async --assets serverside -a
           cd myappdb
           cargo check
+          cargo build --release
         env:
           LOCO_DEV_MODE_PATH: ${{ github.workspace }}
           
@@ -62,6 +56,7 @@ jobs:
           loco new -n myapp --db none --bg none --assets none -a
           cd myapp
           cargo check
+          cargo build --release
         env:
           LOCO_DEV_MODE_PATH: ${{ github.workspace }}
 

--- a/.github/workflows/loco-rs-ci-sanity.yml
+++ b/.github/workflows/loco-rs-ci-sanity.yml
@@ -18,6 +18,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 env:
   RUST_TOOLCHAIN: stable

--- a/.github/workflows/loco-rs-ci.yml
+++ b/.github/workflows/loco-rs-ci.yml
@@ -51,6 +51,24 @@ jobs:
           tool: cargo-hack
       - run: cargo hack check --each-feature
 
+  build:
+    needs: [check, style]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo build
+        run: cargo build --release
   test:
     needs: [check, style]
     runs-on: ubuntu-latest


### PR DESCRIPTION
As a result of PR #1551, which currently breaks the project, I’ve added a `cargo build --release` step to the CI to catch similar issues early.