### PR TITLE
fix(docs): flash of light theme in dark mode

### DIFF
--- a/docs-site/static/js/main.js
+++ b/docs-site/static/js/main.js
@@ -5,10 +5,3 @@ document.getElementById('mode').addEventListener('click', () => {
     localStorage.setItem('theme', document.documentElement.classList.contains('dark') ? 'dark' : 'light');
 
 });
-
-// enforce local storage setting but also fallback to user-agent preferences
-if (localStorage.getItem('theme') === 'dark' || (!localStorage.getItem('theme') && window.matchMedia("(prefers-color-scheme: dark)").matches)) {
-
-    document.documentElement.classList.add('dark');
-
-}

--- a/docs-site/templates/base.html
+++ b/docs-site/templates/base.html
@@ -94,6 +94,14 @@
   <link rel="apple-touch-icon" sizes="180x180" href={{ get_url(path="apple-touch-icon.png" ) }}>
   <link rel="icon" type="image/png" href={{ get_url(path="favicon-32x32.png" ) }}>
 
+  <script>
+    // enforce local storage setting but also fallback to user-agent preferences
+    if (localStorage.getItem('theme') === 'dark' || (!localStorage.getItem('theme') && window.matchMedia("(prefers-color-scheme: dark)").matches)) {
+
+        document.documentElement.classList.add('dark');
+
+    }
+  </script>
 </head>
 
 <body class="bg-background">


### PR DESCRIPTION
Fixes https://github.com/loco-rs/loco/issues/1333

The JS code responsible for the dark mode class is now inlined, so it runs before the page is rendered. No more flashbang in dark mode.