### PR TITLE
Add ability to use Tera template inheritence in emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ async fn after_routes(&self, router: AxumRouter, _ctx: &AppContext) -> Result<Ax
 
 
 
-- Feat: Mailer templates now support full Tera template features including inheritance, blocks, and extends. Templates can also be shared across multiple mailers using `Template::new_with_shared()`. [https://github.com/loco-rs/loco/pull/TBD](https://github.com/loco-rs/loco/pull/TBD)
+- **BREAKING**: `Template::new()` signature changed from `Template::new(dir)` to `Template::new(dir)?` to support template inheritance validation. Mailer templates now support full Tera template features including inheritance, blocks, and extends. Templates can also be shared across multiple mailers using `Template::new_with_shared()`. [https://github.com/loco-rs/loco/pull/1694](https://github.com/loco-rs/loco/pull/1694)
 
 ## v0.16.4 
 - Feat: decouple JWT authentication from database dependency. [https://github.com/loco-rs/loco/pull/1546](https://github.com/loco-rs/loco/pull/1546)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ async fn after_routes(&self, router: AxumRouter, _ctx: &AppContext) -> Result<Ax
 
 
 
+- Feat: Mailer templates now support full Tera template features including inheritance, blocks, and extends. Templates can also be shared across multiple mailers using `Template::new_with_shared()`. [https://github.com/loco-rs/loco/pull/TBD](https://github.com/loco-rs/loco/pull/TBD)
+
 ## v0.16.4 
 - Feat: decouple JWT authentication from database dependency. [https://github.com/loco-rs/loco/pull/1546](https://github.com/loco-rs/loco/pull/1546)
 - Fix: add sqlx dependency to with-db feature. [https://github.com/loco-rs/loco/pull/1557](https://github.com/loco-rs/loco/pull/1557)

--- a/loco-gen/src/templates/mailer/html.t
+++ b/loco-gen/src/templates/mailer/html.t
@@ -3,4 +3,9 @@
 to: "src/mailers/{{module_name}}/welcome/html.t"
 skip_exists: true
 ---
-welcome to <em>acmeworld!</em>
+{% raw %}{% extends "base.t" %}{% endraw %}
+{% raw %}{% block title %}{% endraw %}Welcome!{% raw %}{% endblock %}{% endraw %}
+{% raw %}{% block body %}{% endraw %}
+<h1>Welcome!</h1>
+<p>welcome to <em>acmeworld!</em></p>
+{% raw %}{% endblock %}{% endraw %}

--- a/loco-gen/src/templates/mailer/mailer.t
+++ b/loco-gen/src/templates/mailer/mailer.t
@@ -13,6 +13,7 @@ injections:
 use loco_rs::prelude::*;
 use serde_json::json;
 
+static shared: Dir<'_> = include_dir!("src/mailers/shared");
 static welcome: Dir<'_> = include_dir!("src/mailers/{{module_name}}/welcome");
 
 #[allow(clippy::module_name_repetitions)]
@@ -24,9 +25,10 @@ impl {{struct_name}} {
     /// # Errors
     /// When email sending is failed
     pub async fn send_welcome(ctx: &AppContext, to: &str, msg: &str) -> Result<()> {
-        Self::mail_template(
+        Self::mail_template_with_shared(
             ctx,
             &welcome,
+            &[&shared],
             mailer::Args {
                 to: to.to_string(),
                 locals: json!({

--- a/loco-gen/src/templates/mailer/shared_base.t
+++ b/loco-gen/src/templates/mailer/shared_base.t
@@ -1,0 +1,25 @@
+{% set module_name = name | snake_case -%}
+{% set struct_name = module_name | pascal_case -%}
+to: "src/mailers/shared/base.t"
+skip_exists: true
+---
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{% raw %}{% block title %}{% endraw %}Email{% raw %}{% endblock %}{% endraw %}</title>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
+        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+        .footer { margin-top: 40px; padding-top: 20px; border-top: 1px solid #eee; color: #666; font-size: 12px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        {% raw %}{% block body %}{% endraw %}{% raw %}{% endblock %}{% endraw %}
+        <div class="footer">
+            {% raw %}{% block footer %}{% endraw %}{% raw %}{% endblock %}{% endraw %}
+        </div>
+    </div>
+</body>
+</html>
+

--- a/loco-gen/src/templates/mailer/shared_subject.t
+++ b/loco-gen/src/templates/mailer/shared_subject.t
@@ -1,0 +1,7 @@
+{% set module_name = name | snake_case -%}
+{% set struct_name = module_name | pascal_case -%}
+to: "src/mailers/shared/subject.t"
+skip_exists: true
+---
+{% raw %}{% block subject %}{% endraw %}Email{% raw %}{% endblock %}{% endraw %}
+

--- a/loco-gen/src/templates/mailer/shared_text.t
+++ b/loco-gen/src/templates/mailer/shared_text.t
@@ -1,0 +1,7 @@
+{% set module_name = name | snake_case -%}
+{% set struct_name = module_name | pascal_case -%}
+to: "src/mailers/shared/text.t"
+skip_exists: true
+---
+{% raw %}{% block text %}{% endraw %}{% raw %}{% endblock %}{% endraw %}
+

--- a/loco-gen/tests/templates/mailer.rs
+++ b/loco-gen/tests/templates/mailer.rs
@@ -66,6 +66,18 @@ fn can_generate() {
                 .join("welcome")
                 .join("html.t"),
         ),
+        (
+            "generate[shared_base_t_file]",
+            mailer_path.join("shared").join("base.t"),
+        ),
+        (
+            "generate[shared_subject_t_file]",
+            mailer_path.join("shared").join("subject.t"),
+        ),
+        (
+            "generate[shared_text_t_file]",
+            mailer_path.join("shared").join("text.t"),
+        ),
     ] {
         assert_snapshot!(
             name,

--- a/loco-gen/tests/templates/snapshots/generate[html_t_file]@mailer.snap
+++ b/loco-gen/tests/templates/snapshots/generate[html_t_file]@mailer.snap
@@ -2,4 +2,9 @@
 source: loco-gen/tests/templates/mailer.rs
 expression: "fs::read_to_string(path).unwrap_or_else(|_| panic!(\"{name} missing\"))"
 ---
-welcome to <em>acmeworld!</em>
+{% extends "base.t" %}
+{% block title %}Welcome!{% endblock %}
+{% block body %}
+<h1>Welcome!</h1>
+<p>welcome to <em>acmeworld!</em></p>
+{% endblock %}

--- a/loco-gen/tests/templates/snapshots/generate[mailer_mod_rs]@mailer.snap
+++ b/loco-gen/tests/templates/snapshots/generate[mailer_mod_rs]@mailer.snap
@@ -7,6 +7,7 @@ expression: "fs::read_to_string(path).unwrap_or_else(|_| panic!(\"{name} missing
 use loco_rs::prelude::*;
 use serde_json::json;
 
+static shared: Dir<'_> = include_dir!("src/mailers/shared");
 static welcome: Dir<'_> = include_dir!("src/mailers/reset_password/welcome");
 
 #[allow(clippy::module_name_repetitions)]
@@ -18,9 +19,10 @@ impl ResetPassword {
     /// # Errors
     /// When email sending is failed
     pub async fn send_welcome(ctx: &AppContext, to: &str, msg: &str) -> Result<()> {
-        Self::mail_template(
+        Self::mail_template_with_shared(
             ctx,
             &welcome,
+            &[&shared],
             mailer::Args {
                 to: to.to_string(),
                 locals: json!({

--- a/loco-gen/tests/templates/snapshots/generate[shared_base_t_file]@mailer.snap
+++ b/loco-gen/tests/templates/snapshots/generate[shared_base_t_file]@mailer.snap
@@ -1,0 +1,23 @@
+---
+source: loco-gen/tests/templates/mailer.rs
+expression: "fs::read_to_string(path).unwrap_or_else(|_| panic!(\"{name} missing\"))"
+---
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{% block title %}Email{% endblock %}</title>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
+        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+        .footer { margin-top: 40px; padding-top: 20px; border-top: 1px solid #eee; color: #666; font-size: 12px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        {% block body %}{% endblock %}
+        <div class="footer">
+            {% block footer %}{% endblock %}
+        </div>
+    </div>
+</body>
+</html>

--- a/loco-gen/tests/templates/snapshots/generate[shared_subject_t_file]@mailer.snap
+++ b/loco-gen/tests/templates/snapshots/generate[shared_subject_t_file]@mailer.snap
@@ -1,0 +1,5 @@
+---
+source: loco-gen/tests/templates/mailer.rs
+expression: "fs::read_to_string(path).unwrap_or_else(|_| panic!(\"{name} missing\"))"
+---
+{% block subject %}Email{% endblock %}

--- a/loco-gen/tests/templates/snapshots/generate[shared_text_t_file]@mailer.snap
+++ b/loco-gen/tests/templates/snapshots/generate[shared_text_t_file]@mailer.snap
@@ -1,0 +1,5 @@
+---
+source: loco-gen/tests/templates/mailer.rs
+expression: "fs::read_to_string(path).unwrap_or_else(|_| panic!(\"{name} missing\"))"
+---
+{% block text %}{% endblock %}

--- a/src/mailer/mod.rs
+++ b/src/mailer/mod.rs
@@ -96,7 +96,49 @@ pub trait Mailer {
     /// Renders and sends an email using the provided [`AppContext`], template
     /// directory, and arguments.
     async fn mail_template(ctx: &AppContext, dir: &Dir<'_>, args: Args) -> Result<()> {
-        let content = Template::new(dir)?.render(&args.locals)?;
+        Self::mail_template_with_shared(ctx, dir, &[], args).await
+    }
+
+    /// Renders and sends an email using the provided [`AppContext`], template
+    /// directory, shared template directories, and arguments.
+    ///
+    /// This allows multiple mailers to share common templates (e.g., a base HTML layout).
+    /// Templates from shared directories are loaded first, then templates from the main
+    /// directory. This means templates in the main directory can extend templates from
+    /// shared directories.
+    ///
+    /// # Example
+    ///
+    /// ```rust, ignore
+    /// use include_dir::{include_dir, Dir};
+    /// use loco_rs::prelude::*;
+    ///
+    /// // Shared base template directory
+    /// static shared_base: Dir<'_> = include_dir!("src/mailers/shared");
+    ///
+    /// // Welcome mailer templates
+    /// static welcome: Dir<'_> = include_dir!("src/mailers/auth/welcome");
+    ///
+    /// // Send email with shared templates
+    /// Self::mail_template_with_shared(
+    ///     ctx,
+    ///     &welcome,
+    ///     &[&shared_base],
+    ///     mailer::Args {
+    ///         to: "user@example.com".to_string(),
+    ///         locals: json!({"name": "User"}),
+    ///         ..Default::default()
+    ///     },
+    /// )
+    /// .await?;
+    /// ```
+    async fn mail_template_with_shared(
+        ctx: &AppContext,
+        dir: &Dir<'_>,
+        shared_dirs: &[&Dir<'_>],
+        args: Args,
+    ) -> Result<()> {
+        let content = Template::new_with_shared(dir, shared_dirs)?.render(&args.locals)?;
         Self::mail(
             ctx,
             &Email {

--- a/src/mailer/mod.rs
+++ b/src/mailer/mod.rs
@@ -96,7 +96,7 @@ pub trait Mailer {
     /// Renders and sends an email using the provided [`AppContext`], template
     /// directory, and arguments.
     async fn mail_template(ctx: &AppContext, dir: &Dir<'_>, args: Args) -> Result<()> {
-        let content = Template::new(dir).render(&args.locals)?;
+        let content = Template::new(dir)?.render(&args.locals)?;
         Self::mail(
             ctx,
             &Email {

--- a/src/mailer/snapshots/loco_rs__mailer__template__tests__can_render_template.snap
+++ b/src/mailer/snapshots/loco_rs__mailer__template__tests__can_render_template.snap
@@ -1,6 +1,6 @@
 ---
 source: src/mailer/template.rs
-expression: "Template::new(&include_dir!(\"tests/fixtures/email_template/test\")).render(&args)"
+expression: template.render(&args)
 ---
 Ok(
     Content {

--- a/src/mailer/snapshots/loco_rs__mailer__template__tests__can_render_template_with_inheritance.snap
+++ b/src/mailer/snapshots/loco_rs__mailer__template__tests__can_render_template_with_inheritance.snap
@@ -1,0 +1,9 @@
+---
+source: src/mailer/template.rs
+expression: template.render(&args)?
+---
+Content {
+    subject: "Welcome Test User!\n\n",
+    text: "Hello Test User!\n\nYour verification token is: ABC-123-XYZ\n\nThank you for using our service.\n\n",
+    html: "<!DOCTYPE html>\n<html>\n<head><title>Welcome Email</title></head>\n<body>\n\n<h1>Hello Test User!</h1>\n<p>Your verification token is: <strong>ABC-123-XYZ</strong></p>\n\n</body>\n</html>\n\n",
+}

--- a/src/mailer/snapshots/loco_rs__mailer__template__tests__can_use_shared_templates_across_mailers-2.snap
+++ b/src/mailer/snapshots/loco_rs__mailer__template__tests__can_use_shared_templates_across_mailers-2.snap
@@ -1,0 +1,9 @@
+---
+source: src/mailer/template.rs
+expression: reset_template.render(&reset_args).unwrap()
+---
+Content {
+    subject: "Reset Your Password\n\n",
+    text: "Reset Your Password\n\nClick the link below to reset your password:\nhttps://example.com/reset?token=abc123\n\n",
+    html: "<!DOCTYPE html>\n<html>\n<head>\n    <title>Reset Password</title>\n    <style>\n        body { font-family: Arial, sans-serif; }\n        .footer { color: #666; font-size: 12px; }\n    </style>\n</head>\n<body>\n    \n<h1>Reset Your Password</h1>\n<p>Click the link below to reset your password:</p>\n<p><a href=\"https://example.com/reset?token=abc123\">Reset Password</a></p>\n\n    <div class=\"footer\">\n        © 2024 My Company\n    </div>\n</body>\n</html>\n\n",
+}

--- a/src/mailer/snapshots/loco_rs__mailer__template__tests__can_use_shared_templates_across_mailers.snap
+++ b/src/mailer/snapshots/loco_rs__mailer__template__tests__can_use_shared_templates_across_mailers.snap
@@ -1,0 +1,9 @@
+---
+source: src/mailer/template.rs
+expression: welcome_template.render(&args).unwrap()
+---
+Content {
+    subject: "Welcome Test User!\n\n",
+    text: "Welcome Test User!\n\nThank you for joining us.\n\n",
+    html: "<!DOCTYPE html>\n<html>\n<head>\n    <title>Welcome!</title>\n    <style>\n        body { font-family: Arial, sans-serif; }\n        .footer { color: #666; font-size: 12px; }\n    </style>\n</head>\n<body>\n    \n<h1>Welcome Test User!</h1>\n<p>Thank you for joining us.</p>\n\n    <div class=\"footer\">\n        © 2024 My Company\n    </div>\n</body>\n</html>\n\n",
+}

--- a/src/mailer/template.rs
+++ b/src/mailer/template.rs
@@ -11,12 +11,14 @@
 //!
 //! static welcome: Dir<'_> = include_dir!("src/mailers/auth/welcome");
 //! let args = serde_json::json!({"name": "framework"});
-//! let content = Template::new("contnt").render(&args);
+//! let template = Template::new(&welcome)?;
+//! let content = template.render(&args)?;
 //! ```
 
 use include_dir::Dir;
+use tera::{Context, Tera};
 
-use crate::{errors::Error, tera, Result};
+use crate::{errors::Error, Result};
 
 /// The filename for the subject template file.
 const SUBJECT: &str = "subject.t";
@@ -24,17 +26,6 @@ const SUBJECT: &str = "subject.t";
 const HTML: &str = "html.t";
 /// The filename for the plain text template file.
 const TEXT: &str = "text.t";
-
-/// Reads an embedded file from the provided directory and returns its content
-/// as a string.
-fn embedded_file(dir: &Dir<'_>, name: &str) -> Result<String> {
-    Ok(String::from_utf8_lossy(
-        dir.get_file(name)
-            .ok_or_else(|| Error::Message(format!("no mailer template file found {name}")))?
-            .contents(),
-    )
-    .to_string())
-}
 
 /// A structure representing the content of an email, including subject, text,
 /// and HTML.
@@ -46,29 +37,79 @@ pub struct Content {
 }
 
 /// A structure for managing template rendering using Tera.
-#[derive(Debug, Clone)]
-pub struct Template<'a> {
-    /// The directory containing the embedded template files.
-    dir: &'a Dir<'a>,
+/// This properly initializes Tera to support template inheritance, blocks, and extends.
+#[derive(Debug)]
+pub struct Template {
+    /// The Tera instance with all templates from the directory loaded.
+    tera: Tera,
 }
 
-impl<'a> Template<'a> {
+impl Template {
     /// Creates a new `Template` instance with the provided directory.
-    pub const fn new(dir: &'a Dir<'_>) -> Self {
-        Self { dir }
+    /// This initializes a Tera instance with all templates from the directory,
+    /// enabling template inheritance, blocks, and extends.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Required template files are missing
+    /// - Template syntax is invalid
+    /// - Building inheritance chains fails
+    pub fn new(dir: &Dir<'_>) -> Result<Self> {
+        let mut tera = Tera::default();
+
+        // Load all template files from the directory into Tera
+        // Use the filename as the template name to ensure consistent naming
+        for entry in dir.files() {
+            let path = entry.path();
+            // Use the filename (last component) as the template name
+            // This ensures templates can reference each other by simple names
+            let name = path.file_name().and_then(|n| n.to_str()).ok_or_else(|| {
+                Error::Message(format!("invalid template path: {}", path.to_string_lossy()))
+            })?;
+            let content = String::from_utf8_lossy(entry.contents()).to_string();
+            tera.add_raw_template(name, &content)
+                .map_err(|e| Error::Message(format!("failed to add template '{}': {}", name, e)))?;
+        }
+
+        // Build inheritance chains to enable template inheritance, blocks, and extends
+        tera.build_inheritance_chains().map_err(|e| {
+            Error::Message(format!(
+                "failed to build template inheritance chains: {}",
+                e
+            ))
+        })?;
+
+        Ok(Self { tera })
     }
 
     /// Renders the email content based on the provided locals using the
     /// embedded templates.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Required template files are missing
+    /// - Template rendering fails
     pub fn render(&self, locals: &serde_json::Value) -> Result<Content> {
-        let subject_t = embedded_file(self.dir, SUBJECT)?;
-        let text_t = embedded_file(self.dir, TEXT)?;
-        let html_t = embedded_file(self.dir, HTML)?;
+        let context = Context::from_serialize(locals)
+            .map_err(|e| Error::Message(format!("failed to create template context: {}", e)))?;
 
-        // TODO(consider): check+consider offloading to tokio async this work
-        let text = tera::render_string(&text_t, locals)?;
-        let html = tera::render_string(&html_t, locals)?;
-        let subject = tera::render_string(&subject_t, locals)?;
+        let subject = self
+            .tera
+            .render(SUBJECT, &context)
+            .map_err(|e| Error::Message(format!("failed to render subject template: {}", e)))?;
+
+        let text = self
+            .tera
+            .render(TEXT, &context)
+            .map_err(|e| Error::Message(format!("failed to render text template: {}", e)))?;
+
+        let html = self
+            .tera
+            .render(HTML, &context)
+            .map_err(|e| Error::Message(format!("failed to render html template: {}", e)))?;
+
         Ok(Content {
             subject,
             text,
@@ -85,14 +126,74 @@ mod tests {
 
     use super::*;
 
+    static TEST_TEMPLATE_DIR: include_dir::Dir<'_> =
+        include_dir!("tests/fixtures/email_template/test");
+    static INHERITANCE_TEMPLATE_DIR: include_dir::Dir<'_> =
+        include_dir!("tests/fixtures/email_template/inheritance");
+    static INVALID_INHERITANCE_TEMPLATE_DIR: include_dir::Dir<'_> =
+        include_dir!("tests/fixtures/email_template/invalid_inheritance");
+
     #[test]
     fn can_render_template() {
         let args = serde_json::json!({
             "verifyToken": "1111-2222-3333-4444",
             "name": "Can render test template",
         });
-        assert_debug_snapshot!(
-            Template::new(&include_dir!("tests/fixtures/email_template/test")).render(&args)
+        let template = Template::new(&TEST_TEMPLATE_DIR).unwrap();
+        assert_debug_snapshot!(template.render(&args));
+    }
+
+    #[test]
+    fn can_render_template_with_inheritance() {
+        let args = serde_json::json!({
+            "verifyToken": "ABC-123-XYZ",
+            "name": "Test User",
+        });
+        let template = Template::new(&INHERITANCE_TEMPLATE_DIR).unwrap();
+        let content = template.render(&args).unwrap();
+
+        // Verify that template inheritance worked
+        // Subject should be rendered directly (no inheritance)
+        assert_eq!(content.subject.trim(), "Welcome Test User!");
+
+        // HTML should extend base.t and include the full HTML structure
+        assert!(content.html.contains("<html>"));
+        assert!(content.html.contains("<head>"));
+        assert!(content.html.contains("<title>Welcome Email</title>"));
+        assert!(content.html.contains("<h1>Hello Test User!</h1>"));
+        assert!(content.html.contains("ABC-123-XYZ"));
+        // Check for closing tags separately (they might be on different lines)
+        assert!(content.html.contains("</body>"));
+        assert!(content.html.contains("</html>"));
+
+        // Text should be rendered directly (no inheritance)
+        assert!(content.text.contains("Hello Test User!"));
+        assert!(content.text.contains("ABC-123-XYZ"));
+        assert!(content.text.contains("Thank you for using our service"));
+    }
+
+    #[test]
+    fn fails_when_extending_nonexistent_template() {
+        // Attempting to create a template with a reference to a non-existent parent
+        // should fail during initialization when building inheritance chains
+        let result = Template::new(&INVALID_INHERITANCE_TEMPLATE_DIR);
+
+        assert!(
+            result.is_err(),
+            "Template::new should fail when extending non-existent template"
+        );
+
+        let error = result.unwrap_err();
+        let error_msg = error.to_string();
+
+        // Verify the error message mentions the missing template or inheritance issue
+        assert!(
+            error_msg.contains("non_existent_base.t")
+                || error_msg.contains("inheritance")
+                || error_msg.contains("not found")
+                || error_msg.contains("missing"),
+            "Error message should mention the missing template or inheritance issue. Got: {}",
+            error_msg
         );
     }
 }

--- a/src/mailer/template.rs
+++ b/src/mailer/template.rs
@@ -264,32 +264,14 @@ mod tests {
     }
 
     #[test]
-    fn can_render_template_with_inheritance() {
+    fn can_render_template_with_inheritance() -> Result<()> {
         let args = serde_json::json!({
             "verifyToken": "ABC-123-XYZ",
             "name": "Test User",
         });
-        let template = Template::new(&INHERITANCE_TEMPLATE_DIR).unwrap();
-        let content = template.render(&args).unwrap();
-
-        // Verify that template inheritance worked
-        // Subject should be rendered directly (no inheritance)
-        assert_eq!(content.subject.trim(), "Welcome Test User!");
-
-        // HTML should extend base.t and include the full HTML structure
-        assert!(content.html.contains("<html>"));
-        assert!(content.html.contains("<head>"));
-        assert!(content.html.contains("<title>Welcome Email</title>"));
-        assert!(content.html.contains("<h1>Hello Test User!</h1>"));
-        assert!(content.html.contains("ABC-123-XYZ"));
-        // Check for closing tags separately (they might be on different lines)
-        assert!(content.html.contains("</body>"));
-        assert!(content.html.contains("</html>"));
-
-        // Text should be rendered directly (no inheritance)
-        assert!(content.text.contains("Hello Test User!"));
-        assert!(content.text.contains("ABC-123-XYZ"));
-        assert!(content.text.contains("Thank you for using our service"));
+        let template = Template::new(&INHERITANCE_TEMPLATE_DIR)?;
+        assert_debug_snapshot!(template.render(&args)?);
+        Ok(())
     }
 
     #[test]
@@ -318,50 +300,23 @@ mod tests {
     }
 
     #[test]
-    fn can_use_shared_templates_across_mailers() {
+    fn can_use_shared_templates_across_mailers() -> Result<()> {
         let args = serde_json::json!({
             "name": "Test User",
         });
 
         // Welcome mailer using shared base template
         let welcome_template =
-            Template::new_with_shared(&WELCOME_TEMPLATE_DIR, &[&SHARED_TEMPLATE_DIR]).unwrap();
-        let welcome_content = welcome_template.render(&args).unwrap();
-
-        // Verify welcome email uses shared base template
-        assert_eq!(welcome_content.subject.trim(), "Welcome Test User!");
-        assert!(welcome_content.html.contains("<html>"));
-        assert!(welcome_content.html.contains("<head>"));
-        assert!(welcome_content.html.contains("<title>Welcome!</title>"));
-        assert!(welcome_content.html.contains("<h1>Welcome Test User!</h1>"));
-        assert!(welcome_content.html.contains("Thank you for joining us"));
-        assert!(welcome_content.html.contains("© 2024 My Company")); // Footer from shared template
-        assert!(welcome_content.html.contains("</body>"));
-        assert!(welcome_content.html.contains("</html>"));
+            Template::new_with_shared(&WELCOME_TEMPLATE_DIR, &[&SHARED_TEMPLATE_DIR])?;
+        assert_debug_snapshot!(welcome_template.render(&args)?);
 
         // Reset password mailer using the same shared base template
         let reset_args = serde_json::json!({
             "resetUrl": "https://example.com/reset?token=abc123",
         });
         let reset_template =
-            Template::new_with_shared(&RESET_PASSWORD_TEMPLATE_DIR, &[&SHARED_TEMPLATE_DIR])
-                .unwrap();
-        let reset_content = reset_template.render(&reset_args).unwrap();
-
-        // Verify reset password email also uses shared base template
-        assert_eq!(reset_content.subject.trim(), "Reset Your Password");
-        assert!(reset_content.html.contains("<html>"));
-        assert!(reset_content.html.contains("<head>"));
-        assert!(reset_content.html.contains("<title>Reset Password</title>"));
-        assert!(reset_content.html.contains("<h1>Reset Your Password</h1>"));
-        assert!(reset_content
-            .html
-            .contains("https://example.com/reset?token=abc123"));
-        assert!(reset_content.html.contains("© 2024 My Company")); // Footer from shared template
-        assert!(reset_content.html.contains("</body>"));
-        assert!(reset_content.html.contains("</html>"));
-
-        // Both mailers share the same base template structure but have different content
-        assert_ne!(welcome_content.html, reset_content.html);
+            Template::new_with_shared(&RESET_PASSWORD_TEMPLATE_DIR, &[&SHARED_TEMPLATE_DIR])?;
+        assert_debug_snapshot!(reset_template.render(&reset_args)?);
+        Ok(())
     }
 }

--- a/src/mailer/template.rs
+++ b/src/mailer/template.rs
@@ -129,6 +129,7 @@ impl Template {
     /// - Template syntax is invalid
     /// - Building inheritance chains fails
     /// - A template extends a non-existent parent template
+    #[allow(dead_code)] // used for tests / backwards compatibility
     pub fn new(dir: &Dir<'_>) -> Result<Self> {
         Self::new_with_shared(dir, &[])
     }

--- a/tests/fixtures/email_template/inheritance/base.t
+++ b/tests/fixtures/email_template/inheritance/base.t
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><title>{% block title %}Email{% endblock %}</title></head>
+<body>
+{% block body %}{% endblock %}
+</body>
+</html>
+

--- a/tests/fixtures/email_template/inheritance/html.t
+++ b/tests/fixtures/email_template/inheritance/html.t
@@ -1,0 +1,7 @@
+{% extends "base.t" %}
+{% block title %}Welcome Email{% endblock %}
+{% block body %}
+<h1>Hello {{ name }}!</h1>
+<p>Your verification token is: <strong>{{ verifyToken }}</strong></p>
+{% endblock %}
+

--- a/tests/fixtures/email_template/inheritance/subject.t
+++ b/tests/fixtures/email_template/inheritance/subject.t
@@ -1,0 +1,2 @@
+Welcome {{ name }}!
+

--- a/tests/fixtures/email_template/inheritance/text.t
+++ b/tests/fixtures/email_template/inheritance/text.t
@@ -1,0 +1,6 @@
+Hello {{ name }}!
+
+Your verification token is: {{ verifyToken }}
+
+Thank you for using our service.
+

--- a/tests/fixtures/email_template/invalid_inheritance/html.t
+++ b/tests/fixtures/email_template/invalid_inheritance/html.t
@@ -1,0 +1,5 @@
+{% extends "non_existent_base.t" %}
+{% block content %}
+<h1>This should fail</h1>
+{% endblock %}
+

--- a/tests/fixtures/email_template/invalid_inheritance/subject.t
+++ b/tests/fixtures/email_template/invalid_inheritance/subject.t
@@ -1,0 +1,2 @@
+Subject template
+

--- a/tests/fixtures/email_template/invalid_inheritance/text.t
+++ b/tests/fixtures/email_template/invalid_inheritance/text.t
@@ -1,0 +1,2 @@
+Text template
+

--- a/tests/fixtures/email_template/reset_password/html.t
+++ b/tests/fixtures/email_template/reset_password/html.t
@@ -1,0 +1,8 @@
+{% extends "base.t" %}
+{% block title %}Reset Password{% endblock %}
+{% block body %}
+<h1>Reset Your Password</h1>
+<p>Click the link below to reset your password:</p>
+<p><a href="{{ resetUrl }}">Reset Password</a></p>
+{% endblock %}
+

--- a/tests/fixtures/email_template/reset_password/subject.t
+++ b/tests/fixtures/email_template/reset_password/subject.t
@@ -1,0 +1,2 @@
+Reset Your Password
+

--- a/tests/fixtures/email_template/reset_password/text.t
+++ b/tests/fixtures/email_template/reset_password/text.t
@@ -1,0 +1,5 @@
+Reset Your Password
+
+Click the link below to reset your password:
+{{ resetUrl }}
+

--- a/tests/fixtures/email_template/shared/base.t
+++ b/tests/fixtures/email_template/shared/base.t
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{% block title %}Email{% endblock %}</title>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        .footer { color: #666; font-size: 12px; }
+    </style>
+</head>
+<body>
+    {% block body %}{% endblock %}
+    <div class="footer">
+        {% block footer %}© 2024 My Company{% endblock %}
+    </div>
+</body>
+</html>
+

--- a/tests/fixtures/email_template/shared/subject.t
+++ b/tests/fixtures/email_template/shared/subject.t
@@ -1,0 +1,2 @@
+{% block subject %}Default Subject{% endblock %}
+

--- a/tests/fixtures/email_template/shared/text.t
+++ b/tests/fixtures/email_template/shared/text.t
@@ -1,0 +1,2 @@
+{% block text %}Default text content{% endblock %}
+

--- a/tests/fixtures/email_template/welcome/html.t
+++ b/tests/fixtures/email_template/welcome/html.t
@@ -1,0 +1,7 @@
+{% extends "base.t" %}
+{% block title %}Welcome!{% endblock %}
+{% block body %}
+<h1>Welcome {{ name }}!</h1>
+<p>Thank you for joining us.</p>
+{% endblock %}
+

--- a/tests/fixtures/email_template/welcome/subject.t
+++ b/tests/fixtures/email_template/welcome/subject.t
@@ -1,0 +1,2 @@
+Welcome {{ name }}!
+

--- a/tests/fixtures/email_template/welcome/text.t
+++ b/tests/fixtures/email_template/welcome/text.t
@@ -1,0 +1,4 @@
+Welcome {{ name }}!
+
+Thank you for joining us.
+


### PR DESCRIPTION
This is a first draft for adding templates to emails.

I noticed that I'd like to use Tera's `extends` syntax in my emails so that I can have one file with the layout of the html email and can just use smaller ones with message-specific layout bits.

Here we add a `src/mailers/shared/{base.t,subject.t,text.t}` and add these to the Tera context, so that en email templates you can just use `{% extends "base.t" %}`.

Before this change, this is not possible as we use the `one_off` rendering method and Tera has very little context.

Please let me know what you think.