### PR TITLE
Feature/adding new templates to migrations

### DIFF
--- a/docs-site/content/docs/the-app/models.md
+++ b/docs-site/content/docs/the-app/models.md
@@ -490,6 +490,28 @@ impl MigrationTrait for Migration {
 }
 ```
 
+**Add index**
+
+You can copy some of this code for adding an index
+
+```rust
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        add_index(manager, "movies", "idx-movies-rating", &["rating"]);
+        Ok(())
+    }
+```
+
+**Remove index**
+
+You can copy some of this code for removing an index
+
+```rust
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        remove_index(manager, "movies", "idx-movies-rating");
+        Ok(())
+    }
+```
+
 ### Authoring advanced migrations
 
 Using the `manager` directly lets you access more advanced operations while authoring your migrations.

--- a/loco-gen/src/infer.rs
+++ b/loco-gen/src/infer.rs
@@ -7,6 +7,8 @@ pub enum MigrationType {
     CreateTable { table: String },
     AddColumns { table: String },
     RemoveColumns { table: String },
+    AddIndex { table: String },
+    RemoveIndex { table: String },
     AddReference { table: String },
     CreateJoinTable { table_a: String, table_b: String },
     Empty,
@@ -45,6 +47,12 @@ pub fn guess_migration_type(migration_name: &str) -> MigrationType {
 
     match parts.as_slice() {
         ["create", table_name] => MigrationType::CreateTable {
+            table: table_name.to_plural(),
+        },
+        ["add", "index", _column_names @ .., "to", table_name] => MigrationType::AddIndex {
+            table: table_name.to_plural(),
+        },
+        ["remove", "index", _column_names @ .., "from", table_name] => MigrationType::RemoveIndex {
             table: table_name.to_plural(),
         },
         ["add", _reference_name, "ref", "to", table_name] => MigrationType::AddReference {
@@ -107,6 +115,26 @@ mod tests {
         assert_eq!(
             guess_migration_type("RemoveNameAndAgeFromUsers"),
             MigrationType::RemoveColumns {
+                table: "users".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_infer_add_index() {
+        assert_eq!(
+            guess_migration_type("AddIndexNameToUsers"),
+            MigrationType::AddIndex {
+                table: "users".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_infer_remove_index() {
+        assert_eq!(
+            guess_migration_type("RemoveIndexNameFromUsers"),
+            MigrationType::RemoveIndex {
                 table: "users".to_string(),
             }
         );

--- a/loco-gen/src/migration.rs
+++ b/loco-gen/src/migration.rs
@@ -41,6 +41,16 @@ pub fn generate(
             let vars = json!({"name": name, "table": table, "ts": ts, "pkg_name": pkg_name, "columns": columns});
             render_template(rrgen, Path::new("migration/remove_columns.t"), &vars)
         }
+        infer::MigrationType::AddIndex { table } => {
+            let (columns, references) = get_columns_and_references(fields)?;
+            let vars = json!({"name": name, "table": table, "ts": ts, "pkg_name": pkg_name, "is_link": false, "columns": columns, "references": references});
+            render_template(rrgen, Path::new("migration/add_indexes.t"), &vars)
+        }
+        infer::MigrationType::RemoveIndex { table } => {
+            let (columns, _references) = get_columns_and_references(fields)?;
+            let vars = json!({"name": name, "table": table, "ts": ts, "pkg_name": pkg_name, "columns": columns});
+            render_template(rrgen, Path::new("migration/remove_index.t"), &vars)
+        }
         infer::MigrationType::AddReference { table } => {
             let (columns, references) = get_columns_and_references(fields)?;
             let vars = json!({"name": name, "table": table, "ts": ts, "pkg_name": pkg_name, "columns": columns, "references": references});

--- a/loco-gen/src/migration.rs
+++ b/loco-gen/src/migration.rs
@@ -28,32 +28,82 @@ pub fn generate(
         // NOTE: re-uses the 'new model' migration template!
         infer::MigrationType::CreateTable { table } => {
             let (columns, references) = get_columns_and_references(fields)?;
-            let vars = json!({"name": table, "ts": ts, "with_tz": with_tz,"pkg_name": pkg_name, "is_link": false, "columns": columns, "references": references});
+            let vars = json!({
+                "name": table,
+                "ts": ts,
+                "with_tz": with_tz,
+                "pkg_name": pkg_name,
+                "is_link": false,
+                "columns": columns,
+                "references": references
+            });
             render_template(rrgen, Path::new("model/model.t"), &vars)
         }
         infer::MigrationType::AddColumns { table } => {
             let (columns, references) = get_columns_and_references(fields)?;
-            let vars = json!({"name": name, "table": table, "ts": ts, "pkg_name": pkg_name, "is_link": false, "columns": columns, "references": references});
+            let vars = json!({
+                "name": name,
+                "table": table,
+                "ts": ts,
+                "pkg_name": pkg_name,
+                "is_link": false,
+                "columns": columns,
+                "references": references
+            });
             render_template(rrgen, Path::new("migration/add_columns.t"), &vars)
         }
         infer::MigrationType::RemoveColumns { table } => {
             let (columns, _references) = get_columns_and_references(fields)?;
-            let vars = json!({"name": name, "table": table, "ts": ts, "pkg_name": pkg_name, "columns": columns});
+            let vars = json!({
+                "name": name,
+                "table": table,
+                "ts": ts,
+                "pkg_name": pkg_name,
+                "columns": columns
+            });
             render_template(rrgen, Path::new("migration/remove_columns.t"), &vars)
         }
         infer::MigrationType::AddIndex { table } => {
             let (columns, references) = get_columns_and_references(fields)?;
-            let vars = json!({"name": name, "table": table, "ts": ts, "pkg_name": pkg_name, "is_link": false, "columns": columns, "references": references});
+            let vars = json!({
+                "name": name,
+                "table": table,
+                "ts": ts,
+                "pkg_name": pkg_name,
+                "is_link": false,
+                "columns": columns.iter()
+                                  .map(|(k, _)| format!("{}", k))
+                                  .collect::<Vec<String>>()
+                                  .join(","),
+                "references": references
+            });
             render_template(rrgen, Path::new("migration/add_indexes.t"), &vars)
         }
         infer::MigrationType::RemoveIndex { table } => {
-            let (columns, _references) = get_columns_and_references(fields)?;
-            let vars = json!({"name": name, "table": table, "ts": ts, "pkg_name": pkg_name, "columns": columns});
-            render_template(rrgen, Path::new("migration/remove_index.t"), &vars)
+            let (columns, references) = get_columns_and_references(fields)?;
+            let vars = json!({
+                "name": name,
+                "table": table,
+                "ts": ts,
+                "pkg_name": pkg_name,
+                "columns": columns.iter()
+                                  .map(|(k, _)| format!("{}", k))
+                                  .collect::<Vec<String>>()
+                                  .join(","),
+                "references": references
+            });
+            render_template(rrgen, Path::new("migration/remove_indexes.t"), &vars)
         }
         infer::MigrationType::AddReference { table } => {
             let (columns, references) = get_columns_and_references(fields)?;
-            let vars = json!({"name": name, "table": table, "ts": ts, "pkg_name": pkg_name, "columns": columns, "references": references});
+            let vars = json!({
+                "name": name,
+                "table": table,
+                "ts": ts,
+                "pkg_name": pkg_name,
+                "columns": columns,
+                "references": references
+            });
             render_template(rrgen, Path::new("migration/add_references.t"), &vars)
         }
         infer::MigrationType::CreateJoinTable { table_a, table_b } => {
@@ -65,7 +115,14 @@ pub fn generate(
                 .chain(extra_references)
                 .collect::<Vec<_>>();
 
-            let vars = json!({"name": name, "table": table, "ts": ts, "pkg_name": pkg_name, "columns": columns, "references": references});
+            let vars = json!({
+                "name": name,
+                "table": table,
+                "ts": ts,
+                "pkg_name": pkg_name, 
+                "columns": columns,
+                "references": references
+            });
             render_template(rrgen, Path::new("migration/join_table.t"), &vars)
         }
         infer::MigrationType::Empty => {

--- a/loco-gen/src/templates/migration/add_indexes.t
+++ b/loco-gen/src/templates/migration/add_indexes.t
@@ -1,0 +1,37 @@
+{% set mig_ts = ts | date(format="%Y%m%d_%H%M%S") -%}
+{% set mig_name = name | snake_case -%}
+{% set plural_snake = table | plural | snake_case -%}
+{% set module_name = "m" ~  mig_ts ~ "_" ~ mig_name -%}
+to: "migration/src/{{module_name}}.rs"
+skip_glob: "migration/src/m????????_??????_{{mig_name}}.rs"
+message: "Migration `{{mig_name}}` added! You can now apply it with `$ cargo loco db migrate && cargo loco db entities`."
+injections:
+- into: "migration/src/lib.rs"
+  before: "inject-above"
+  content: "            Box::new({{module_name}}::Migration),"
+- into: "migration/src/lib.rs"
+  before: "pub struct Migrator"
+  content: "mod {{module_name}};"
+---
+use loco_rs::schema::*;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, m: &SchemaManager) -> Result<(), DbErr> {
+        {% for column in columns -%}
+        add_index(m, "{{plural_snake}}", "{{column.0}}", vec!["{{column.1}}"]).await?;
+        {% endfor -%}
+        Ok(())
+    }
+
+    async fn down(&self, m: &SchemaManager) -> Result<(), DbErr> {
+        {% for column in columns -%}
+        remove_index(m, "{{plural_snake}}", "{{column.0}}").await?;
+        {% endfor -%}
+        Ok(())
+    }
+}

--- a/loco-gen/src/templates/migration/add_indexes.t
+++ b/loco-gen/src/templates/migration/add_indexes.t
@@ -22,16 +22,12 @@ pub struct Migration;
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, m: &SchemaManager) -> Result<(), DbErr> {
-        {% for column in columns -%}
-        add_index(m, "{{plural_snake}}", "{{column.0}}", vec!["{{column.1}}"]).await?;
-        {% endfor -%}
+        add_index(m, "{{plural_snake}}", "index_{{plural_snake}}_{{columns}}", &["{{columns}}"]).await?;
         Ok(())
     }
 
     async fn down(&self, m: &SchemaManager) -> Result<(), DbErr> {
-        {% for column in columns -%}
-        remove_index(m, "{{plural_snake}}", "{{column.0}}").await?;
-        {% endfor -%}
+        remove_index(m, "{{plural_snake}}", "index_{{plural_snake}}_{{columns}}").await?;
         Ok(())
     }
 }

--- a/loco-gen/src/templates/migration/remove_columns.t
+++ b/loco-gen/src/templates/migration/remove_columns.t
@@ -22,16 +22,12 @@ pub struct Migration;
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, m: &SchemaManager) -> Result<(), DbErr> {
-        {% for column in columns -%}
-        remove_column(m, "{{plural_snake}}", "{{column.0}}").await?;
-        {% endfor -%}
+        remove_index(m, "{{plural_snake}}", "index_{{plural_snake}}_{{columns}}").await?;
         Ok(())
     }
 
     async fn down(&self, m: &SchemaManager) -> Result<(), DbErr> {
-        {% for column in columns -%}
-        add_column(m, "{{plural_snake}}", "{{column.0}}", ColType::{{column.1}}).await?;
-        {% endfor -%}
+        add_index(m, "{{plural_snake}}", "index_{{plural_snake}}_{{columns}}", &["{{columns}}"]).await?;
         Ok(())
     }
 }

--- a/loco-gen/src/templates/migration/remove_columns.t
+++ b/loco-gen/src/templates/migration/remove_columns.t
@@ -22,12 +22,16 @@ pub struct Migration;
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, m: &SchemaManager) -> Result<(), DbErr> {
-        remove_index(m, "{{plural_snake}}", "index_{{plural_snake}}_{{columns}}").await?;
+        {% for column in columns -%}
+        remove_column(m, "{{plural_snake}}", "{{column.0}}").await?;
+        {% endfor -%}
         Ok(())
     }
 
     async fn down(&self, m: &SchemaManager) -> Result<(), DbErr> {
-        add_index(m, "{{plural_snake}}", "index_{{plural_snake}}_{{columns}}", &["{{columns}}"]).await?;
+        {% for column in columns -%}
+        add_column(m, "{{plural_snake}}", "{{column.0}}", ColType::{{column.1}}).await?;
+        {% endfor -%}
         Ok(())
     }
 }

--- a/loco-gen/src/templates/migration/remove_indexes.t
+++ b/loco-gen/src/templates/migration/remove_indexes.t
@@ -1,0 +1,33 @@
+{% set mig_ts = ts | date(format="%Y%m%d_%H%M%S") -%}
+{% set mig_name = name | snake_case -%}
+{% set plural_snake = table | plural | snake_case -%}
+{% set module_name = "m" ~  mig_ts ~ "_" ~ mig_name -%}
+to: "migration/src/{{module_name}}.rs"
+skip_glob: "migration/src/m????????_??????_{{mig_name}}.rs"
+message: "Migration `{{mig_name}}` added! You can now apply it with `$ cargo loco db migrate && cargo loco db entities`."
+injections:
+- into: "migration/src/lib.rs"
+  before: "inject-above"
+  content: "            Box::new({{module_name}}::Migration),"
+- into: "migration/src/lib.rs"
+  before: "pub struct Migrator"
+  content: "mod {{module_name}};"
+---
+use loco_rs::schema::*;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, m: &SchemaManager) -> Result<(), DbErr> {
+        remove_index(m, "{{plural_snake}}", "index_{{plural_snake}}_{{columns}}").await?;
+        Ok(())
+    }
+
+    async fn down(&self, m: &SchemaManager) -> Result<(), DbErr> {
+        add_index(m, "{{plural_snake}}", "index_{{plural_snake}}_{{columns}}", &["{{columns}}"]).await?;
+        Ok(())
+    }
+}

--- a/loco-gen/tests/db.rs
+++ b/loco-gen/tests/db.rs
@@ -91,6 +91,8 @@ fn test_migrations_flow(#[values("postgres", "sqlite")] db_kind: &str) {
         "loco g migration CreateAwards name:string actor:references",
         "loco g migration RemoveContentFromMovies content:string",
         "loco g migration AddRatingToMovies rating:int",
+        "loco g migration AddIndexNameToUsers name:string",
+        "loco g migration RemoveIndexNameFromUsers name:string",
         "loco db migrate",
         "loco db entities",
         "loco db schema",

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -759,7 +759,7 @@ pub async fn add_index(
         index.col(Alias::new(*column_name));
     }
 
-    m.create_index(index.to_owned()).await?;
+    m.create_index(index.if_not_exists().to_owned()).await?;
     Ok(())
 }
 
@@ -777,6 +777,7 @@ pub async fn remove_index(m: &SchemaManager<'_>, table: &str, name: &str) -> Res
         Index::drop()
             .name(name.to_string())
             .table(Alias::new(nz_table))
+            .if_exists()
             .to_owned(),
     )
     .await?;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -738,6 +738,52 @@ pub async fn remove_column(m: &SchemaManager<'_>, table: &str, name: &str) -> Re
 }
 
 ///
+/// Add a index to a table with a list of column
+///
+/// ```ignore
+/// add_column(m, "movies", "title", Vec<String>).await;
+/// ```
+/// # Errors
+/// fails when it fails
+pub async fn add_index(
+    m: &SchemaManager<'_>,
+    table: &str,
+    name: &str,
+    column_names: &[&str],
+) -> Result<(), DbErr> {
+    let nz_table = normalize_table(table);
+    let mut index = Index::create();
+    index.name(name.to_string()).table(Alias::new(nz_table));
+
+    for column_name in column_names {
+        index.col(Alias::new(*column_name));
+    }
+
+    m.create_index(index.to_owned()).await?;
+    Ok(())
+}
+
+///
+/// Drop a index from a table.
+///
+/// ```ignore
+/// drop_column(m, "movies", "title").await;
+/// ```
+/// # Errors
+/// fails when it fails
+pub async fn remove_index(m: &SchemaManager<'_>, table: &str, name: &str) -> Result<(), DbErr> {
+    let nz_table = normalize_table(table);
+    m.drop_index(
+        Index::drop()
+            .name(name.to_string())
+            .table(Alias::new(nz_table))
+            .to_owned(),
+    )
+    .await?;
+    Ok(())
+}
+
+///
 /// Adds a reference. Reads "movies belongs-to users":
 /// ```ignore
 /// add_reference(m, "movies", "users").await;


