### PR TITLE
refactor: Decouple extractors from `AppContext` using `FromRef`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use axum::extract::FromRef;
 use axum::Router as AxumRouter;
 use dashmap::DashMap;
 
@@ -249,7 +250,7 @@ impl<T: 'static + Send + Sync> std::ops::Deref for RefGuard<'_, T> {
 /// the web server to operate. It is typically used to store and manage shared
 /// resources and settings that are accessible throughout the application's
 /// lifetime.
-#[derive(Clone)]
+#[derive(Clone, FromRef)]
 #[allow(clippy::module_name_repetitions)]
 pub struct AppContext {
     /// The environment in which the application is running.

--- a/tests/controller/from_ref.rs
+++ b/tests/controller/from_ref.rs
@@ -1,0 +1,95 @@
+use axum::extract::FromRef;
+use loco_rs::{
+    app::{AppContext, SharedStore},
+    cache,
+    prelude::*,
+    tests_cfg,
+};
+use std::sync::Arc;
+
+use crate::infra_cfg;
+
+#[cfg(feature = "with-db")]
+use sea_orm::DatabaseConnection;
+
+/// Tests that DatabaseConnection can be extracted from AppContext via FromRef
+#[cfg(feature = "with-db")]
+#[tokio::test]
+async fn can_extract_db_connection_from_app_context() {
+    let ctx = tests_cfg::app::get_app_context().await;
+
+    #[allow(clippy::items_after_statements)]
+    async fn action(State(ctx): State<AppContext>) -> Result<Response> {
+        // Use FromRef to extract DatabaseConnection from AppContext
+        let _db: DatabaseConnection = DatabaseConnection::from_ref(&ctx);
+        format::json(serde_json::json!({"extracted": "db"}))
+    }
+
+    let port = get_available_port().await;
+    let handle = infra_cfg::server::start_with_route(ctx, "/", get(action), Some(port)).await;
+
+    let res = reqwest::get(get_base_url_port(port))
+        .await
+        .expect("Valid response");
+
+    assert_eq!(res.status(), 200);
+
+    let body: serde_json::Value = res.json().await.expect("JSON response");
+    assert_eq!(body["extracted"], "db");
+
+    handle.abort();
+}
+
+/// Tests that Arc<Cache> can be extracted from AppContext via FromRef
+#[tokio::test]
+async fn can_extract_cache_from_app_context() {
+    let ctx = tests_cfg::app::get_app_context().await;
+
+    #[allow(clippy::items_after_statements)]
+    async fn action(State(ctx): State<AppContext>) -> Result<Response> {
+        // Use FromRef to extract Arc<Cache> from AppContext
+        let _cache: Arc<cache::Cache> = Arc::from_ref(&ctx);
+        format::json(serde_json::json!({"extracted": "cache"}))
+    }
+
+    let port = get_available_port().await;
+    let handle = infra_cfg::server::start_with_route(ctx, "/", get(action), Some(port)).await;
+
+    let res = reqwest::get(get_base_url_port(port))
+        .await
+        .expect("Valid response");
+
+    assert_eq!(res.status(), 200);
+
+    let body: serde_json::Value = res.json().await.expect("JSON response");
+    assert_eq!(body["extracted"], "cache");
+
+    handle.abort();
+}
+
+/// Tests that Arc<SharedStore> can be extracted from AppContext via FromRef
+#[tokio::test]
+async fn can_extract_shared_store_from_app_context() {
+    let ctx = tests_cfg::app::get_app_context().await;
+
+    #[allow(clippy::items_after_statements)]
+    async fn action(State(ctx): State<AppContext>) -> Result<Response> {
+        // Use FromRef to extract Arc<SharedStore> from AppContext
+        let _store: Arc<SharedStore> = Arc::from_ref(&ctx);
+        format::json(serde_json::json!({"extracted": "shared_store"}))
+    }
+
+    let port = get_available_port().await;
+    let handle = infra_cfg::server::start_with_route(ctx, "/", get(action), Some(port)).await;
+
+    let res = reqwest::get(get_base_url_port(port))
+        .await
+        .expect("Valid response");
+
+    assert_eq!(res.status(), 200);
+
+    let body: serde_json::Value = res.json().await.expect("JSON response");
+    assert_eq!(body["extracted"], "shared_store");
+
+    handle.abort();
+}

--- a/tests/controller/mod.rs
+++ b/tests/controller/mod.rs
@@ -1,3 +1,4 @@
 mod extractor;
+mod from_ref;
 mod into_response;
 mod middlewares;


### PR DESCRIPTION
This PR derives [`FromRef::from_ref`](https://docs.rs/axum/latest/axum/extract/trait.FromRef.html) on `AppContext` to allow extractors to pull out fields of `AppContext` as [substates](https://docs.rs/axum/0.8.8/axum/extract/struct.State.html\#substates) in handers. It also refactors our existing extractors to be able to work with any state that implements `FromRef` to pull out the required substate (e.g. `DatabaseConnection`, `Config`, `SharedStore`, `Cache`, etc.).