### PR TITLE
Fix cargo fmt error in loco new

### DIFF
--- a/loco-new/base_template/tests/requests/auth.rs.t
+++ b/loco-new/base_template/tests/requests/auth.rs.t
@@ -116,7 +116,7 @@ async fn login_with_un_existing_email() {
     configure_insta!();
 
     request::<App, _, _>(|request, _ctx| async move {
-      
+
         let login_response = request
             .post("/api/auth/login")
             .json(&serde_json::json!({


### PR DESCRIPTION
cargo fmt gives a trailing whitespace error in loco new, this fix simply removes that whitespace.
<img width="1552" height="790" alt="image" src="https://github.com/user-attachments/assets/ec2940db-981a-473c-b2d9-e8abce5d7778" />
