### PR TITLE
Fix recommendation on getting User from JWT

### DIFF
--- a/docs-site/content/docs/the-app/controller.md
+++ b/docs-site/content/docs/the-app/controller.md
@@ -571,7 +571,7 @@ async fn current(
 }
 ```
 
-Additionally, you can fetch the current user by replacing auth::JWT with `auth::ApiToken<users::Model>`.
+Additionally, you can fetch the current user by replacing auth::JWT with `auth::JWTWithUser<users::Model>`.
 
 #### API Key
 


### PR DESCRIPTION
Copy paste error from the API token section? This change will return the user when using JWT with cookies.