### PR TITLE
Fix doubled words in doc comments

### DIFF
--- a/loco-new/base_template/src/controllers/auth.rs
+++ b/loco-new/base_template/src/controllers/auth.rs
@@ -92,7 +92,7 @@ async fn verify(State(ctx): State<AppContext>, Path(token): Path<String>) -> Res
 
 /// In case the user forgot his password  this endpoints generate a forgot token
 /// and send email to the user. In case the email not found in our DB, we are
-/// returning a valid request for for security reasons (not exposing users DB
+/// returning a valid request for security reasons (not exposing users DB
 /// list).
 #[debug_handler]
 async fn forgot(

--- a/loco-new/src/generator/mod.rs
+++ b/loco-new/src/generator/mod.rs
@@ -18,7 +18,7 @@ static APP_TEMPLATE: Dir<'_> = include_dir!("base_template");
 /// application.
 ///
 /// # Errors
-/// when could not extract the the base template
+/// when could not extract the base template
 pub fn extract_default_template() -> std::io::Result<tree_fs::Tree> {
     let generator_tmp_folder = tree_fs::TreeBuilder::default().create()?;
 


### PR DESCRIPTION
Two small doubled-word typos in doc comments:

- `loco-new/src/generator/mod.rs`: "could not extract the the base template" -> "extract the base template".
- `loco-new/base_template/src/controllers/auth.rs`: "returning a valid request for for security reasons" -> "for security reasons".

Documentation only.
