### PR TITLE
fix(docs): add dark mode to prose blocks

### DIFF
--- a/docs-site/templates/blog/page.html
+++ b/docs-site/templates/blog/page.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 <div class="container" role="document">
-  <article class="prose mx-auto my-[2rem] md:my-[8rem]">
+  <article class="prose dark:prose-invert mx-auto my-[2rem] md:my-[8rem]">
     {{ macros_publish::page_publish_metadata(page=page) }}
     <h1 class="mb-1 font-extrabold">{{ page.title }}</h1>
     <div class="text-gray-500 font-semibold">

--- a/docs-site/templates/casts/page.html
+++ b/docs-site/templates/casts/page.html
@@ -15,7 +15,7 @@
   <article class="max-w-[1024px] mx-auto my-[2rem] md:my-[8rem]">
     {{ youtube::youtube(id=page.extra.id) }}
     {% if page.extra.lead %}<p class="lead">{{ page.extra.lead | safe }}</p>{% endif %}
-    <div class="prose markdown mt-8 mx-auto">
+    <div class="prose dark:prose-invert markdown mt-8 mx-auto">
       {{ macros_publish::page_publish_metadata(page=page) }}
       <h1 class="mb-3">{{ page.title }}</h1>
       {{ page.content | safe }}

--- a/docs-site/templates/index.html
+++ b/docs-site/templates/index.html
@@ -156,7 +156,7 @@ compilation: <span class="text-yellow-400">debug</span>
 
             {% for val in config.extra.homepage.features %}
             <div class="col-span-2 grid items-start xl:col-span-1 text-center">
-                    <div class="overflow-auto text-sm prose min-w-[100%] text-left">
+                    <div class="overflow-auto text-sm prose dark:prose-invert min-w-[100%] text-left">
                         {{ val.example | markdown(inline=true) | safe }}
                     </div>
 


### PR DESCRIPTION
Fixes prose blocks dark theme.

Before
<img width="734" height="511" alt="image" src="https://github.com/user-attachments/assets/d137dfe6-2d88-4c97-b548-905a2bf260e6" />


After
<img width="734" height="511" alt="image" src="https://github.com/user-attachments/assets/66345d74-3915-4def-bd3c-b3680a0e2b0f" />
