### PR TITLE
fix(docs): set images width and height to avoid content jumping

### DIFF
--- a/docs-site/content/blog/hello-world.md
+++ b/docs-site/content/blog/hello-world.md
@@ -12,7 +12,7 @@ authors = ["Team Loco"]
 +++
 
 <center>
-<img width="150" src="/icon.svg"/> 
+<img width="150" height="150" src="/icon.svg"/> 
 
 
 **What if [Rails](https://rubyonrails.org) was built on Rust and not Ruby?**

--- a/docs-site/content/docs/getting-started/tour/index.md
+++ b/docs-site/content/docs/getting-started/tour/index.md
@@ -14,7 +14,7 @@ flair =[]
 +++
 
 
-<img style="width:100%; max-width:640px" src="tour.png"/>
+<img style="width:100%; max-width:640px" src="tour.png" width="1024" height="1024"/>
 <br/>
 <br/>
 <br/>

--- a/docs-site/content/docs/processing/workers.md
+++ b/docs-site/content/docs/processing/workers.md
@@ -262,7 +262,7 @@ workers:
 ## Manage a Workers From UI
 
 You can manage the jobs queue with the [Loco admin job project](https://github.com/loco-rs/admin-jobs).
-![<img style="width:100%; max-width:640px" src="tour.png"/>](https://github.com/loco-rs/admin-jobs/raw/main/media/screenshot.png)
+<img src="https://github.com/loco-rs/admin-jobs/raw/main/media/screenshot.png" width="1276" height="964" />
 
 ### Managing Job Queues via CLI
 

--- a/docs-site/static/styles/styles.css
+++ b/docs-site/static/styles/styles.css
@@ -1238,6 +1238,11 @@ a.active {
   margin-bottom: 0.25rem;
 }
 
+.my-16 {
+  margin-top: 4rem;
+  margin-bottom: 4rem;
+}
+
 .my-3 {
   margin-top: 0.75rem;
   margin-bottom: 0.75rem;
@@ -1246,36 +1251,6 @@ a.active {
 .my-5 {
   margin-top: 1.25rem;
   margin-bottom: 1.25rem;
-}
-
-.my-8 {
-  margin-top: 2rem;
-  margin-bottom: 2rem;
-}
-
-.my-\[8rem\] {
-  margin-top: 8rem;
-  margin-bottom: 8rem;
-}
-
-.my-16 {
-  margin-top: 4rem;
-  margin-bottom: 4rem;
-}
-
-.my-4 {
-  margin-top: 1rem;
-  margin-bottom: 1rem;
-}
-
-.my-\[4rem\] {
-  margin-top: 4rem;
-  margin-bottom: 4rem;
-}
-
-.my-\[4\] {
-  margin-top: 4;
-  margin-bottom: 4;
 }
 
 .my-\[2rem\] {
@@ -1297,6 +1272,10 @@ a.active {
 
 .mb-12 {
   margin-bottom: 3rem;
+}
+
+.mb-2 {
+  margin-bottom: 0.5rem;
 }
 
 .mb-20 {
@@ -1367,18 +1346,6 @@ a.active {
   margin-top: 1px;
 }
 
-.mb-2 {
-  margin-bottom: 0.5rem;
-}
-
-.mt-14 {
-  margin-top: 3.5rem;
-}
-
-.mt-16 {
-  margin-top: 4rem;
-}
-
 .block {
   display: block;
 }
@@ -1431,6 +1398,14 @@ a.active {
   height: 2.25rem;
 }
 
+.h-\[130px\] {
+  height: 130px;
+}
+
+.h-\[30px\] {
+  height: 30px;
+}
+
 .h-full {
   height: 100%;
 }
@@ -1453,6 +1428,14 @@ a.active {
 
 .w-8 {
   width: 2rem;
+}
+
+.w-\[130px\] {
+  width: 130px;
+}
+
+.w-\[30px\] {
+  width: 30px;
 }
 
 .w-full {
@@ -1722,11 +1705,6 @@ a.active {
   padding-bottom: 15px;
 }
 
-.py-4 {
-  padding-top: 1rem;
-  padding-bottom: 1rem;
-}
-
 .pb-12 {
   padding-bottom: 3rem;
 }
@@ -1749,10 +1727,6 @@ a.active {
 
 .pt-8 {
   padding-top: 2rem;
-}
-
-.pt-2 {
-  padding-top: 0.5rem;
 }
 
 .text-left {
@@ -1919,6 +1893,10 @@ a.active {
   --tw-shadow: 0 0 #0000;
   --tw-shadow-colored: 0 0 #0000;
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.filter {
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 
 .backdrop-blur {
@@ -2399,21 +2377,6 @@ html.dark .toggle-dark {
 }
 
 @media (min-width: 640px) {
-  .sm\:my-6 {
-    margin-top: 1.5rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .sm\:my-\[4rem\] {
-    margin-top: 4rem;
-    margin-bottom: 4rem;
-  }
-
-  .sm\:my-\[8rem\] {
-    margin-top: 8rem;
-    margin-bottom: 8rem;
-  }
-
   .sm\:flex {
     display: flex;
   }
@@ -2458,26 +2421,12 @@ html.dark .toggle-dark {
     margin-bottom: 8rem;
   }
 
-  .md\:my-\[6rem\] {
-    margin-top: 6rem;
-    margin-bottom: 6rem;
-  }
-
-  .md\:my-\[4rem\] {
-    margin-top: 4rem;
-    margin-bottom: 4rem;
+  .md\:mb-4 {
+    margin-bottom: 1rem;
   }
 
   .md\:mt-0 {
     margin-top: 0px;
-  }
-
-  .md\:mb-2 {
-    margin-bottom: 0.5rem;
-  }
-
-  .md\:mb-4 {
-    margin-bottom: 1rem;
   }
 
   .md\:grid {
@@ -2492,17 +2441,8 @@ html.dark .toggle-dark {
     grid-template-columns: 240px minmax(0,1fr);
   }
 
-  .md\:justify-start {
-    justify-content: flex-start;
-  }
-
   .md\:gap-10 {
     gap: 2.5rem;
-  }
-
-  .md\:py-8 {
-    padding-top: 2rem;
-    padding-bottom: 2rem;
   }
 
   .md\:pr-12 {
@@ -2521,11 +2461,6 @@ html.dark .toggle-dark {
 
   .lg\:justify-end {
     justify-content: flex-end;
-  }
-
-  .lg\:py-8 {
-    padding-top: 2rem;
-    padding-bottom: 2rem;
   }
 }
 

--- a/docs-site/templates/index.html
+++ b/docs-site/templates/index.html
@@ -28,7 +28,8 @@
 <div class="prose dark:prose-invert max-w-[100%]">
 
 <div class="relative bg-left-bottom mt-12 md:mt-0">
-    <img class="m-0 mt-[-60px] w-full" src="header.svg"/>
+    {% set header_meta = get_image_metadata(path="header.svg") %}
+    <img class="m-0 mt-[-60px] w-full" src="header.svg" width="{{ header_meta.width }}" height="{{ header_meta.height }}"/>
 </div>
 
 
@@ -111,7 +112,8 @@ compilation: <span class="text-yellow-400">debug</span>
     </div>
     <div class="py-6"></div>
 
-    <img src="/cloud.svg" class="absolute right-0 bottom-0 m-0" />
+    {% set cloud_meta = get_image_metadata(path="cloud.svg") %}
+    <img src="/cloud.svg" class="absolute right-0 bottom-0 m-0" width="{{ cloud_meta.width }}" height="{{ cloud_meta.height }}" />
 </div>
 
 
@@ -128,15 +130,18 @@ compilation: <span class="text-yellow-400">debug</span>
 
     <div class="container">
         <div class="flex flex-col items-center rounded-lg shadow-lg bg-red-900 w-full sm:w-7/12 mx-auto">
-            <img src="bench-db-q.svg"/>
-            <img src="bench-no-db.svg"/>
+            {% set bench_db_meta = get_image_metadata(path="bench-db-q.svg") %}
+            {% set bench_no_db_meta = get_image_metadata(path="bench-no-db.svg") %}
+            <img src="bench-db-q.svg" width="{{ bench_db_meta.width }}" height="{{ bench_db_meta.height }}" />
+            <img src="bench-no-db.svg" width="{{ bench_no_db_meta.width }}" height="{{ bench_no_db_meta.height }}" />
         </div>
     </div>
 
     <div class="flex items-center justify-center py-6 z-10 relative">
         <a class="fatbtn dark:bg-foreground dark:text-background" href="/docs/getting-started/tour/">Get started &rarr;</a>
     </div>
-    <img src="/mountain-bg.svg" class="absolute left-0 top-[-490px]" />
+    {% set mountain_meta = get_image_metadata(path="mountain-bg.svg") %}
+    <img src="/mountain-bg.svg" class="absolute left-0 top-[-490px]" width="{{ mountain_meta.width }}" height="{{ mountain_meta.height }}" />
 </div>
 
 <div class="section bg-gray-100 dark:bg-background">

--- a/docs-site/templates/macros/footer.html
+++ b/docs-site/templates/macros/footer.html
@@ -2,7 +2,8 @@
 <div class="section bg-redrust dark:bg-zinc-800 pt-8">
   <div class="container flex flex-col items-center text-center text-background py-8 pb-12">
       <div class="mb-8">
-      <img src="/icon.svg" width="130px" />
+      {% set icon_meta = get_image_metadata(path="icon.svg") %}
+      <img class="w-[130px] h-[130px]" src="/icon.svg" width="{{ icon_meta.width }}" height="{{ icon_meta.height }}" />
       </div>
       <div class="footer-links">
           <a href="https://github.com/loco-rs/loco">

--- a/docs-site/templates/macros/header.html
+++ b/docs-site/templates/macros/header.html
@@ -4,7 +4,8 @@
 	<div class="container relative flex h-14 md:grid md:grid-cols-[240px_minmax(0,1fr)] xl:max-w-[80rem]">
 		<div class="mr-4 hidden sm:flex">
 			<a class="flex mr-4  items-center space-x-2" href="/">
-				<img src="/icon.svg" width="30px" />
+				{% set icon_meta = get_image_metadata(path="icon.svg") %}
+				<img class="w-[30px] h-[30px]" src="/icon.svg" width="{{ icon_meta.width }}" height="{{ icon_meta.height }}" />
 			</a>
 			<nav class="flex w-full bg-transparent items-center gap-4 text-sm">
 				{% if lang == config.default_language %}
@@ -51,7 +52,8 @@
 				<div class="absolute mt-[106px] left-0 right-0">
 						<nav id="menu-toggle" class="flex hidden bg-background  items-center gap-4 text-sm py-[15px] px-2 w-full">
 							<a class="flex items-center" href="/">
-								<img src="/icon.svg" width="30px" />
+								{% set icon_meta = get_image_metadata(path="icon.svg") %}
+								<img class="w-[30px] h-[30px]" src="/icon.svg" width="{{ icon_meta.width }}" height="{{ icon_meta.height }}" />
 							</a>
 							{% if lang == config.default_language %}
 							{% set rootsectionpath = "_index.md" %}

--- a/docs-site/templates/macros/youtube.html
+++ b/docs-site/templates/macros/youtube.html
@@ -10,5 +10,5 @@
 {% endmacro %}
 
 {% macro thumb(id, class=false) %}
-<img class="max-w-[200px] max-h-[230px] rounded-md" {% if class %}class="{{class}}"{% endif %} src="https://i3.ytimg.com/vi/{{id}}/hqdefault.jpg" />
+<img class="max-w-[200px] max-h-[230px] rounded-md" {% if class %}class="{{class}}"{% endif %} src="https://i3.ytimg.com/vi/{{id}}/hqdefault.jpg" width="480" height="360" />
 {% endmacro %}

--- a/docs-site/translations/tour-fr.md
+++ b/docs-site/translations/tour-fr.md
@@ -15,7 +15,7 @@ flair =[]
 
 [English](./index.md) - Français
 
-<img style="width:100%; max-width:640px" src="tour.png"/>
+<img style="width:100%; max-width:640px" src="tour.png" width="1024" height="1024"/>
 <br/>
 <br/>
 <br/>


### PR DESCRIPTION
Missing `width` and `height` attributes caused content jumping on several pages. Fixed by adding the attributes to all image elements.