### PR TITLE
Feature/adding new imports about multipart

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ thiserror = "1"
 serde = "1"
 serde_json = "1"
 async-trait = { version = "0.1.74" }
-axum = { version = "0.8.1", features = ["macros"] }
+axum = { version = "0.8.1", features = ["macros", "multipart"] }
 tower = "0.4"
 tower-http = { version = "0.6.1", features = [
     "trace",

--- a/docs-site/content/docs/extras/pluggability.md
+++ b/docs-site/content/docs/extras/pluggability.md
@@ -885,7 +885,7 @@ You have two main ways to retrieve data in your controllers:
   use loco_rs::prelude::*;
   use crate::app::MyClonableService; // Or wherever it's defined
 
-  #[axum::debug_handler]
+  #[debug_handler]
   pub async fn index(
       // Extracts and clones MyClonableService into `service`
       SharedStore(service): SharedStore<MyClonableService>,
@@ -903,7 +903,7 @@ You have two main ways to retrieve data in your controllers:
   use loco_rs::prelude::*;
   use crate::app::MyNonClonableService; // Or wherever it's defined
 
-  #[axum::debug_handler]
+  #[debug_handler]
   pub async fn index(
       State(ctx): State<AppContext>, // Need the AppContext state
   ) -> Result<impl IntoResponse> {

--- a/docs-site/content/docs/getting-started/guide.md
+++ b/docs-site/content/docs/getting-started/guide.md
@@ -158,7 +158,6 @@ This is the generated controller body:
 #![allow(clippy::unnecessary_struct_initialization)]
 #![allow(clippy::unused_async)]
 use loco_rs::prelude::*;
-use axum::debug_handler;
 
 #[debug_handler]
 pub async fn index(State(_ctx): State<AppContext>) -> Result<Response> {

--- a/docs-site/content/docs/infrastructure/storage.md
+++ b/docs-site/content/docs/infrastructure/storage.md
@@ -155,6 +155,8 @@ In case you have a specific strategy, you can easily create it by implementing t
 Follow this example, make sure you enable `multipart` feature in axum crate.
 
 ```rust
+use loco_rs::prelude::*;
+
 async fn upload_file(
     State(ctx): State<AppContext>,
     mut multipart: Multipart,

--- a/docs-site/content/docs/the-app/controller.md
+++ b/docs-site/content/docs/the-app/controller.md
@@ -1036,7 +1036,6 @@ Loco extractors validate data within HTTP handlers, proceeding with validated da
 #### Example 1: JSON Validation with `JsonValidate`
 
 ```rust
-use axum::debug_handler;
 use loco_rs::prelude::*;
 
 #[debug_handler]
@@ -1054,7 +1053,6 @@ pub async fn index(
 #### Example 2: Query Validation with `QueryValidate`
 
 ```rust
-use axum::debug_handler;
 use loco_rs::prelude::*;
 
 #[debug_handler]
@@ -1072,7 +1070,6 @@ pub async fn index(
 #### Example 3: Form Validation with `FormValidateWithMessage`
 
 ```rust
-use axum::debug_handler;
 use loco_rs::prelude::*;
 
 #[debug_handler]

--- a/loco-gen/src/templates/controller/api/controller.t
+++ b/loco-gen/src/templates/controller/api/controller.t
@@ -15,7 +15,6 @@ injections:
 #![allow(clippy::unnecessary_struct_initialization)]
 #![allow(clippy::unused_async)]
 use loco_rs::prelude::*;
-use axum::debug_handler;
 
 #[debug_handler]
 pub async fn index(State(_ctx): State<AppContext>) -> Result<Response> {

--- a/loco-gen/src/templates/controller/html/controller.t
+++ b/loco-gen/src/templates/controller/html/controller.t
@@ -15,7 +15,6 @@ injections:
 #![allow(clippy::unnecessary_struct_initialization)]
 #![allow(clippy::unused_async)]
 use loco_rs::prelude::*;
-use axum::debug_handler;
 
 {% for action in actions -%}
 #[debug_handler]

--- a/loco-gen/src/templates/controller/htmx/controller.t
+++ b/loco-gen/src/templates/controller/htmx/controller.t
@@ -15,7 +15,6 @@ injections:
 #![allow(clippy::unnecessary_struct_initialization)]
 #![allow(clippy::unused_async)]
 use loco_rs::prelude::*;
-use axum::debug_handler;
 
 {% for action in actions -%}
 #[debug_handler]

--- a/loco-gen/src/templates/scaffold/api/controller.t
+++ b/loco-gen/src/templates/scaffold/api/controller.t
@@ -16,7 +16,6 @@ injections:
 #![allow(clippy::unused_async)]
 use loco_rs::prelude::*;
 use serde::{Deserialize, Serialize};
-use axum::debug_handler;
 
 use crate::models::_entities::{{file_name | plural}}::{ActiveModel, Entity, Model};
 

--- a/loco-gen/src/templates/scaffold/html/controller.t
+++ b/loco-gen/src/templates/scaffold/html/controller.t
@@ -19,7 +19,6 @@ use serde::{Deserialize, Serialize};
 use axum::response::Redirect;
 use axum_extra::extract::Form;
 use sea_orm::{sea_query::Order, QueryOrder};
-use axum::debug_handler;
 
 use crate::{
     models::_entities::{{file_name | plural}}::{ActiveModel, Column, Entity, Model},

--- a/loco-gen/src/templates/scaffold/htmx/controller.t
+++ b/loco-gen/src/templates/scaffold/htmx/controller.t
@@ -17,7 +17,6 @@ injections:
 use loco_rs::prelude::*;
 use serde::{Deserialize, Serialize};
 use sea_orm::{sea_query::Order, QueryOrder};
-use axum::debug_handler;
 
 use crate::{
     models::_entities::{{file_name | plural}}::{ActiveModel, Column, Entity, Model},

--- a/loco-gen/tests/templates/snapshots/generate[controller_file]@Api_controller.snap
+++ b/loco-gen/tests/templates/snapshots/generate[controller_file]@Api_controller.snap
@@ -6,7 +6,6 @@ expression: "fs::read_to_string(controllers_path.join(\"movie.rs\")).expect(\"co
 #![allow(clippy::unnecessary_struct_initialization)]
 #![allow(clippy::unused_async)]
 use loco_rs::prelude::*;
-use axum::debug_handler;
 
 #[debug_handler]
 pub async fn index(State(_ctx): State<AppContext>) -> Result<Response> {

--- a/loco-gen/tests/templates/snapshots/generate[controller_file]@Api_scaffold.snap
+++ b/loco-gen/tests/templates/snapshots/generate[controller_file]@Api_scaffold.snap
@@ -1,14 +1,12 @@
 ---
 source: loco-gen/tests/templates/scaffold.rs
 expression: "fs::read_to_string(controllers_path.join(\"movie.rs\")).expect(\"controller file missing\")"
-snapshot_kind: text
 ---
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::unnecessary_struct_initialization)]
 #![allow(clippy::unused_async)]
 use loco_rs::prelude::*;
 use serde::{Deserialize, Serialize};
-use axum::debug_handler;
 
 use crate::models::_entities::movies::{ActiveModel, Entity, Model};
 

--- a/loco-gen/tests/templates/snapshots/generate[controller_file]@Html_controller.snap
+++ b/loco-gen/tests/templates/snapshots/generate[controller_file]@Html_controller.snap
@@ -6,7 +6,6 @@ expression: "fs::read_to_string(controllers_path.join(\"movie.rs\")).expect(\"co
 #![allow(clippy::unnecessary_struct_initialization)]
 #![allow(clippy::unused_async)]
 use loco_rs::prelude::*;
-use axum::debug_handler;
 
 #[debug_handler]
 pub async fn GET(

--- a/loco-gen/tests/templates/snapshots/generate[controller_file]@Html_scaffold.snap
+++ b/loco-gen/tests/templates/snapshots/generate[controller_file]@Html_scaffold.snap
@@ -1,7 +1,6 @@
 ---
 source: loco-gen/tests/templates/scaffold.rs
 expression: "fs::read_to_string(controllers_path.join(\"movie.rs\")).expect(\"controller file missing\")"
-snapshot_kind: text
 ---
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::unnecessary_struct_initialization)]
@@ -11,7 +10,6 @@ use serde::{Deserialize, Serialize};
 use axum::response::Redirect;
 use axum_extra::extract::Form;
 use sea_orm::{sea_query::Order, QueryOrder};
-use axum::debug_handler;
 
 use crate::{
     models::_entities::movies::{ActiveModel, Column, Entity, Model},

--- a/loco-gen/tests/templates/snapshots/generate[controller_file]@Htmx_controller.snap
+++ b/loco-gen/tests/templates/snapshots/generate[controller_file]@Htmx_controller.snap
@@ -6,7 +6,6 @@ expression: "fs::read_to_string(controllers_path.join(\"movie.rs\")).expect(\"co
 #![allow(clippy::unnecessary_struct_initialization)]
 #![allow(clippy::unused_async)]
 use loco_rs::prelude::*;
-use axum::debug_handler;
 
 #[debug_handler]
 pub async fn GET(

--- a/loco-gen/tests/templates/snapshots/generate[controller_file]@Htmx_scaffold.snap
+++ b/loco-gen/tests/templates/snapshots/generate[controller_file]@Htmx_scaffold.snap
@@ -1,7 +1,6 @@
 ---
 source: loco-gen/tests/templates/scaffold.rs
 expression: "fs::read_to_string(controllers_path.join(\"movie.rs\")).expect(\"controller file missing\")"
-snapshot_kind: text
 ---
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::unnecessary_struct_initialization)]
@@ -9,7 +8,6 @@ snapshot_kind: text
 use loco_rs::prelude::*;
 use serde::{Deserialize, Serialize};
 use sea_orm::{sea_query::Order, QueryOrder};
-use axum::debug_handler;
 
 use crate::{
     models::_entities::movies::{ActiveModel, Column, Entity, Model},

--- a/loco-gen/tests/templates/snapshots/generate[shuttle.rs]@deployment.snap.new
+++ b/loco-gen/tests/templates/snapshots/generate[shuttle.rs]@deployment.snap.new
@@ -1,0 +1,32 @@
+---
+source: loco-gen/tests/templates/deployment.rs
+assertion_line: 161
+expression: "fs::read_to_string(tree_fs.root.join(\"src\").join(\"bin\").join(\"shuttle.rs\")).expect(\"shuttle rs missing\")"
+---
+use loco_rs::boot::{create_app, StartMode};
+use loco_rs::environment::Environment;
+use tester::app::App;
+
+
+#[shuttle_runtime::main]
+async fn main(
+    
+    #[shuttle_runtime::Metadata] meta: shuttle_runtime::DeploymentMetadata,
+) -> shuttle_axum::ShuttleAxum {
+    
+    let environment = match meta.env {
+        shuttle_runtime::Environment::Local => Environment::Development,
+        shuttle_runtime::Environment::Deployment => Environment::Production,
+    };
+
+    let config = environment
+        .load()
+        .expect("Failed to load configuration from the environment");
+
+    let boot_result = create_app::<App>(StartMode::ServerOnly, &environment, config)
+        .await
+        .unwrap();
+
+    let router = boot_result.router.unwrap();
+    Ok(router.into())
+}

--- a/loco-new/base_template/src/controllers/auth.rs
+++ b/loco-new/base_template/src/controllers/auth.rs
@@ -6,7 +6,6 @@ use crate::{
     },
     views::auth::{CurrentResponse, LoginResponse},
 };
-use axum::debug_handler;
 use loco_rs::prelude::*;
 use regex::Regex;
 use serde::{Deserialize, Serialize};

--- a/loco-new/base_template/src/controllers/home.rs
+++ b/loco-new/base_template/src/controllers/home.rs
@@ -1,4 +1,3 @@
-use axum::debug_handler;
 use loco_rs::prelude::*;
 
 use crate::views::home::HomeResponse;

--- a/src/controller/views/engine.rs
+++ b/src/controller/views/engine.rs
@@ -1,13 +1,14 @@
 use std::path::{Path, PathBuf};
 
-use super::tera_builtins;
-use crate::{controller::views::ViewRenderer, Error, Result};
 use notify::{
     event::{EventKind, ModifyKind},
     Event, RecursiveMode, Watcher,
 };
 use serde::Serialize;
 use tracing::{debug, warn};
+
+use super::tera_builtins;
+use crate::{controller::views::ViewRenderer, Error, Result};
 
 pub static DEFAULT_ASSET_FOLDER: &str = "assets";
 
@@ -62,7 +63,8 @@ impl TeraView {
         Self::from_custom_dir(&PathBuf::from(DEFAULT_ASSET_FOLDER).join("views"))
     }
 
-    /// Attach the Tera view engine with a post-processing function for subsequent instantiation.
+    /// Attach the Tera view engine with a post-processing function for
+    /// subsequent instantiation.
     ///
     /// The post-processing function is also run during the call to this method.
     ///
@@ -118,7 +120,7 @@ impl TeraView {
             )));
         }
         let view_dir = path.as_ref();
-        let view_path: PathBuf = view_dir.join("**").join("*.html").into();
+        let view_path: PathBuf = view_dir.join("**").join("*.html");
 
         // Create instance
         let tera = Self::create_tera_instance(&view_path)?;
@@ -144,7 +146,7 @@ impl TeraView {
                 // Only handle sub-directories and .html files
                 if !paths
                     .iter()
-                    .all(|p| p.is_dir() || p.extension().map_or(false, |ext| ext == "html"))
+                    .all(|p| p.is_dir() || p.extension().is_some_and(|ext| ext == "html"))
                 {
                     return;
                 }
@@ -228,8 +230,9 @@ impl ViewRenderer for TeraView {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{json, Value};
     use std::collections::HashMap;
+
+    use serde_json::{json, Value};
     use tree_fs;
 
     use super::*;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,6 @@
 pub use async_trait::async_trait;
 pub use axum::{
-    extract::{Form, Path, State},
+    extract::{Form, Path, State, Multipart, Query},
     response::{IntoResponse, Response},
     routing::{delete, get, head, options, patch, post, put, trace},
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,7 @@
 pub use async_trait::async_trait;
 pub use axum::{
     debug_handler,
-    extract::{Form, Path, State, Multipart, Query},
+    extract::{Form, Multipart, Path, Query, State},
     response::{IntoResponse, Response},
     routing::{delete, get, head, options, patch, post, put, trace},
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,6 @@
 pub use async_trait::async_trait;
 pub use axum::{
+    debug_handler,
     extract::{Form, Path, State, Multipart, Query},
     response::{IntoResponse, Response},
     routing::{delete, get, head, options, patch, post, put, trace},


### PR DESCRIPTION
I was developing an app to upload files and noticed that `Multipart` and `Query` is not defined in `use loco_rs::prelude::*`. So a added to `src/prelude.rs` this two `use axum::extract::Multipart` and  `use axum::extract::Query`. 

```
#![allow(clippy::missing_errors_doc)]
#![allow(clippy::unnecessary_struct_initialization)]
#![allow(clippy::unused_async)]
use axum::debug_handler;
use loco_rs::prelude::*;
use serde::{Deserialize, Serialize};

use crate::models::_entities::users;
use crate::services::StorageService;

#[derive(Clone, Debug, Serialize, Deserialize)]
pub struct ResponseUpload {
    pub uuid: String,
    pub status: String
}

impl ResponseUpload {
    pub fn success(uuid: String) -> Self {
        Self { status: "success".to_string(), uuid: uuid }
    }
}

#[debug_handler]
pub async fn upload(
    _auth: auth::JWTWithUser<users::Model>,
    State(ctx): State<AppContext>,
    mut multipart: Multipart
) -> Result<Response> {
    let storage_service = StorageService::build(&ctx);
    while let Some(field) = multipart
        .next_field()
        .await
        .map_err(|e| Error::BadRequest(e.to_string()))?
    {
        if let Some(file_name) = field.file_name().map(|f| f.to_string()) {
            let data: Vec<u8> = field
                .bytes()
                .await
                .map_err(|e| Error::BadRequest(e.to_string()))?
                .to_vec();

            let doc = storage_service.save_dir(file_name, &data).await.unwrap();

            return format::json(ResponseUpload::success(doc.uuid));
        }
    }

    Err(Error::BadRequest("No file uploaded".into()))
}

pub fn routes() -> Routes {
    Routes::new()
        .prefix("api/documents/")
        .add("upload", post(upload))
}
```

```

```