### PR TITLE
feat(mailer): add MultiEmail and mail_template_multi for multiple recipients

### DIFF
--- a/src/mailer/email_sender.rs
+++ b/src/mailer/email_sender.rs
@@ -9,7 +9,7 @@ use lettre::{
 };
 use tracing::error;
 
-use super::{Email, Result, DEFAULT_FROM_SENDER};
+use super::{Email, MultiEmail, Result, DEFAULT_FROM_SENDER};
 use crate::{config, errors::Error};
 
 /// An enumeration representing the possible transport methods for sending
@@ -144,6 +144,66 @@ impl EmailSender {
                 error
             })?;
 
+        self.send(msg).await
+    }
+
+    /// Sends an email with multiple recipients using the configured transport
+    /// method.
+    ///
+    /// # Errors
+    ///
+    /// When email doesn't send successfully or has an error to build the
+    /// message
+    pub async fn mail_multi(&self, email: &MultiEmail) -> Result<()> {
+        let content = MultiPart::alternative_plain_html(email.text.clone(), email.html.clone());
+        let mut builder = Message::builder().from(
+            email
+                .from
+                .clone()
+                .unwrap_or_else(|| DEFAULT_FROM_SENDER.to_string())
+                .parse()?,
+        );
+
+        for to in &email.to {
+            builder = builder.to(to.parse()?);
+        }
+
+        for bcc in &email.bcc {
+            builder = builder.bcc(bcc.parse()?);
+        }
+
+        for cc in &email.cc {
+            builder = builder.cc(cc.parse()?);
+        }
+
+        if let Some(reply_to) = &email.reply_to {
+            builder = builder.reply_to(reply_to.parse()?);
+        }
+
+        if let Some(headers) = &email.headers {
+            if let Some(references) = &headers.references {
+                builder = builder.header(header::References::from(references.clone()));
+            }
+            if let Some(in_reply_to) = &headers.in_reply_to {
+                builder = builder.header(header::InReplyTo::from(in_reply_to.clone()));
+            }
+            if let Some(message_id) = &headers.message_id {
+                builder = builder.header(header::MessageId::from(message_id.clone()));
+            }
+        }
+
+        let msg = builder
+            .subject(email.subject.clone())
+            .multipart(content)
+            .map_err(|error| {
+                error!(err.msg = %error, err.detail = ?error, "email_building_error");
+                error
+            })?;
+
+        self.send(msg).await
+    }
+
+    async fn send(&self, msg: lettre::Message) -> Result<()> {
         match &self.transport {
             EmailTransport::Smtp(xp) => {
                 xp.send(msg).await?;
@@ -235,6 +295,86 @@ mod tests {
         };
         assert!(sender.mail(&data).await.is_ok());
 
+        with_settings!({filters => vec![
+            (r"[0-9A-Za-z]+{40}", "IDENTIFIER"),
+            (r"\w+, \d{1,2} \w+ \d{4} \d{2}:\d{2}:\d{2} [+-]\d{4}", "DATE")
+        ]}, {
+            assert_debug_snapshot!(stub.messages());
+        });
+    }
+
+    #[tokio::test]
+    async fn can_send_multi_email_with_multiple_to_recipients() {
+        let stub = StubTransport::new_ok();
+        let sender = EmailSender {
+            transport: EmailTransport::Test(stub.clone()),
+        };
+        let data = MultiEmail {
+            from: Some("test@framework.com".to_string()),
+            to: vec![
+                "user1@framework.com".to_string(),
+                "user2@framework.com".to_string(),
+            ],
+            subject: "Multi-To".to_string(),
+            text: "Hello".to_string(),
+            html: "<html><body>Hello</body></html>".to_string(),
+            ..Default::default()
+        };
+        assert!(sender.mail_multi(&data).await.is_ok());
+        with_settings!({filters => vec![
+            (r"[0-9A-Za-z]+{40}", "IDENTIFIER"),
+            (r"\w+, \d{1,2} \w+ \d{4} \d{2}:\d{2}:\d{2} [+-]\d{4}", "DATE")
+        ]}, {
+            assert_debug_snapshot!(stub.messages());
+        });
+    }
+
+    #[tokio::test]
+    async fn can_send_multi_email_with_multiple_bcc_recipients() {
+        let stub = StubTransport::new_ok();
+        let sender = EmailSender {
+            transport: EmailTransport::Test(stub.clone()),
+        };
+        let data = MultiEmail {
+            from: Some("test@framework.com".to_string()),
+            to: vec!["user1@framework.com".to_string()],
+            bcc: vec![
+                "bcc1@framework.com".to_string(),
+                "bcc2@framework.com".to_string(),
+            ],
+            subject: "Multi-BCC".to_string(),
+            text: "Hello".to_string(),
+            html: "<html><body>Hello</body></html>".to_string(),
+            ..Default::default()
+        };
+        assert!(sender.mail_multi(&data).await.is_ok());
+        with_settings!({filters => vec![
+            (r"[0-9A-Za-z]+{40}", "IDENTIFIER"),
+            (r"\w+, \d{1,2} \w+ \d{4} \d{2}:\d{2}:\d{2} [+-]\d{4}", "DATE")
+        ]}, {
+            assert_debug_snapshot!(stub.messages());
+        });
+    }
+
+    #[tokio::test]
+    async fn can_send_multi_email_with_multiple_cc_recipients() {
+        let stub = StubTransport::new_ok();
+        let sender = EmailSender {
+            transport: EmailTransport::Test(stub.clone()),
+        };
+        let data = MultiEmail {
+            from: Some("test@framework.com".to_string()),
+            to: vec!["user1@framework.com".to_string()],
+            cc: vec![
+                "cc1@framework.com".to_string(),
+                "cc2@framework.com".to_string(),
+            ],
+            subject: "Multi-CC".to_string(),
+            text: "Hello".to_string(),
+            html: "<html><body>Hello</body></html>".to_string(),
+            ..Default::default()
+        };
+        assert!(sender.mail_multi(&data).await.is_ok());
         with_settings!({filters => vec![
             (r"[0-9A-Za-z]+{40}", "IDENTIFIER"),
             (r"\w+, \d{1,2} \w+ \d{4} \d{2}:\d{2}:\d{2} [+-]\d{4}", "DATE")

--- a/src/mailer/mod.rs
+++ b/src/mailer/mod.rs
@@ -37,6 +37,18 @@ pub struct Args {
     pub headers: Option<EmailHeaders>,
 }
 
+/// The arguments struct for specifying email details with multiple recipients.
+#[derive(Debug, Clone, Default)]
+pub struct MultiArgs {
+    pub from: Option<String>,
+    pub to: Vec<String>,
+    pub reply_to: Option<String>,
+    pub locals: serde_json::Value,
+    pub bcc: Vec<String>,
+    pub cc: Vec<String>,
+    pub headers: Option<EmailHeaders>,
+}
+
 /// The structure representing an email details.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Email {
@@ -56,6 +68,29 @@ pub struct Email {
     pub bcc: Option<String>,
     /// CC header to message
     pub cc: Option<String>,
+    /// Custom headers for the email (e.g., References, In-Reply-To, Message-ID)
+    pub headers: Option<EmailHeaders>,
+}
+
+/// The structure representing an email with multiple recipients.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct MultiEmail {
+    /// Mailbox to `From` header
+    pub from: Option<String>,
+    /// Mailboxes to `To` header
+    pub to: Vec<String>,
+    /// Mailbox to `ReplyTo` header
+    pub reply_to: Option<String>,
+    /// Subject header to message
+    pub subject: String,
+    /// Plain text message
+    pub text: String,
+    /// HTML template
+    pub html: String,
+    /// Mailboxes to `BCC` header
+    pub bcc: Vec<String>,
+    /// Mailboxes to `CC` header
+    pub cc: Vec<String>,
     /// Custom headers for the email (e.g., References, In-Reply-To, Message-ID)
     pub headers: Option<EmailHeaders>,
 }
@@ -93,6 +128,19 @@ pub trait Mailer {
         Ok(())
     }
 
+    /// Sends an email to multiple recipients using the provided [`AppContext`]
+    /// and email details.
+    async fn mail_multi(ctx: &AppContext, email: &MultiEmail) -> Result<()> {
+        let opts = Self::opts();
+        let mut email = email.clone();
+
+        email.from = Some(email.from.unwrap_or_else(|| opts.from.clone()));
+        email.reply_to = email.reply_to.or_else(|| opts.reply_to.clone());
+
+        MultiMailerWorker::perform_later(ctx, email.clone()).await?;
+        Ok(())
+    }
+
     /// Renders and sends an email using the provided [`AppContext`], template
     /// directory, and arguments.
     async fn mail_template(ctx: &AppContext, dir: &Dir<'_>, args: Args) -> Result<()> {
@@ -100,6 +148,27 @@ pub trait Mailer {
         Self::mail(
             ctx,
             &Email {
+                from: args.from.clone(),
+                to: args.to.clone(),
+                reply_to: args.reply_to.clone(),
+                subject: content.subject,
+                text: content.text,
+                html: content.html,
+                bcc: args.bcc.clone(),
+                cc: args.cc.clone(),
+                headers: args.headers.clone(),
+            },
+        )
+        .await
+    }
+
+    /// Renders and sends an email to multiple recipients using the provided
+    /// [`AppContext`], template directory, and arguments.
+    async fn mail_template_multi(ctx: &AppContext, dir: &Dir<'_>, args: MultiArgs) -> Result<()> {
+        let content = Template::new(dir).render(&args.locals)?;
+        Self::mail_multi(
+            ctx,
+            &MultiEmail {
                 from: args.from.clone(),
                 to: args.to.clone(),
                 reply_to: args.reply_to.clone(),
@@ -138,6 +207,47 @@ impl BackgroundWorker<Email> for MailerWorker {
     async fn perform(&self, email: Email) -> crate::Result<()> {
         if let Some(mailer) = &self.ctx.mailer {
             let res = mailer.mail(&email).await;
+            match res {
+                Ok(res) => Ok(res),
+                Err(err) => {
+                    error!(err = err.to_string(), "mailer error");
+                    Err(err)
+                }
+            }
+        } else {
+            let err = crate::Error::Message(
+                "attempting to send email but no email sender configured".to_string(),
+            );
+            error!(err = err.to_string(), "mailer error");
+            Err(err)
+        }
+    }
+}
+
+/// The [`MultiMailerWorker`] struct represents a worker responsible for
+/// asynchronous email processing with multiple recipients.
+#[allow(clippy::module_name_repetitions)]
+pub struct MultiMailerWorker {
+    pub ctx: AppContext,
+}
+
+/// Implementation of the [`Worker`] trait for the [`MultiMailerWorker`].
+#[async_trait]
+impl BackgroundWorker<MultiEmail> for MultiMailerWorker {
+    fn queue() -> Option<String> {
+        Some("mailer".to_string())
+    }
+
+    fn build(ctx: &AppContext) -> Self {
+        Self { ctx: ctx.clone() }
+    }
+
+    /// Performs the email sending operation using the provided [`AppContext`]
+    /// and email details.
+    async fn perform(&self, email: MultiEmail) -> crate::Result<()> {
+        if let Some(mailer) = &self.ctx.mailer {
+            let res = mailer.mail_multi(&email).await;
+            // mailer is EmailSender, which has mail_multi defined on it
             match res {
                 Ok(res) => Ok(res),
                 Err(err) => {

--- a/src/mailer/snapshots/loco_rs__mailer__email_sender__tests__can_send_multi_email_with_multiple_bcc_recipients.snap
+++ b/src/mailer/snapshots/loco_rs__mailer__email_sender__tests__can_send_multi_email_with_multiple_bcc_recipients.snap
@@ -1,0 +1,31 @@
+---
+source: src/mailer/email_sender.rs
+expression: stub.messages()
+---
+[
+    (
+        Envelope {
+            forward_path: [
+                Address {
+                    serialized: "user1@framework.com",
+                    at_start: 5,
+                },
+                Address {
+                    serialized: "bcc1@framework.com",
+                    at_start: 4,
+                },
+                Address {
+                    serialized: "bcc2@framework.com",
+                    at_start: 4,
+                },
+            ],
+            reverse_path: Some(
+                Address {
+                    serialized: "test@framework.com",
+                    at_start: 4,
+                },
+            ),
+        },
+        "From: test@framework.com\r\nTo: user1@framework.com\r\nSubject: Multi-BCC\r\nMIME-Version: 1.0\r\nDate: DATE\r\nContent-Type: multipart/alternative;\r\n boundary=\"IDENTIFIER\"\r\n\r\n--IDENTIFIER\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\nHello\r\n--IDENTIFIER\r\nContent-Type: text/html; charset=utf-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\n<html><body>Hello</body></html>\r\n--IDENTIFIER--\r\n",
+    ),
+]

--- a/src/mailer/snapshots/loco_rs__mailer__email_sender__tests__can_send_multi_email_with_multiple_cc_recipients.snap
+++ b/src/mailer/snapshots/loco_rs__mailer__email_sender__tests__can_send_multi_email_with_multiple_cc_recipients.snap
@@ -1,0 +1,31 @@
+---
+source: src/mailer/email_sender.rs
+expression: stub.messages()
+---
+[
+    (
+        Envelope {
+            forward_path: [
+                Address {
+                    serialized: "user1@framework.com",
+                    at_start: 5,
+                },
+                Address {
+                    serialized: "cc1@framework.com",
+                    at_start: 3,
+                },
+                Address {
+                    serialized: "cc2@framework.com",
+                    at_start: 3,
+                },
+            ],
+            reverse_path: Some(
+                Address {
+                    serialized: "test@framework.com",
+                    at_start: 4,
+                },
+            ),
+        },
+        "From: test@framework.com\r\nTo: user1@framework.com\r\nCc: cc1@framework.com, cc2@framework.com\r\nSubject: Multi-CC\r\nMIME-Version: 1.0\r\nDate: DATE\r\nContent-Type: multipart/alternative;\r\n boundary=\"IDENTIFIER\"\r\n\r\n--IDENTIFIER\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\nHello\r\n--IDENTIFIER\r\nContent-Type: text/html; charset=utf-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\n<html><body>Hello</body></html>\r\n--IDENTIFIER--\r\n",
+    ),
+]

--- a/src/mailer/snapshots/loco_rs__mailer__email_sender__tests__can_send_multi_email_with_multiple_to_recipients.snap
+++ b/src/mailer/snapshots/loco_rs__mailer__email_sender__tests__can_send_multi_email_with_multiple_to_recipients.snap
@@ -1,0 +1,27 @@
+---
+source: src/mailer/email_sender.rs
+expression: stub.messages()
+---
+[
+    (
+        Envelope {
+            forward_path: [
+                Address {
+                    serialized: "user1@framework.com",
+                    at_start: 5,
+                },
+                Address {
+                    serialized: "user2@framework.com",
+                    at_start: 5,
+                },
+            ],
+            reverse_path: Some(
+                Address {
+                    serialized: "test@framework.com",
+                    at_start: 4,
+                },
+            ),
+        },
+        "From: test@framework.com\r\nTo: user1@framework.com, user2@framework.com\r\nSubject: Multi-To\r\nMIME-Version: 1.0\r\nDate: DATE\r\nContent-Type: multipart/alternative;\r\n boundary=\"IDENTIFIER\"\r\n\r\n--IDENTIFIER\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\nHello\r\n--IDENTIFIER\r\nContent-Type: text/html; charset=utf-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\n<html><body>Hello</body></html>\r\n--IDENTIFIER--\r\n",
+    ),
+]


### PR DESCRIPTION
## Problem

The current `Mailer` API only supports a single recipient in the `to`, `cc`, and `bcc` fields (`String`). There is no built-in way to send one email to multiple recipients in a single call.

This is a common real-world need — notification emails, team digests, CC-to-manager flows — and currently requires users to loop and call `mail_template` once per recipient, which is inefficient and semantically incorrect (each call produces a separate email rather than one email with multiple recipients).

## Solution

Introduces a parallel set of types alongside the existing single-recipient API. The existing `Email`, `Args`, `MailerWorker`, and `mail_template` are **completely untouched** — no breaking changes.

### New additions

| Symbol | Description |
|---|---|
| `MultiEmail` | Serializable job payload with `to`, `cc`, `bcc` as `Vec<String>` |
| `MultiArgs` | Caller-facing args struct with `to`, `cc`, `bcc` as `Vec<String>` |
| `MultiMailerWorker` | Background worker that processes `MultiEmail` via the existing `mailer` queue |
| `Mailer::mail_multi` | Dispatches a `MultiEmail` to `MultiMailerWorker` |
| `Mailer::mail_template_multi` | Renders a template and calls `mail_multi` |
| `EmailSender::mail_multi` | Builds and sends a lettre message from `MultiEmail` |

### Usage

```rust
MyMailer::mail_template_multi(
    &ctx,
    &TEMPLATES,
    MultiArgs {
        to: vec!["alice@example.com".to_string(), "bob@example.com".to_string()],
        cc: vec!["manager@example.com".to_string()],
        locals: json!({ "name": "Team" }),
        ..Default::default()
    },
)
.await?;
```

## Testing

- Existing snapshot tests (`can_send_email`, `can_send_email_with_custom_headers`) pass unchanged, confirming no regression on the original path.
- Three new snapshot tests cover `mail_multi` with multiple `to`, `cc`, and `bcc` recipients, verifying the correct headers appear in the built message.
- `cargo fmt` (nightly) — no changes required.
- `cargo clippy -p loco-rs` — zero warnings in mailer code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)