### PR TITLE
Add Route methods to make collecting and nesting easier

### DIFF
--- a/src/controller/routes.rs
+++ b/src/controller/routes.rs
@@ -144,7 +144,7 @@ impl Routes {
     /// // - POST /api/products
     /// ```
     #[must_use]
-    pub fn merge(mut self, other: Routes) -> Self {
+    pub fn merge(mut self, other: Self) -> Self {
         // Extend the handlers vector with all handlers from the other Routes
         self.handlers.extend(other.handlers);
         self
@@ -153,7 +153,7 @@ impl Routes {
     /// Merge multiple Routes instances into this one.
     ///
     /// This is a convenience method that allows you to merge multiple Routes
-    /// instances at once, which is particularly useful when setting up AppRoutes
+    /// instances at once, which is particularly useful when setting up `AppRoutes`
     /// and you want to collect routes from different controllers before nesting them.
     ///
     /// # Example
@@ -194,7 +194,7 @@ impl Routes {
     /// // - GET /api/orders
     /// ```
     #[must_use]
-    pub fn merge_all(mut self, others: Vec<Routes>) -> Self {
+    pub fn merge_all(mut self, others: Vec<Self>) -> Self {
         // Extend the handlers vector with all handlers from all Routes
         for other in others {
             self.handlers.extend(other.handlers);
@@ -325,7 +325,7 @@ impl Routes {
     /// // - DELETE /api/v1/users/{id}
     /// ```
     #[must_use]
-    pub fn nest(mut self, path: &str, nested_routes: Routes) -> Self {
+    pub fn nest(mut self, path: &str, nested_routes: Self) -> Self {
         // Normalize the path to ensure it starts with / and doesn't end with /
         let mut normalized_path = path.to_string();
         if !normalized_path.starts_with('/') {

--- a/src/controller/routes.rs
+++ b/src/controller/routes.rs
@@ -155,4 +155,188 @@ impl Routes {
                 .collect(),
         }
     }
+
+    /// Nest another Routes instance under a prefix path.
+    ///
+    /// This method allows you to nest a group of routes under a specific path prefix,
+    /// similar to Axum's `nest` method. The nested routes will have their URIs
+    /// prefixed with the given path.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use loco_rs::prelude::*;
+    /// use axum::routing::{get, post, delete, patch};
+    ///
+    /// // Define user-related handlers
+    /// async fn list_users() -> Result<Response> {
+    ///     format::json("users list")
+    /// }
+    ///
+    /// async fn get_user() -> Result<Response> {
+    ///     format::json("user detail")
+    /// }
+    ///
+    /// async fn create_user() -> Result<Response> {
+    ///     format::json("user created")
+    /// }
+    ///
+    /// async fn update_user() -> Result<Response> {
+    ///     format::json("user updated")
+    /// }
+    ///
+    /// async fn delete_user() -> Result<Response> {
+    ///     format::json("user deleted")
+    /// }
+    ///
+    /// // Create API routes for users
+    /// let user_routes = Routes::new()
+    ///     .add("/users", get(list_users))
+    ///     .add("/users", post(create_user))
+    ///     .add("/users/{id}", get(get_user))
+    ///     .add("/users/{id}", patch(update_user))
+    ///     .add("/users/{id}", delete(delete_user));
+    ///
+    /// // Create the main application routes
+    /// let app_routes = Routes::new()
+    ///     .add("/health", get(|| async { "ok" }))
+    ///     .nest("/api/v1", user_routes);
+    ///
+    /// // This will result in routes:
+    /// // - GET /health
+    /// // - GET /api/v1/users
+    /// // - POST /api/v1/users
+    /// // - GET /api/v1/users/{id}
+    /// // - PATCH /api/v1/users/{id}
+    /// // - DELETE /api/v1/users/{id}
+    /// ```
+    #[must_use]
+    pub fn nest(mut self, path: &str, nested_routes: Routes) -> Self {
+        // Normalize the path to ensure it starts with / and doesn't end with /
+        let mut normalized_path = path.to_string();
+        if !normalized_path.starts_with('/') {
+            normalized_path.insert(0, '/');
+        }
+        if normalized_path.ends_with('/') && normalized_path != "/" {
+            normalized_path.pop();
+        }
+
+        // Process each handler from the nested routes
+        for handler in nested_routes.handlers {
+            // Combine the path prefix with the handler's URI
+            let combined_uri = if handler.uri == "/" {
+                normalized_path.clone()
+            } else {
+                format!("{}{}", normalized_path, handler.uri)
+            };
+
+            // Create a new handler with the combined URI
+            let new_handler = Handler {
+                uri: combined_uri,
+                method: handler.method,
+                actions: handler.actions,
+            };
+
+            self.handlers.push(new_handler);
+        }
+
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prelude::*;
+    use axum::routing::get;
+
+    async fn users() -> Result<Response> {
+        format::json("users list")
+    }
+
+    async fn user_detail() -> Result<Response> {
+        format::json("user detail")
+    }
+
+    async fn ping() -> Result<Response> {
+        format::json("pong")
+    }
+
+    #[test]
+    fn test_nest_method() {
+        // Create nested routes
+        let api_routes = Routes::new()
+            .add("/users", get(users))
+            .add("/users/{id}", get(user_detail));
+
+        // Nest them under /api
+        let app_routes = Routes::new()
+            .add("/ping", get(ping))
+            .nest("/api", api_routes);
+
+        // Verify the routes are correctly nested
+        assert_eq!(app_routes.handlers.len(), 3);
+
+        // Check that the ping route is unchanged
+        let ping_handler = &app_routes.handlers[0];
+        assert_eq!(ping_handler.uri, "/ping");
+
+        // Check that the nested routes have the correct prefixes
+        let users_handler = &app_routes.handlers[1];
+        assert_eq!(users_handler.uri, "/api/users");
+
+        let user_detail_handler = &app_routes.handlers[2];
+        assert_eq!(user_detail_handler.uri, "/api/users/{id}");
+    }
+
+    #[test]
+    fn test_nest_method_with_root_path() {
+        // Create nested routes with a root path
+        let api_routes = Routes::new()
+            .add("/", get(users))
+            .add("/users", get(user_detail));
+
+        // Nest them under /api
+        let app_routes = Routes::new().nest("/api", api_routes);
+
+        // Verify the routes are correctly nested
+        assert_eq!(app_routes.handlers.len(), 2);
+
+        // Check that the root path is handled correctly
+        let root_handler = &app_routes.handlers[0];
+        assert_eq!(root_handler.uri, "/api");
+
+        let users_handler = &app_routes.handlers[1];
+        assert_eq!(users_handler.uri, "/api/users");
+    }
+
+    #[test]
+    fn test_nest_method_with_trailing_slash() {
+        // Create nested routes
+        let api_routes = Routes::new().add("/users", get(users));
+
+        // Nest them under /api/ (with trailing slash)
+        let app_routes = Routes::new().nest("/api/", api_routes);
+
+        // Verify the routes are correctly nested (trailing slash should be removed)
+        assert_eq!(app_routes.handlers.len(), 1);
+
+        let users_handler = &app_routes.handlers[0];
+        assert_eq!(users_handler.uri, "/api/users");
+    }
+
+    #[test]
+    fn test_nest_method_without_leading_slash() {
+        // Create nested routes
+        let api_routes = Routes::new().add("/users", get(users));
+
+        // Nest them under api (without leading slash)
+        let app_routes = Routes::new().nest("api", api_routes);
+
+        // Verify the routes are correctly nested (leading slash should be added)
+        assert_eq!(app_routes.handlers.len(), 1);
+
+        let users_handler = &app_routes.handlers[0];
+        assert_eq!(users_handler.uri, "/api/users");
+    }
 }


### PR DESCRIPTION
## Motivation

Similar to the example in the [`nest` method from Axum](https://docs.rs/axum/latest/axum/struct.Router.html#method.nest), it is useful if you want to define a bunch of routes independently and then include all of them under some common prefix, like `/api`. Otherwise, right now, in Loco, you would have to manually set every Route's prefix individually requiring duplicating that prefix.

This PR proposes some additions on `Routes` to make this possible. 

## Methods

### `nest`

In the same way that Axum has [`Router::nest`](https://docs.rs/axum/latest/axum/struct.Router.html#method.nest) to nest an existing Routes under a prefix.

### `merge`

Move the given Routes into this one.

### `merge_all`

Move all the given routes into this one.

These two methods make it easier to collect up all the separate routes you want to then nest under a common prefix.

I am happy to be told this isn't the way to do this and there's a better way! I had built https://github.com/kyle-rader/rust-web-app as a template project with a similar set of goals to Loco, so I was very happy to find tat Loco exists and is further along!

Cheers!
