### PR TITLE
fix: resolve deployment CLI argument parsing issue

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -319,8 +319,8 @@ After running the migration, follow these steps to complete the process:
     },
     /// Generate a deployment infrastructure
     Deployment {
-        // deployment kind.
-        #[clap(value_enum)]
+        /// The type of deployment to generate
+        #[clap(short, long, value_enum)]
         kind: DeploymentKind,
     },
 


### PR DESCRIPTION
changed from `cargo loco generate deployment -- --kind docker` to `cargo loco generate deployment --kind docker`