### PR TITLE
Add automatic creation of open api documentation through the aide crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ axum-test = { version = "17.0.1", optional = true }
 chrono = { workspace = true }
 cfg-if = "1"
 
-uuid = { version = "1.10.0", features = ["v4", "fast-rng"] }
+uuid = { version = "1.10.0", features = ["v4", "fast-rng", "serde"] }
 
 # File Upload
 opendal = { version = "0.50.2", default-features = false, features = [
@@ -158,6 +158,8 @@ rusty-sidekiq = { version = "0.11.0", default-features = false, optional = true 
 bb8 = { version = "0.8.1", optional = true }
 
 scraper = { version = "0.21.0", features = ["deterministic"], optional = true }
+aide = { "version" = "0.14.0", "features" = ["axum", "axum-json"]}
+schemars = { "version" = "0.8.21", "features" = ["uuid1"]}
 
 [workspace.dependencies]
 colored = { version = "2" }

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -3,7 +3,7 @@
 //! your application.
 use std::path::PathBuf;
 
-use axum::Router;
+use aide::axum::ApiRouter;
 #[cfg(feature = "with-db")]
 use sea_orm_migration::MigratorTrait;
 use tokio::{select, signal, task::JoinHandle};
@@ -44,7 +44,7 @@ pub struct BootResult {
     /// Application Context
     pub app_context: AppContext,
     /// Web server routes
-    pub router: Option<Router>,
+    pub router: Option<ApiRouter>,
     /// worker processor
     pub run_worker: bool,
 }

--- a/src/controller/describe.rs
+++ b/src/controller/describe.rs
@@ -1,5 +1,6 @@
 use std::sync::OnceLock;
 
+use aide::axum::routing::ApiMethodRouter;
 use axum::{http, routing::MethodRouter};
 use regex::Regex;
 
@@ -16,8 +17,8 @@ fn get_describe_method_action() -> &'static Regex {
 /// Currently axum not exposed the action type of the router. for hold extra
 /// information about routers we need to convert the `method` to string and
 /// capture the details
-pub fn method_action(method: &MethodRouter<AppContext>) -> Vec<http::Method> {
-    let method_str = format!("{method:?}");
+pub fn method_action(method: &ApiMethodRouter<AppContext>) -> Vec<http::Method> {
+    let method_str = format!("{:?}", MethodRouter::<AppContext>::from(method.clone()));
 
     get_describe_method_action()
         .captures(&method_str)

--- a/src/controller/format.rs
+++ b/src/controller/format.rs
@@ -26,6 +26,7 @@ use axum::{
     body::Body,
     http::{response::Builder, HeaderName, HeaderValue},
     response::{Html, IntoResponse, Redirect, Response},
+    Json,
 };
 use axum_extra::extract::cookie::Cookie;
 use bytes::{BufMut, BytesMut};
@@ -34,10 +35,7 @@ use serde::Serialize;
 use serde_json::json;
 
 use crate::{
-    controller::{
-        views::{self, ViewRenderer},
-        Json,
-    },
+    controller::views::{self, ViewRenderer},
     Result,
 };
 

--- a/src/controller/health.rs
+++ b/src/controller/health.rs
@@ -2,21 +2,23 @@
 //! reporting. These routes are commonly used to monitor the health of the
 //! application and its dependencies.
 
-use axum::{extract::State, response::Response, routing::get};
+use aide::axum::routing::get;
+use axum::{extract::State, Json};
+use schemars::JsonSchema;
 use serde::Serialize;
 
-use super::{format, routes::Routes};
-use crate::{app::AppContext, Result};
+use super::routes::Routes;
+use crate::app::AppContext;
 
 /// Represents the health status of the application.
-#[derive(Serialize)]
+#[derive(Serialize, JsonSchema)]
 struct Health {
     pub ok: bool,
 }
 
 /// Check the healthiness of the application bt ping to the redis and the DB to
 /// insure that connection
-async fn health(State(ctx): State<AppContext>) -> Result<Response> {
+async fn health(State(ctx): State<AppContext>) -> Json<Health> {
     let mut is_ok = match ctx.db.ping().await {
         Ok(()) => true,
         Err(error) => {
@@ -31,7 +33,7 @@ async fn health(State(ctx): State<AppContext>) -> Result<Response> {
             is_ok = false;
         }
     }
-    format::json(Health { ok: is_ok })
+    Json(Health { ok: is_ok })
 }
 
 /// Defines and returns the health-related routes.

--- a/src/controller/middleware/auth.rs
+++ b/src/controller/middleware/auth.rs
@@ -21,6 +21,7 @@
 //! ```
 use std::collections::HashMap;
 
+use aide::OperationInput;
 use axum::{
     extract::{FromRef, FromRequestParts, Query},
     http::{request::Parts, HeaderMap},
@@ -50,6 +51,8 @@ pub struct JWTWithUser<T: Authenticable> {
     pub claims: auth::jwt::UserClaims,
     pub user: T,
 }
+
+impl<T: Authenticable> OperationInput for JWTWithUser<T> {}
 
 // Implement the FromRequestParts trait for the Auth struct
 impl<S, T> FromRequestParts<S> for JWTWithUser<T>
@@ -88,6 +91,8 @@ where
 pub struct JWT {
     pub claims: auth::jwt::UserClaims,
 }
+
+impl OperationInput for JWT {}
 
 // Implement the FromRequestParts trait for the Auth struct
 impl<S> FromRequestParts<S> for JWT

--- a/src/controller/middleware/catch_panic.rs
+++ b/src/controller/middleware/catch_panic.rs
@@ -5,7 +5,7 @@
 //! internal server error response. This middleware helps ensure that the
 //! application can gracefully handle unexpected errors without crashing the
 //! server.
-use axum::Router as AXRouter;
+use aide::axum::ApiRouter;
 use serde::{Deserialize, Serialize};
 use tower_http::catch_panic::CatchPanicLayer;
 
@@ -53,7 +53,7 @@ impl MiddlewareLayer for CatchPanic {
     }
 
     /// Applies the Catch Panic middleware layer to the Axum router.
-    fn apply(&self, app: AXRouter<AppContext>) -> Result<AXRouter<AppContext>> {
+    fn apply(&self, app: ApiRouter<AppContext>) -> Result<ApiRouter<AppContext>> {
         Ok(app.layer(CatchPanicLayer::custom(handle_panic)))
     }
 }

--- a/src/controller/middleware/compression.rs
+++ b/src/controller/middleware/compression.rs
@@ -5,7 +5,7 @@
 //! times and reducing bandwidth usage. The middleware configuration allows for
 //! enabling or disabling compression based on the application settings.
 
-use axum::Router as AXRouter;
+use aide::axum::ApiRouter;
 use serde::{Deserialize, Serialize};
 use tower_http::compression::CompressionLayer;
 
@@ -33,7 +33,7 @@ impl MiddlewareLayer for Compression {
     }
 
     /// Applies the Compression middleware layer to the Axum router.
-    fn apply(&self, app: AXRouter<AppContext>) -> Result<AXRouter<AppContext>> {
+    fn apply(&self, app: ApiRouter<AppContext>) -> Result<ApiRouter<AppContext>> {
         Ok(app.layer(CompressionLayer::new()))
     }
 }

--- a/src/controller/middleware/cors.rs
+++ b/src/controller/middleware/cors.rs
@@ -7,7 +7,7 @@
 
 use std::time::Duration;
 
-use axum::Router as AXRouter;
+use aide::axum::ApiRouter;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tower_http::cors::{self, Any};
@@ -157,7 +157,7 @@ impl MiddlewareLayer for Cors {
     }
 
     /// Applies the CORS middleware layer to the Axum router.
-    fn apply(&self, app: AXRouter<AppContext>) -> Result<AXRouter<AppContext>> {
+    fn apply(&self, app: ApiRouter<AppContext>) -> Result<ApiRouter<AppContext>> {
         Ok(app.layer(self.cors()?))
     }
 }

--- a/src/controller/middleware/etag.rs
+++ b/src/controller/middleware/etag.rs
@@ -8,9 +8,8 @@
 
 use std::task::{Context, Poll};
 
-use axum::{
-    body::Body, extract::Request, http::StatusCode, response::Response, Router as AXRouter,
-};
+use aide::axum::ApiRouter;
+use axum::{body::Body, extract::Request, http::StatusCode, response::Response};
 use futures_util::future::BoxFuture;
 use hyper::header::{ETAG, IF_NONE_MATCH};
 use serde::{Deserialize, Serialize};
@@ -40,7 +39,7 @@ impl MiddlewareLayer for Etag {
     }
 
     /// Applies the `ETag` middleware to the application router.
-    fn apply(&self, app: AXRouter<AppContext>) -> Result<AXRouter<AppContext>> {
+    fn apply(&self, app: ApiRouter<AppContext>) -> Result<ApiRouter<AppContext>> {
         Ok(app.layer(EtagLayer))
     }
 }

--- a/src/controller/middleware/fallback.rs
+++ b/src/controller/middleware/fallback.rs
@@ -4,7 +4,8 @@
 //! not match. It serves a file, a custom not-found message, or a default HTML
 //! fallback page based on the configuration.
 
-use axum::{http::StatusCode, response::Html, Router as AXRouter};
+use aide::axum::ApiRouter;
+use axum::{http::StatusCode, response::Html};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::json;
 use tower_http::services::ServeFile;
@@ -85,7 +86,7 @@ impl MiddlewareLayer for Fallback {
     }
 
     /// Applies the fallback middleware to the application router.
-    fn apply(&self, app: AXRouter<AppContext>) -> Result<AXRouter<AppContext>> {
+    fn apply(&self, app: ApiRouter<AppContext>) -> Result<ApiRouter<AppContext>> {
         let app = if let Some(path) = &self.file {
             app.fallback_service(ServeFile::new(path))
         } else if let Some(not_found) = &self.not_found {

--- a/src/controller/middleware/limit_payload.rs
+++ b/src/controller/middleware/limit_payload.rs
@@ -11,7 +11,7 @@
 //! request action to enforce the payload limit correctly. Without this, the
 //! middleware will not function as intended.
 
-use axum::Router as AXRouter;
+use aide::axum::ApiRouter;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{app::AppContext, controller::middleware::MiddlewareLayer, Result};
@@ -77,7 +77,7 @@ impl MiddlewareLayer for LimitPayload {
 
     /// Applies the payload limit middleware to the application router by adding
     /// a `DefaultBodyLimit` layer.
-    fn apply(&self, app: AXRouter<AppContext>) -> Result<AXRouter<AppContext>> {
+    fn apply(&self, app: ApiRouter<AppContext>) -> Result<ApiRouter<AppContext>> {
         let body_limit_layer = match self.body_limit {
             DefaultBodyLimitKind::Disable => axum::extract::DefaultBodyLimit::disable(),
             DefaultBodyLimitKind::Limit(limit) => axum::extract::DefaultBodyLimit::max(limit),

--- a/src/controller/middleware/logger.rs
+++ b/src/controller/middleware/logger.rs
@@ -7,7 +7,8 @@
 //! into the log context, allowing environment-specific logging (e.g.,
 //! "development", "production").
 
-use axum::{http, Router as AXRouter};
+use aide::axum::ApiRouter;
+use axum::http;
 use serde::{Deserialize, Serialize};
 use tower_http::{add_extension::AddExtensionLayer, trace::TraceLayer};
 
@@ -66,7 +67,7 @@ impl MiddlewareLayer for Middleware {
     /// The `TraceLayer` is customized with `make_span_with` to extract
     /// request-specific details like method, URI, version, user agent, and
     /// request ID, then create a tracing span for the request.
-    fn apply(&self, app: AXRouter<AppContext>) -> Result<AXRouter<AppContext>> {
+    fn apply(&self, app: ApiRouter<AppContext>) -> Result<ApiRouter<AppContext>> {
         Ok(app
             .layer(
                 TraceLayer::new_for_http().make_span_with(|request: &http::Request<_>| {

--- a/src/controller/middleware/mod.rs
+++ b/src/controller/middleware/mod.rs
@@ -23,7 +23,7 @@ pub mod secure_headers;
 pub mod static_assets;
 pub mod timeout;
 
-use axum::Router as AXRouter;
+use aide::axum::ApiRouter;
 use serde::{Deserialize, Serialize};
 
 use crate::{app::AppContext, environment::Environment, Result};
@@ -64,7 +64,7 @@ pub trait MiddlewareLayer {
     /// # Errors
     ///
     /// If there is an issue when adding the middleware to the router.
-    fn apply(&self, app: AXRouter<AppContext>) -> Result<AXRouter<AppContext>>;
+    fn apply(&self, app: ApiRouter<AppContext>) -> Result<ApiRouter<AppContext>>;
 }
 
 #[allow(clippy::unnecessary_lazy_evaluations)]

--- a/src/controller/middleware/powered_by.rs
+++ b/src/controller/middleware/powered_by.rs
@@ -8,10 +8,8 @@
 
 use std::sync::OnceLock;
 
-use axum::{
-    http::header::{HeaderName, HeaderValue},
-    Router as AXRouter,
-};
+use aide::axum::ApiRouter;
+use axum::http::header::{HeaderName, HeaderValue};
 use tower_http::set_header::SetResponseHeaderLayer;
 
 use crate::{app::AppContext, controller::middleware::MiddlewareLayer, Result};
@@ -77,7 +75,7 @@ impl MiddlewareLayer for Middleware {
 
     /// Applies the middleware to the application by adding the `X-Powered-By`
     /// header to each response.
-    fn apply(&self, app: AXRouter<AppContext>) -> Result<AXRouter<AppContext>> {
+    fn apply(&self, app: ApiRouter<AppContext>) -> Result<ApiRouter<AppContext>> {
         Ok(app.layer(SetResponseHeaderLayer::overriding(
             HeaderName::from_static("x-powered-by"),
             self.ident

--- a/src/controller/middleware/remote_ip.rs
+++ b/src/controller/middleware/remote_ip.rs
@@ -17,12 +17,12 @@ use std::{
     task::{Context, Poll},
 };
 
+use aide::axum::ApiRouter;
 use axum::{
     body::Body,
     extract::{ConnectInfo, FromRequestParts, Request},
     http::request::Parts,
     response::Response,
-    Router as AXRouter,
 };
 use futures_util::future::BoxFuture;
 use hyper::HeaderMap;
@@ -120,7 +120,7 @@ impl MiddlewareLayer for RemoteIpMiddleware {
     }
 
     /// Applies the Remote IP middleware to the given Axum router.
-    fn apply(&self, app: AXRouter<AppContext>) -> Result<AXRouter<AppContext>> {
+    fn apply(&self, app: ApiRouter<AppContext>) -> Result<ApiRouter<AppContext>> {
         Ok(app.layer(RemoteIPLayer::new(self)?))
     }
 }

--- a/src/controller/middleware/request_id.rs
+++ b/src/controller/middleware/request_id.rs
@@ -6,9 +6,8 @@
 //! This can be useful for tracking requests across services, logging, and
 //! debugging.
 
-use axum::{
-    extract::Request, http::HeaderValue, middleware::Next, response::Response, Router as AXRouter,
-};
+use aide::axum::ApiRouter;
+use axum::{extract::Request, http::HeaderValue, middleware::Next, response::Response};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -54,7 +53,7 @@ impl MiddlewareLayer for RequestId {
     ///
     /// # Errors
     /// This function returns an error if the middleware cannot be applied.
-    fn apply(&self, app: AXRouter<AppContext>) -> Result<AXRouter<AppContext>> {
+    fn apply(&self, app: ApiRouter<AppContext>) -> Result<ApiRouter<AppContext>> {
         Ok(app.layer(axum::middleware::from_fn(request_id_middleware)))
     }
 }

--- a/src/controller/middleware/secure_headers.rs
+++ b/src/controller/middleware/secure_headers.rs
@@ -9,11 +9,11 @@ use std::{
     task::{Context, Poll},
 };
 
+use aide::axum::ApiRouter;
 use axum::{
     body::Body,
     http::{HeaderName, HeaderValue, Request},
     response::Response,
-    Router as AXRouter,
 };
 use futures_util::future::BoxFuture;
 use serde::{Deserialize, Serialize};
@@ -111,7 +111,7 @@ impl MiddlewareLayer for SecureHeader {
     }
 
     /// Applies the secure headers layer to the application router
-    fn apply(&self, app: AXRouter<AppContext>) -> Result<AXRouter<AppContext>> {
+    fn apply(&self, app: ApiRouter<AppContext>) -> Result<ApiRouter<AppContext>> {
         Ok(app.layer(SecureHeaders::new(self)?))
     }
 }

--- a/src/controller/middleware/static_assets.rs
+++ b/src/controller/middleware/static_assets.rs
@@ -11,7 +11,7 @@
 
 use std::path::PathBuf;
 
-use axum::Router as AXRouter;
+use aide::axum::ApiRouter;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tower_http::services::{ServeDir, ServeFile};
@@ -88,14 +88,14 @@ impl MiddlewareLayer for StaticAssets {
 
     /// Applies the static assets middleware to the application router.
     ///
-    /// This method wraps the provided [`AXRouter`] with a service to serve
+    /// This method wraps the provided [`ApiRouter`] with a service to serve
     /// static files from the folder specified in the configuration. It will
     /// serve a fallback file if the requested file is not found, and can
     /// also serve precompressed (gzip) files if enabled.
     ///
     /// Before applying, it checks if the folder and fallback file exist. If
     /// either is missing, it returns an error.
-    fn apply(&self, app: AXRouter<AppContext>) -> Result<AXRouter<AppContext>> {
+    fn apply(&self, app: ApiRouter<AppContext>) -> Result<ApiRouter<AppContext>> {
         if self.must_exist
             && (!PathBuf::from(&self.folder.path).exists()
                 || !PathBuf::from(&self.fallback).exists())

--- a/src/controller/middleware/timeout.rs
+++ b/src/controller/middleware/timeout.rs
@@ -11,7 +11,7 @@
 //! the request took too long to process.
 use std::time::Duration;
 
-use axum::Router as AXRouter;
+use aide::axum::ApiRouter;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tower_http::timeout::TimeoutLayer;
@@ -55,10 +55,10 @@ impl MiddlewareLayer for TimeOut {
 
     /// Applies the timeout middleware to the application router.
     ///
-    /// This method wraps the provided [`AXRouter`] in a [`TimeoutLayer`],
+    /// This method wraps the provided [`ApiRouter`] in a [`TimeoutLayer`],
     /// ensuring that requests exceeding the specified timeout duration will
     /// be interrupted.
-    fn apply(&self, app: AXRouter<AppContext>) -> Result<AXRouter<AppContext>> {
+    fn apply(&self, app: ApiRouter<AppContext>) -> Result<ApiRouter<AppContext>> {
         Ok(app.layer(TimeoutLayer::new(Duration::from_millis(self.timeout))))
     }
 }

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -67,9 +67,9 @@
 
 pub use app_routes::{AppRoutes, ListRoutes};
 use axum::{
-    extract::FromRequest,
     http::StatusCode,
     response::{IntoResponse, Response},
+    Json,
 };
 use colored::Colorize;
 pub use routes::Routes;
@@ -163,16 +163,6 @@ impl ErrorDetail {
             description: None,
             errors: None,
         }
-    }
-}
-
-#[derive(Debug, FromRequest)]
-#[from_request(via(axum::Json), rejection(Error))]
-pub struct Json<T>(pub T);
-
-impl<T: Serialize> IntoResponse for Json<T> {
-    fn into_response(self) -> axum::response::Response {
-        axum::Json(self.0).into_response()
     }
 }
 

--- a/src/controller/ping.rs
+++ b/src/controller/ping.rs
@@ -2,21 +2,22 @@
 //! reporting. These routes are commonly used to monitor the health of the
 //! application and its dependencies.
 
-use axum::{response::Response, routing::get};
+use aide::axum::{routing::get, IntoApiResponse};
+use axum::Json;
+use schemars::JsonSchema;
 use serde::Serialize;
 
-use super::{format, routes::Routes};
-use crate::Result;
+use super::routes::Routes;
 
 /// Represents the health status of the application.
-#[derive(Serialize)]
+#[derive(Serialize, JsonSchema)]
 struct Health {
     pub ok: bool,
 }
 
 /// Check application ping endpoint
-async fn ping() -> Result<Response> {
-    format::json(Health { ok: true })
+async fn ping() -> impl IntoApiResponse {
+    Json(Health { ok: true })
 }
 
 /// Defines and returns the health-related routes.

--- a/src/controller/routes.rs
+++ b/src/controller/routes.rs
@@ -1,6 +1,11 @@
 use std::convert::Infallible;
 
-use axum::{extract::Request, response::IntoResponse, routing::Route};
+use aide::axum::routing::ApiMethodRouter;
+use axum::{
+    extract::Request,
+    response::IntoResponse,
+    routing::{MethodRouter, Route},
+};
 use tower::{Layer, Service};
 
 use super::describe;
@@ -12,11 +17,24 @@ pub struct Routes {
     // pub version: Option<String>,
 }
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default)]
 pub struct Handler {
     pub uri: String,
-    pub method: axum::routing::MethodRouter<AppContext>,
+    pub method: ApiMethodRouter<AppContext>,
     pub actions: Vec<axum::http::Method>,
+}
+
+impl std::fmt::Debug for Handler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Handler")
+            .field("uri", &self.uri)
+            .field(
+                "method",
+                &Into::<MethodRouter<AppContext>>::into(self.method.clone()),
+            )
+            .field("actions", &self.actions)
+            .finish()
+    }
 }
 
 impl Routes {
@@ -78,7 +96,7 @@ impl Routes {
     /// Routes::new().add("/_ping", get(ping));
     /// ````
     #[must_use]
-    pub fn add(mut self, uri: &str, method: axum::routing::MethodRouter<AppContext>) -> Self {
+    pub fn add(mut self, uri: &str, method: ApiMethodRouter<AppContext>) -> Self {
         describe::method_action(&method);
         self.handlers.push(Handler {
             uri: uri.to_owned(),

--- a/src/initializers/extra_db.rs
+++ b/src/initializers/extra_db.rs
@@ -1,5 +1,6 @@
+use aide::axum::ApiRouter;
 use async_trait::async_trait;
-use axum::{Extension, Router as AxumRouter};
+use axum::Extension;
 
 use crate::{
     app::{AppContext, Initializer},
@@ -15,7 +16,7 @@ impl Initializer for ExtraDbInitializer {
         "extra_db".to_string()
     }
 
-    async fn after_routes(&self, router: AxumRouter, ctx: &AppContext) -> Result<AxumRouter> {
+    async fn after_routes(&self, router: ApiRouter, ctx: &AppContext) -> Result<ApiRouter> {
         let extra_db_config = ctx
             .config
             .initializers

--- a/src/initializers/multi_db.rs
+++ b/src/initializers/multi_db.rs
@@ -1,5 +1,6 @@
+use aide::axum::ApiRouter;
 use async_trait::async_trait;
-use axum::{Extension, Router as AxumRouter};
+use axum::Extension;
 
 use crate::{
     app::{AppContext, Initializer},
@@ -15,7 +16,7 @@ impl Initializer for MultiDbInitializer {
         "multi_db".to_string()
     }
 
-    async fn after_routes(&self, router: AxumRouter, ctx: &AppContext) -> Result<AxumRouter> {
+    async fn after_routes(&self, router: ApiRouter, ctx: &AppContext) -> Result<ApiRouter> {
         let settings = ctx
             .config
             .initializers

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,8 +1,10 @@
+pub use aide::axum::routing::{delete, get, head, options, patch, post, put, trace};
 pub use async_trait::async_trait;
+
 pub use axum::{
     extract::{Form, Path, State},
     response::{IntoResponse, Response},
-    routing::{delete, get, head, options, patch, post, put, trace},
+    Json,
 };
 pub use axum_extra::extract::cookie;
 pub use chrono::NaiveDateTime as DateTime;
@@ -35,7 +37,7 @@ pub use crate::{
         },
         not_found, unauthorized,
         views::{engines::TeraView, ViewEngine, ViewRenderer},
-        Json, Routes,
+        Routes,
     },
     errors::Error,
     mailer,

--- a/src/testing/request.rs
+++ b/src/testing/request.rs
@@ -1,5 +1,6 @@
 use std::net::SocketAddr;
 
+use aide::openapi::OpenApi;
 use axum_test::{TestServer, TestServerConfig};
 
 use crate::{
@@ -81,9 +82,11 @@ where
         default_content_type: Some("application/json".to_string()),
         ..Default::default()
     };
+    let mut api = OpenApi::default();
     let server = TestServer::new_with_config(
         boot.router
             .unwrap()
+            .finish_api(&mut api)
             .into_make_service_with_connect_info::<SocketAddr>(),
         config,
     )


### PR DESCRIPTION
These changes allow for open api documentation to be generated automatically when people run the app.
I wrote these changes awhile ago hence being several versions behind and I don't fully remember how the changes work but I've been meaning to get around to making a PR for a while now.
I'm aware https://github.com/loco-rs/loco-openapi-Initializer has come about since I made this fork but that makes use of Utoipa which I have always found fiddly to use. It requires that paths and params be repeated twice, once in the documentation and once in the code, which defeats the entire point of auto generating documentation.
This PR instead uses the code as a single source of truth meaning that changes in the code are reflected in the documentation in real time.

I've furthermore been able to make use of this by using the generated docs to create a full api client in my frontend code using the openapi-qraft generator which may be worth integrating in a future PR.

I'm pretty certain this PR involves several breaking changes however as I said, it's been almost a year since I made the fork and I haven't worked on it since so I don't remember and won't have the time to check it properly for a couple of weeks.