### PR TITLE
feat(mailer): support implicit TLS (SMTPS / port 465)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -529,6 +529,20 @@ pub enum WorkerMode {
 ///     port: 1025
 ///     secure: false
 /// ```
+///
+/// Example (production) with implicit TLS on port 465 (SMTPS) — note `tls: implicit`,
+/// since `secure: true` only does STARTTLS (port 587):
+/// ```yaml
+/// mailer:
+///   smtp:
+///     enable: true
+///     host: smtp.example.com
+///     port: 465
+///     tls: implicit
+///     auth:
+///       user: postmaster@mg.example.com
+///       password: "{{ get_env(name='SMTP_PASSWORD') }}"
+/// ```
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Mailer {
     pub smtp: Option<SmtpMailer>,
@@ -551,6 +565,21 @@ pub struct Mailer {
 ///       unique within the oauth2 config. ... # other fields
 pub type Initializers = BTreeMap<String, serde_json::Value>;
 
+/// TLS mode for the SMTP connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MailerTls {
+    /// Opportunistic TLS: connect in cleartext, then upgrade with `STARTTLS`
+    /// (the SMTP submission port, 587). This is what `secure: true` selects.
+    Starttls,
+    /// Implicit TLS: the connection is encrypted from the first byte (SMTPS,
+    /// port 465). Required by providers that listen for implicit TLS on 465 —
+    /// `STARTTLS` does not work there.
+    Implicit,
+    /// No transport security (cleartext). For local sinks like Mailpit only.
+    None,
+}
+
 /// SMTP mailer configuration structure.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SmtpMailer {
@@ -559,12 +588,33 @@ pub struct SmtpMailer {
     pub host: String,
     /// SMTP port/
     pub port: u16,
-    /// Enable TLS
+    /// Enable TLS.
+    ///
+    /// Backwards-compatible shorthand: `true` selects `STARTTLS`, `false`
+    /// cleartext. Prefer [`SmtpMailer::tls`] for implicit TLS (port 465);
+    /// when `tls` is set it takes precedence over this flag.
     pub secure: bool,
+    /// Explicit TLS mode. When set, overrides [`SmtpMailer::secure`]. Use
+    /// [`MailerTls::Implicit`] for SMTPS on port 465.
+    #[serde(default)]
+    pub tls: Option<MailerTls>,
     /// Auth SMTP server
     pub auth: Option<MailerAuth>,
     /// Optional EHLO client ID instead of hostname
     pub hello_name: Option<String>,
+}
+
+impl SmtpMailer {
+    /// Resolve the effective TLS mode: explicit [`SmtpMailer::tls`] when set,
+    /// otherwise derived from the legacy [`SmtpMailer::secure`] flag.
+    #[must_use]
+    pub fn tls_mode(&self) -> MailerTls {
+        self.tls.unwrap_or(if self.secure {
+            MailerTls::Starttls
+        } else {
+            MailerTls::None
+        })
+    }
 }
 
 /// Authentication details for the mailer

--- a/src/mailer/email_sender.rs
+++ b/src/mailer/email_sender.rs
@@ -44,16 +44,31 @@ impl EmailSender {
     ///
     /// when could not initialize SMTP transport
     pub fn smtp(config: &config::SmtpMailer) -> Result<Self> {
-        let mut email_builder = if config.secure {
-            lettre::AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&config.host)
-                .map_err(|error| {
-                    error!(err.msg = %error, err.detail = ?error, "smtp_init_error");
-                    error
-                })?
-                .port(config.port)
-        } else {
-            lettre::AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&config.host)
-                .port(config.port)
+        let host = &config.host;
+        let mut email_builder = match config.tls_mode() {
+            // Opportunistic upgrade on a cleartext connection (STARTTLS, port 587).
+            config::MailerTls::Starttls => {
+                lettre::AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(host)
+                    .map_err(|error| {
+                        error!(err.msg = %error, err.detail = ?error, "smtp_init_error");
+                        error
+                    })?
+                    .port(config.port)
+            }
+            // Implicit TLS — encrypted from the first byte (SMTPS, port 465).
+            config::MailerTls::Implicit => {
+                lettre::AsyncSmtpTransport::<Tokio1Executor>::relay(host)
+                    .map_err(|error| {
+                        error!(err.msg = %error, err.detail = ?error, "smtp_init_error");
+                        error
+                    })?
+                    .port(config.port)
+            }
+            // Cleartext (no TLS).
+            config::MailerTls::None => {
+                lettre::AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(host)
+                    .port(config.port)
+            }
         };
 
         if let Some(auth) = config.auth.as_ref() {
@@ -164,6 +179,35 @@ mod tests {
     use lettre::transport::stub::StubTransport;
 
     use super::*;
+
+    #[test]
+    fn smtp_builds_for_each_tls_mode() {
+        use crate::config::{MailerTls, SmtpMailer};
+
+        let cfg = |tls: Option<MailerTls>, secure: bool| SmtpMailer {
+            enable: true,
+            host: "smtp.example.com".to_string(),
+            port: 465,
+            secure,
+            tls,
+            auth: None,
+            hello_name: None,
+        };
+
+        // Every explicit TLS mode builds a transport (incl. implicit TLS for 465 — the case
+        // that was previously impossible: `secure: true` only ever did STARTTLS).
+        assert!(EmailSender::smtp(&cfg(Some(MailerTls::Starttls), false)).is_ok());
+        assert!(EmailSender::smtp(&cfg(Some(MailerTls::Implicit), false)).is_ok());
+        assert!(EmailSender::smtp(&cfg(Some(MailerTls::None), false)).is_ok());
+
+        // Legacy `secure` flag keeps mapping as before when `tls` is unset.
+        assert_eq!(cfg(None, true).tls_mode(), MailerTls::Starttls);
+        assert_eq!(cfg(None, false).tls_mode(), MailerTls::None);
+        assert!(EmailSender::smtp(&cfg(None, true)).is_ok());
+
+        // Explicit `tls` takes precedence over `secure`.
+        assert_eq!(cfg(Some(MailerTls::Implicit), true).tls_mode(), MailerTls::Implicit);
+    }
 
     #[tokio::test]
     async fn can_send_email() {


### PR DESCRIPTION
## What

Adds implicit-TLS support to the SMTP mailer so it can reach providers that listen for TLS on port 465 (SMTPS). Today `secure: true` only ever does STARTTLS (`starttls_relay`), so 465 cannot work and fails silently in the mailer worker.

Fixes #1773.

## How

- New `MailerTls` enum (`starttls` | `implicit` | `none`) and an optional `SmtpMailer.tls` field.
- `SmtpMailer::tls_mode()` resolves the effective mode: explicit `tls` wins; otherwise it is derived from the legacy `secure` bool (`true` → starttls, `false` → none).
- `EmailSender::smtp()` matches the mode → `starttls_relay` / `relay` (implicit) / `builder_dangerous`.

## Backwards compatibility

Fully compatible — `tls` is `#[serde(default)]` optional; configs that only set `secure` behave exactly as before.

## Config

```yaml
mailer:
  smtp:
    host: smtp.example.com
    port: 465
    tls: implicit
```

## Tests

Added `smtp_builds_for_each_tls_mode` covering all three modes, the legacy `secure` mapping, and `tls`-over-`secure` precedence. `cargo test --lib mailer` green; the two clippy warnings in CI are pre-existing (`schema.rs`, `engine.rs`), not in the touched files.