### PR DESCRIPTION

There is no bug detected and fixed. Just adding a new template when adding a index and creating a function to wrap the add index function.

``` 
///
/// Add a index to a table with a list of column
///
/// ```ignore
/// add_column(m, "movies", "title", Vec<String>).await;
/// ```
/// # Errors
/// fails when it fails
pub async fn add_index(
    m: &SchemaManager<'_>,
    table: &str,
    name: &str,
    column_names: &[&str],
) -> Result<(), DbErr> {
    let nz_table = normalize_table(table);
    let mut index = Index::create();
    index.name(name.to_string()).table(Alias::new(nz_table));

    for column_name in column_names {
        index.col(Alias::new(*column_name));
    }

    m.create_index(index.if_not_exists().to_owned()).await?;
    Ok(())
}

///
/// Drop a index from a table.
///
/// ```ignore
/// drop_column(m, "movies", "title").await;
/// ```
/// # Errors
/// fails when it fails
pub async fn remove_index(m: &SchemaManager<'_>, table: &str, name: &str) -> Result<(), DbErr> {
    let nz_table = normalize_table(table);
    m.drop_index(
        Index::drop()
            .name(name.to_string())
            .table(Alias::new(nz_table))
            .if_exists()
            .to_owned(),
    )
    .await?;
    Ok(())
}
```

I added this two functions on src/schema.rs and create two functions on loco-gen.