### PR TITLE
fix(testing): redact timestamps with negative UTC offsets

### DIFF
--- a/src/testing/redaction.rs
+++ b/src/testing/redaction.rs
@@ -22,7 +22,7 @@ pub fn get_cleanup_date() -> &'static Vec<(&'static str, &'static str)> {
     CLEANUP_DATE.get_or_init(|| {
         vec![
             (
-                r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?\+\d{2}:\d{2}",
+                r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?[+-]\d{2}:\d{2}",
                 "DATE",
             ), // with tz
             (r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+", "DATE"),
@@ -112,6 +112,25 @@ mod tests {
     /// comma) followed by another field on the same line.
     const SAMPLE_RECORD: &str = r#"password: "$argon2id$v=19$m=19456,t=2,p=1$ETQBx4rTgNAZhSaeYZKOZg$eYTdH26CRT6nUJtacLDEboP0li6xUwUF/q5nSlQ8uuc", api_key: "lo-95ec80d7-cb60-4b70-9b4b-9ef74cb88758","#;
 
+    /// Timestamps as `assert_debug_snapshot!` renders a
+    /// `DateTimeWithTimeZone` (chrono `DateTime<FixedOffset>`): RFC 3339 with
+    /// an explicit numeric UTC offset whose sign follows the local timezone.
+    const DATES_WITH_OFFSET: &[&str] = &[
+        "2026-08-07T03:33:44.123456789-03:00", // west of UTC
+        "2026-08-07T03:33:44.123456789+02:00", // east of UTC
+        "2026-08-07T03:33:44.123456789+00:00", // UTC itself
+        "2026-08-07T03:33:44-03:00",           // no fractional seconds
+    ];
+
+    fn redact_date(input: &str) -> String {
+        let mut redacted = input.to_string();
+        for (pattern, replacement) in get_cleanup_date() {
+            let re = Regex::new(pattern).unwrap();
+            redacted = re.replace_all(&redacted, *replacement).to_string();
+        }
+        redacted
+    }
+
     fn password_filter() -> (&'static str, &'static str) {
         get_cleanup_user_model()
             .iter()
@@ -173,5 +192,31 @@ mod tests {
             !redacted.contains(",,"),
             "redaction must not double the comma"
         );
+    }
+
+    #[test]
+    fn old_date_regex_only_matched_positive_offsets() {
+        // Regression guard: the "with tz" rule used to end in `\+\d{2}:\d{2}`,
+        // which only matches a *positive* UTC offset. It is the sole rule that
+        // consumes the offset, so on a machine west of UTC the timestamp fell
+        // through to the offset-less rules — those stop at the seconds and
+        // leave the offset stranded, redacting to `DATE-03:00` instead of
+        // `DATE`. That desync fails every snapshot carrying a timestamp.
+        let old_pattern =
+            Regex::new(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?\+\d{2}:\d{2}").unwrap();
+
+        assert!(!old_pattern.is_match("2026-08-07T03:33:44.123456789-03:00"));
+        assert!(old_pattern.is_match("2026-08-07T03:33:44.123456789+02:00"));
+    }
+
+    #[test]
+    fn cleanup_date_redacts_either_offset_sign() {
+        for sample in DATES_WITH_OFFSET {
+            assert_eq!(
+                redact_date(sample),
+                "DATE",
+                "`{sample}` must redact whole, leaving no offset behind"
+            );
+        }
     }
 }


### PR DESCRIPTION
## The bug

`testing::redaction::get_cleanup_date` returns three ordered filters. The first one — the only rule that consumes a UTC offset — ends in `\+\d{2}:\d{2}`, so it matches a **positive** offset only:

```rust
(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?\+\d{2}:\d{2}", "DATE"), // with tz
(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+", "DATE"),
(r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})", "DATE"),
```

`DateTimeWithTimeZone` debug-prints as RFC 3339 with an explicit numeric offset whose sign follows the local timezone. On a machine **west of UTC** the first rule misses, the timestamp falls through to rules 2/3, and those stop at the seconds — leaving the offset stranded:

```
-            DATE,
+            DATE-03:00,
```

Every snapshot carrying a timestamp then fails. CI never caught it because GitHub runners are UTC, where the offset is `+00:00` and rule 1 matches.

## Reproduction

On a host with a negative-offset `TZ` (reproduced on `America/Halifax`, UTC−3, and confirmed to pass under `TZ=UTC`):

```sh
loco new --name hello_loco --db sqlite --bg async --assets none
cd hello_loco && cargo test
```

```
failures:
    requests::auth::can_register
    requests::auth::can_resend_verification_email

test result: FAILED. 24 passed; 2 failed
```

Both failures are the `email_verification_sent_at` field redacting to `DATE-03:00`. So a freshly generated app has a red test suite out of the box for anyone west of UTC — the pattern has been this way since #1047 (2024-12-03).

## The fix

Widen the sign to `[+-]`. One character; no behavior change on UTC or positive offsets, since `[+-]` is a strict superset of `\+`. No existing snapshot needs regenerating.

## Notes for the reviewer

- I deliberately left the `Z` suffix form unhandled — `DateTimeWithTimeZone` is `chrono::DateTime<FixedOffset>`, whose `Debug` always renders a numeric offset (`+00:00`), never `Z`, so it isn't reachable from these snapshots. Happy to widen it if you'd rather the filter be format-complete.
- `old_date_regex_only_matched_positive_offsets` follows the style of the existing `old_password_regex_was_inert` guard: it pins the old pattern's behavior so the regression can't quietly return.

## Testing

- `cargo test --all-features --lib testing::redaction` → 5 passed, including the two new tests.
- `cargo test --all-features --lib` → 494 passed, 0 failed.
- `cargo fmt --all -- --check` → clean.
- `cargo clippy --all-features -- -D warnings -W clippy::pedantic -W clippy::nursery -W rust-2018-idioms` → clean.

