### PR TITLE
chore(deps): bump opendal to 0.58.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ chrono = { workspace = true }
 uuid = { version = "1.10.0", features = ["v4", "fast-rng"] }
 
 # File Upload
-opendal = { version = "0.57", default-features = false, features = [
+opendal = { version = "0.58.1", default-features = false, features = [
     "services-memory",
     "services-fs",
     "layers-retry",

--- a/src/storage/drivers/aws.rs
+++ b/src/storage/drivers/aws.rs
@@ -27,7 +27,8 @@ pub struct Credential {
 /// When could not initialize the client instance
 pub fn new(bucket_name: &str, region: &str) -> StorageResult<Box<dyn StoreDriver>> {
     let s3 = S3::default().bucket(bucket_name).region(region);
-    Ok(Box::new(OpendalAdapter::new(Operator::new(s3)?.finish())))
+    // opendal 0.58: Operator::new returns a finished Operator (no .finish()).
+    Ok(Box::new(OpendalAdapter::new(Operator::new(s3)?)))
 }
 
 /// Create new AWS s3 storage with bucket, region and credentials and URL.
@@ -67,7 +68,7 @@ pub fn with_credentials_and_endpoint(
     if let Some(token) = credentials.token {
         s3 = s3.session_token(&token);
     }
-    Ok(Box::new(OpendalAdapter::new(Operator::new(s3)?.finish())))
+    Ok(Box::new(OpendalAdapter::new(Operator::new(s3)?)))
 }
 
 /// Create new AWS s3 storage with bucket, region and credentials.
@@ -99,7 +100,7 @@ pub fn with_credentials(
     if let Some(token) = credentials.token {
         s3 = s3.session_token(&token);
     }
-    Ok(Box::new(OpendalAdapter::new(Operator::new(s3)?.finish())))
+    Ok(Box::new(OpendalAdapter::new(Operator::new(s3)?)))
 }
 
 /// Build store with failure
@@ -116,5 +117,5 @@ pub fn with_failure() -> Box<dyn StoreDriver> {
         .skip_signature() // opendal 0.57 renamed `allow_anonymous`
         .disable_ec2_metadata();
 
-    Box::new(OpendalAdapter::new(Operator::new(s3).unwrap().finish()))
+    Box::new(OpendalAdapter::new(Operator::new(s3).unwrap()))
 }

--- a/src/storage/drivers/azure.rs
+++ b/src/storage/drivers/azure.rs
@@ -26,7 +26,6 @@ pub fn new(
         .account_key(access_key)
         .endpoint(endpoint);
 
-    Ok(Box::new(OpendalAdapter::new(
-        Operator::new(azure)?.finish(),
-    )))
+    // opendal 0.58: Operator::new returns a finished Operator (no .finish()).
+    Ok(Box::new(OpendalAdapter::new(Operator::new(azure)?)))
 }

--- a/src/storage/drivers/gcp.rs
+++ b/src/storage/drivers/gcp.rs
@@ -19,5 +19,6 @@ pub fn new(bucket_name: &str, credential_path: &str) -> StorageResult<Box<dyn St
         .bucket(bucket_name)
         .credential_path(credential_path);
 
-    Ok(Box::new(OpendalAdapter::new(Operator::new(gcs)?.finish())))
+    // opendal 0.58: Operator::new returns a finished Operator (no .finish()).
+    Ok(Box::new(OpendalAdapter::new(Operator::new(gcs)?)))
 }

--- a/src/storage/drivers/local.rs
+++ b/src/storage/drivers/local.rs
@@ -22,10 +22,9 @@ use crate::storage::{drivers::opendal_adapter::OpendalAdapter, StorageResult};
 #[must_use]
 pub fn new() -> Box<dyn StoreDriver> {
     let fs = Fs::default().root(".");
+    // opendal 0.58: Operator::new returns a finished Operator (no .finish()).
     Box::new(OpendalAdapter::new(
-        Operator::new(fs)
-            .expect("fs service should build with success")
-            .finish(),
+        Operator::new(fs).expect("fs service should build with success"),
     ))
 }
 
@@ -42,5 +41,5 @@ pub fn new() -> Box<dyn StoreDriver> {
 /// Returns an error if the path does not exist
 pub fn new_with_prefix(prefix: impl AsRef<std::path::Path>) -> StorageResult<Box<dyn StoreDriver>> {
     let fs = Fs::default().root(&prefix.as_ref().display().to_string());
-    Ok(Box::new(OpendalAdapter::new(Operator::new(fs)?.finish())))
+    Ok(Box::new(OpendalAdapter::new(Operator::new(fs)?)))
 }

--- a/src/storage/drivers/mem.rs
+++ b/src/storage/drivers/mem.rs
@@ -16,9 +16,8 @@ use crate::storage::drivers::opendal_adapter::OpendalAdapter;
 /// Panics if the memory service built failed.
 #[must_use]
 pub fn new() -> Box<dyn StoreDriver> {
+    // opendal 0.58: Operator::new returns a finished Operator (no .finish()).
     Box::new(OpendalAdapter::new(
-        Operator::new(Memory::default())
-            .expect("memory service must build with success")
-            .finish(),
+        Operator::new(Memory::default()).expect("memory service must build with success"),
     ))
 }

--- a/src/storage/drivers/opendal_adapter.rs
+++ b/src/storage/drivers/opendal_adapter.rs
@@ -80,7 +80,8 @@ impl StoreDriver for OpendalAdapter {
     /// Returns a `StorageResult` indicating the success of the rename/move
     /// operation.
     async fn rename(&self, from: &Path, to: &Path) -> StorageResult<()> {
-        if self.opendal_impl.info().full_capability().rename {
+        // opendal 0.58: full_capability()/native_capability() removed; use capability().
+        if self.opendal_impl.info().capability().rename {
             let from = from.display().to_string();
             let to = to.display().to_string();
             Ok(self.opendal_impl.rename(&from, &to).await?)
@@ -103,9 +104,9 @@ impl StoreDriver for OpendalAdapter {
     async fn copy(&self, from: &Path, to: &Path) -> StorageResult<()> {
         let from = from.display().to_string();
         let to = to.display().to_string();
-        if self.opendal_impl.info().full_capability().copy {
-            // opendal 0.57's `copy` returns the destination `Metadata`; we
-            // don't surface it.
+        // opendal 0.58: full_capability() removed; use capability().
+        if self.opendal_impl.info().capability().copy {
+            // `copy` returns the destination `Metadata`; we don't surface it.
             self.opendal_impl.copy(&from, &to).await?;
         } else {
             let mut reader = self


### PR DESCRIPTION
## Why

Bump the direct `opendal` dependency from `0.57` to `0.58.1` so Loco's storage backends stay on a current OpenDAL release.

## Changes

- Pin `opendal` to `0.58.1` in the root `Cargo.toml` (same feature set: memory/fs/retry + optional s3/azure/gcs).
- Adapt storage drivers to OpenDAL 0.58 public API:
  - `Operator::new(...)` now returns a finished `Operator` (remove `.finish()`).
  - Replace `info().full_capability()` with `info().capability()`.

## Validation

- `cargo check -p loco-rs --features all_storage` (resolves `opendal` **0.58.1**).
- `cargo test -p loco-rs --lib storage --features "all_storage,testing,worker_redis"` — 40 storage tests passed.
