### PR TITLE
chore: update scraper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ ulid = { version = "1", optional = true }
 # bg_redis: redis workers
 redis = { version = "0.31", features = ["aio", "tokio-comp"], optional = true }
 
-scraper = { version = "0.21.0", features = ["deterministic"], optional = true }
+scraper = { version = "0.25.0", features = ["deterministic"], optional = true }
 
 dashmap = "6"
 notify = "8.1.0"


### PR DESCRIPTION
closes #1726

[scraper replaced fxhash with rust-hash](https://github.com/rust-scraper/scraper/issues/285)
