### PR TITLE
refactor: `Vars::cli_arg` returns `Result<&str>`

### DIFF
--- a/loco-new/base_template/src/tasks/user_create.rs
+++ b/loco-new/base_template/src/tasks/user_create.rs
@@ -26,9 +26,9 @@ impl Task for UserCreate {
             .map_err(|_| Error::string("password is mandatory"))?;
 
         let register_params = RegisterParams {
-            email: email.clone(),
-            password: password.clone(),
-            name: name.clone(),
+            email: email.to_owned(),
+            password: password.to_owned(),
+            name: name.to_owned(),
         };
 
         // Create user with password using the same logic as register controller

--- a/src/task.rs
+++ b/src/task.rs
@@ -2,7 +2,7 @@
 //!
 //! This module defines the task management framework used to manage and execute
 //! tasks in a web server application.
-use std::{collections::BTreeMap, ops::Deref};
+use std::collections::BTreeMap;
 
 use async_trait::async_trait;
 
@@ -58,7 +58,7 @@ impl Vars {
     pub fn cli_arg(&self, key: &str) -> Result<&str> {
         self.cli
             .get(key)
-            .map(Deref::deref)
+            .map(String::as_str)
             .ok_or(Error::Message(format!("the argument {key} does not exist")))
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -2,7 +2,7 @@
 //!
 //! This module defines the task management framework used to manage and execute
 //! tasks in a web server application.
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, ops::Deref};
 
 use async_trait::async_trait;
 
@@ -55,9 +55,10 @@ impl Vars {
     /// assert!(vars.cli_arg("key1").is_ok());
     /// assert!(vars.cli_arg("not-exists").is_err());
     /// ```
-    pub fn cli_arg(&self, key: &str) -> Result<&String> {
+    pub fn cli_arg(&self, key: &str) -> Result<&str> {
         self.cli
             .get(key)
+            .map(|key| key.deref())
             .ok_or(Error::Message(format!("the argument {key} does not exist")))
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -58,7 +58,7 @@ impl Vars {
     pub fn cli_arg(&self, key: &str) -> Result<&str> {
         self.cli
             .get(key)
-            .map(|key| key.deref())
+            .map(Deref::deref)
             .ok_or(Error::Message(format!("the argument {key} does not exist")))
     }
 }


### PR DESCRIPTION
This is a small QOL adjustment that allows you to quickly pattern match on a CLI argument. i.e.
```rust
match vars.cli_arg("foo")? {
  "apple" => ...
  "banana" => ...
  _ => ...
}
```
Sometimes when the value is optional...
```rust
match vars.cli_arg("foo") {
  Ok( "apple") => ...
  Ok(_) => ...
  Err(e) => ...
}
```

I don't see any particular behavior that would be lost from auto-dereffing the String [here](https://doc.rust-lang.org/std/string/struct.String.html). It seems that `&str` is more often more useful than `&String`.