### PR TITLE
storage: add list/stat/exists to storage instance api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
+## Unreleased
 
+### Breaking Changes
+
+- **Storage `StoreDriver` / `StorageStrategy` gain required `list` and `stat`
+  methods** (and `StorageStrategy` also requires `exists`). Custom driver and
+  strategy implementations must implement them. Built-in drivers/strategies
+  already do. The `Storage` facade exposes matching `exists` / `list` / `stat`
+  (and `*_with_policy`) APIs alongside the existing upload/download/delete
+  surface.
 
 ## 1.0.0 - 2026-07-25
 

--- a/docs-site/content/docs/how-to/configure-storage.md
+++ b/docs-site/content/docs/how-to/configure-storage.md
@@ -206,7 +206,38 @@ If you need the whole payload as one `Bytes` buffer anyway, `BytesStream::collec
 
 **Strategy caveat:** streaming isn't uniformly "true streaming" once a strategy other than `SingleStrategy` is involved. `ReplicatedStrategy` unifies the former mirror/backup behavior: reads (both the buffered `download` and `download_stream`) fall back to secondaries when `read_from_secondaries` is set — i.e. constructed via `ReplicatedStrategy::mirror` — and are served from the primary only when constructed via `ReplicatedStrategy::backup`. Either way, `upload_stream` buffers the whole payload once via `collect()` and then fans out concurrently to secondaries. If you need guaranteed zero-buffering streaming to a single store, stick to `SingleStrategy` (the default).
 
-## 6. Verify
+## 6. Check existence, list, and stat
+
+`Storage` also exposes `exists`, `list`, and `stat`, each going through the selected strategy the same way `upload`/`download` do (with `exists_with_policy`/`list_with_policy`/`stat_with_policy` siblings for overriding the strategy per call).
+
+```rust
+use std::path::Path;
+
+// Does a key exist?
+let found = ctx.storage.exists(Path::new("uploads/report.pdf")).await?;
+
+// List everything under a prefix, recursively.
+let all_entries = ctx.storage.list(Path::new("uploads"), true).await?;
+
+// List one level deep — child prefixes come back as directory entries.
+let top_level = ctx.storage.list(Path::new("uploads"), false).await?;
+
+// Metadata for a single key, without downloading its content.
+let meta = ctx.storage.stat(Path::new("uploads/report.pdf")).await?;
+println!("{} bytes, is_dir={}", meta.content_length.unwrap_or(0), meta.is_dir);
+```
+
+Each entry returned by `list`/`stat` is a `storage::drivers::ListEntry` (prefer `ListEntry::new(...)` over struct literals).
+
+On `ReplicatedStrategy` (mirror / `read_from_secondaries`):
+
+- `stat` falls back to secondaries on primary error (same as `download`)
+- `exists` falls back when the primary reports `false` **or** errors (a miss is not itself an error)
+- `list` falls back when the primary errors **or** returns an empty listing; empty secondaries are skipped so a later secondary with data still wins
+
+Backup mode (`read_from_secondaries: false`) keeps all three primary-only.
+
+## 7. Verify
 
 ```rust
 use loco_rs::testing::prelude::*;

--- a/src/app.rs
+++ b/src/app.rs
@@ -434,6 +434,7 @@ pub trait Hooks: Send {
     ///
     /// # Returns
     /// A Result indicating success () or an error if the server fails to start.
+    #[must_use]
     async fn serve(app: AxumRouter, ctx: &AppContext, serve_params: &ServeParams) -> Result<()> {
         let listener = tokio::net::TcpListener::bind(&format!(
             "{}:{}",
@@ -471,6 +472,7 @@ pub trait Hooks: Send {
     ///
     /// This function is responsible for retrieving the configuration for the application
     /// based on the current environment.
+    #[must_use]
     async fn load_config(env: &Environment) -> Result<Config> {
         env.load()
     }
@@ -481,6 +483,7 @@ pub trait Hooks: Send {
     ///
     /// # Errors
     /// Return an [`Result`] when the router could not be created
+    #[must_use]
     async fn before_routes(_ctx: &AppContext) -> Result<AxumRouter<AppContext>> {
         Ok(AxumRouter::new())
     }
@@ -491,6 +494,7 @@ pub trait Hooks: Send {
     ///
     /// # Errors
     /// Axum router error
+    #[must_use]
     async fn after_routes(router: AxumRouter, _ctx: &AppContext) -> Result<AxumRouter> {
         Ok(router)
     }
@@ -498,6 +502,7 @@ pub trait Hooks: Send {
     /// Provide a list of initializers
     /// An initializer can be used to seamlessly add functionality to your app
     /// or to initialize some aspects of it.
+    #[must_use]
     async fn initializers(_ctx: &AppContext) -> Result<Vec<Box<dyn Initializer>>> {
         Ok(vec![])
     }
@@ -511,6 +516,7 @@ pub trait Hooks: Send {
     /// Calling the function before run the app
     /// You can now code some custom loading of resources or other things before
     /// the app runs
+    #[must_use]
     async fn before_run(_app_context: &AppContext) -> Result<()> {
         Ok(())
     }
@@ -519,6 +525,7 @@ pub trait Hooks: Send {
     fn routes(_ctx: &AppContext) -> AppRoutes;
 
     // Provides the options to change Loco [`AppContext`] after initialization.
+    #[must_use]
     async fn after_context(ctx: AppContext) -> Result<AppContext> {
         Ok(ctx)
     }
@@ -557,6 +564,7 @@ pub trait Hooks: Send {
     /// }
     /// ```
     #[cfg(feature = "with-db")]
+    #[must_use]
     async fn dump(ctx: &AppContext, base: &Path) -> Result<()> {
         crate::db::dump_tables(&ctx.db, base, None).await
     }
@@ -564,6 +572,7 @@ pub trait Hooks: Send {
     /// Called when the application is shutting down.
     /// This function allows users to perform any necessary cleanup or final
     /// actions before the application stops completely.
+    #[must_use]
     async fn on_shutdown(_ctx: &AppContext) {}
 }
 

--- a/src/mailer/mod.rs
+++ b/src/mailer/mod.rs
@@ -133,6 +133,7 @@ pub trait Mailer {
     }
 
     /// Sends an email using the provided [`AppContext`] and email details.
+    #[must_use]
     async fn mail(ctx: &AppContext, email: &Email) -> Result<()> {
         let opts = Self::opts();
         let mut email = email.clone();
@@ -149,6 +150,7 @@ pub trait Mailer {
     ///
     /// # Errors
     /// Returns an error if enqueuing the email fails.
+    #[must_use]
     async fn mail_multi(ctx: &AppContext, email: &MultiEmail) -> Result<()> {
         let opts = Self::opts();
         let mut email = email.clone();
@@ -162,6 +164,7 @@ pub trait Mailer {
 
     /// Renders and sends an email using the provided [`AppContext`], template
     /// directory, and arguments.
+    #[must_use]
     async fn mail_template(ctx: &AppContext, dir: &Dir<'_>, args: Args) -> Result<()> {
         Self::mail_template_with_shared(ctx, dir, &[], args).await
     }
@@ -176,6 +179,7 @@ pub trait Mailer {
     ///
     /// # Errors
     /// Returns an error if a template is missing/invalid or the send fails.
+    #[must_use]
     async fn mail_template_with_shared(
         ctx: &AppContext,
         dir: &Dir<'_>,
@@ -205,6 +209,7 @@ pub trait Mailer {
     ///
     /// # Errors
     /// Returns an error if a template is missing/invalid or enqueuing fails.
+    #[must_use]
     async fn mail_template_multi(ctx: &AppContext, dir: &Dir<'_>, args: MultiArgs) -> Result<()> {
         let content = Template::new(dir)?.render(&args.locals)?;
         Self::mail_multi(
@@ -230,6 +235,7 @@ pub trait Mailer {
     ///
     /// # Errors
     /// Returns an error if no mailer is configured or the send fails.
+    #[must_use]
     async fn deliver_now(ctx: &AppContext, email: &Email) -> Result<()> {
         let opts = Self::opts();
         let mut email = email.clone();
@@ -244,6 +250,7 @@ pub trait Mailer {
     ///
     /// # Errors
     /// Returns an error if rendering fails, no mailer is configured, or the send fails.
+    #[must_use]
     async fn mail_template_now(ctx: &AppContext, dir: &Dir<'_>, args: Args) -> Result<()> {
         let content = Template::new(dir)?.render(&args.locals)?;
         Self::deliver_now(

--- a/src/storage/drivers/mod.rs
+++ b/src/storage/drivers/mod.rs
@@ -35,6 +35,45 @@ impl UploadResponse {
     }
 }
 
+/// A single entry returned by [`StoreDriver::list`] or [`StoreDriver::stat`].
+#[derive(Debug, Clone)]
+pub struct ListEntry {
+    /// The full path of the entry.
+    pub path: String,
+    /// Whether the entry is a directory (common prefix) rather than a file.
+    pub is_dir: bool,
+    /// The size in bytes of the entry, if known.
+    pub content_length: Option<u64>,
+    /// The last-modified time of the entry, if known.
+    pub last_modified: Option<chrono::DateTime<chrono::Utc>>,
+    /// The entity tag of the entry, if known.
+    pub etag: Option<String>,
+}
+
+impl ListEntry {
+    /// Builds a `ListEntry` from listing/stat metadata.
+    ///
+    /// Custom [`StoreDriver`] implementations use this to return listing/stat
+    /// results without relying on struct-literal construction, so the fields
+    /// can later evolve behind the constructor.
+    #[must_use]
+    pub fn new(
+        path: String,
+        is_dir: bool,
+        content_length: Option<u64>,
+        last_modified: Option<chrono::DateTime<chrono::Utc>>,
+        etag: Option<String>,
+    ) -> Self {
+        Self {
+            path,
+            is_dir,
+            content_length,
+            last_modified,
+            etag,
+        }
+    }
+}
+
 /// The response of a [`StoreDriver::get`] call.
 ///
 /// Internally this is either an `OpenDAL` reader (used by the built-in,
@@ -151,6 +190,24 @@ pub trait StoreDriver: Sync + Send {
     /// Returns a `StorageResult` with a boolean indicating the existence of the
     /// content.
     async fn exists(&self, path: &Path) -> StorageResult<bool>;
+
+    /// Lists entries whose paths start with the given prefix.
+    ///
+    /// When `recursive` is `false`, only one level below `path` is listed,
+    /// with child prefixes returned as directory entries. When `recursive` is
+    /// `true`, all entries under `path` are listed.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `StorageResult` with the listing operation's result.
+    async fn list(&self, path: &Path, recursive: bool) -> StorageResult<Vec<ListEntry>>;
+
+    /// Retrieves metadata for a single path without downloading its content.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `StorageResult` with the entry's metadata.
+    async fn stat(&self, path: &Path) -> StorageResult<ListEntry>;
 
     /// Retrieves content from the specified path and returns it as a stream.
     /// This method is more memory-efficient than `get()` for large files as it

--- a/src/storage/drivers/null.rs
+++ b/src/storage/drivers/null.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use async_trait::async_trait;
 use bytes::Bytes;
 
-use super::{GetResponse, StorageResult, StoreDriver, UploadResponse};
+use super::{GetResponse, ListEntry, StorageResult, StoreDriver, UploadResponse};
 use crate::storage::StorageError;
 
 pub struct NullStorage {}
@@ -88,6 +88,28 @@ impl StoreDriver for NullStorage {
     /// Returns a `StorageResult` with a boolean indicating the existence of the
     /// content.
     async fn exists(&self, _path: &Path) -> StorageResult<bool> {
+        Err(StorageError::Any(
+            "Operation not supported by null storage".into(),
+        ))
+    }
+
+    /// Lists entries whose paths start with the given prefix.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `StorageResult` with the listing operation's result.
+    async fn list(&self, _path: &Path, _recursive: bool) -> StorageResult<Vec<ListEntry>> {
+        Err(StorageError::Any(
+            "Operation not supported by null storage".into(),
+        ))
+    }
+
+    /// Retrieves metadata for a single path without downloading its content.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `StorageResult` with the entry's metadata.
+    async fn stat(&self, _path: &Path) -> StorageResult<ListEntry> {
         Err(StorageError::Any(
             "Operation not supported by null storage".into(),
         ))

--- a/src/storage/drivers/opendal_adapter.rs
+++ b/src/storage/drivers/opendal_adapter.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
 use opendal::{layers::RetryLayer, Operator};
 
-use super::{GetResponse, StoreDriver, UploadResponse};
+use super::{GetResponse, ListEntry, StoreDriver, UploadResponse};
 use crate::storage::{stream::BytesStream, StorageError, StorageResult};
 
 pub struct OpendalAdapter {
@@ -142,6 +142,61 @@ impl StoreDriver for OpendalAdapter {
     async fn exists(&self, path: &Path) -> StorageResult<bool> {
         let path = path.display().to_string();
         Ok(self.opendal_impl.exists(&path).await.unwrap_or(false))
+    }
+
+    /// Lists entries whose paths start with the given prefix.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `StorageResult` with the listing operation's result.
+    async fn list(&self, path: &Path, recursive: bool) -> StorageResult<Vec<ListEntry>> {
+        // OpenDAL treats a prefix without a trailing slash as an exact-key
+        // lookup (returning the directory itself as a single entry) rather
+        // than a directory listing, so normalize the prefix before listing.
+        let mut prefix = path.display().to_string();
+        if !prefix.is_empty() && !prefix.ends_with('/') {
+            prefix.push('/');
+        }
+
+        let entries = self
+            .opendal_impl
+            .list_with(&prefix)
+            .recursive(recursive)
+            .await?;
+
+        Ok(entries
+            .into_iter()
+            .map(|entry| {
+                let (path, meta) = entry.into_parts();
+                ListEntry::new(
+                    path,
+                    meta.is_dir(),
+                    Some(meta.content_length()),
+                    meta.last_modified().map(|ts| {
+                        chrono::DateTime::<chrono::Utc>::from(std::time::SystemTime::from(ts))
+                    }),
+                    meta.etag().map(std::string::ToString::to_string),
+                )
+            })
+            .collect())
+    }
+
+    /// Retrieves metadata for a single path without downloading its content.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `StorageResult` with the entry's metadata.
+    async fn stat(&self, path: &Path) -> StorageResult<ListEntry> {
+        let path_str = path.display().to_string();
+        let meta = self.opendal_impl.stat(&path_str).await?;
+        Ok(ListEntry::new(
+            path_str,
+            meta.is_dir(),
+            Some(meta.content_length()),
+            meta.last_modified()
+                .map(|ts| chrono::DateTime::<chrono::Utc>::from(std::time::SystemTime::from(ts))),
+            meta.etag().map(std::string::ToString::to_string),
+        ))
     }
 
     /// Native streaming implementation for `OpenDAL`.

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2,7 +2,8 @@
 //!
 //! This module defines a generic storage abstraction represented by the
 //! [`Storage`] struct. It provides methods for performing common storage
-//! operations such as upload, download, delete, rename, and copy.
+//! operations such as upload, download, delete, rename, copy, exists, list,
+//! and stat.
 //!
 //! ## Storage Strategy
 //!
@@ -21,7 +22,10 @@ use std::{
 
 use bytes::Bytes;
 
-use self::{drivers::StoreDriver, stream::BytesStream};
+use self::{
+    drivers::{ListEntry, StoreDriver},
+    stream::BytesStream,
+};
 
 #[derive(thiserror::Error, Debug)]
 #[allow(clippy::module_name_repetitions)]
@@ -327,6 +331,140 @@ impl Storage {
         strategy: &dyn strategies::StorageStrategy,
     ) -> StorageResult<()> {
         strategy.copy(self, from, to).await
+    }
+
+    /// Checks whether content exists at the specified path.
+    ///
+    /// This method uses the selected strategy for the exists check.
+    ///
+    /// # Examples
+    ///```
+    /// use loco_rs::storage;
+    /// use std::path::Path;
+    /// use bytes::Bytes;
+    /// pub async fn check_exists() {
+    ///     let storage = storage::Storage::single(storage::drivers::mem::new());
+    ///     let path = Path::new("example.txt");
+    ///     storage.upload(path, &Bytes::from("Loco!")).await.unwrap();
+    ///
+    ///     assert!(storage.exists(path).await.unwrap());
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// This method returns an error if the exists check fails or if there is
+    /// an issue with the strategy configuration.
+    pub async fn exists(&self, path: &Path) -> StorageResult<bool> {
+        self.exists_with_policy(path, &*self.strategy).await
+    }
+
+    /// Checks whether content exists at the specified path using a specific
+    /// strategy.
+    ///
+    /// This method allows specifying a custom strategy for the exists check.
+    ///
+    /// # Errors
+    ///
+    /// This method returns an error if the exists check fails or if there is
+    /// an issue with the strategy configuration.
+    pub async fn exists_with_policy(
+        &self,
+        path: &Path,
+        strategy: &dyn strategies::StorageStrategy,
+    ) -> StorageResult<bool> {
+        strategy.exists(self, path).await
+    }
+
+    /// Lists entries whose paths start with the given prefix.
+    ///
+    /// This method uses the selected strategy for the listing operation.
+    ///
+    /// # Examples
+    ///```
+    /// use loco_rs::storage;
+    /// use std::path::Path;
+    /// use bytes::Bytes;
+    /// pub async fn list_entries() {
+    ///     let storage = storage::Storage::single(storage::drivers::mem::new());
+    ///     let path = Path::new("dir/example.txt");
+    ///     storage.upload(path, &Bytes::from("Loco!")).await.unwrap();
+    ///
+    ///     let entries = storage.list(Path::new("dir"), true).await.unwrap();
+    ///     assert_eq!(entries.len(), 1);
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// This method returns an error if the listing operation fails or if
+    /// there is an issue with the strategy configuration.
+    pub async fn list(&self, path: &Path, recursive: bool) -> StorageResult<Vec<ListEntry>> {
+        self.list_with_policy(path, recursive, &*self.strategy)
+            .await
+    }
+
+    /// Lists entries whose paths start with the given prefix using a specific
+    /// strategy.
+    ///
+    /// This method allows specifying a custom strategy for the listing
+    /// operation.
+    ///
+    /// # Errors
+    ///
+    /// This method returns an error if the listing operation fails or if
+    /// there is an issue with the strategy configuration.
+    pub async fn list_with_policy(
+        &self,
+        path: &Path,
+        recursive: bool,
+        strategy: &dyn strategies::StorageStrategy,
+    ) -> StorageResult<Vec<ListEntry>> {
+        strategy.list(self, path, recursive).await
+    }
+
+    /// Retrieves metadata for a single path without downloading its content.
+    ///
+    /// This method uses the selected strategy for the stat operation.
+    ///
+    /// # Examples
+    ///```
+    /// use loco_rs::storage;
+    /// use std::path::Path;
+    /// use bytes::Bytes;
+    /// pub async fn stat_entry() {
+    ///     let storage = storage::Storage::single(storage::drivers::mem::new());
+    ///     let path = Path::new("example.txt");
+    ///     storage.upload(path, &Bytes::from("Loco!")).await.unwrap();
+    ///
+    ///     let entry = storage.stat(path).await.unwrap();
+    ///     assert_eq!(entry.content_length, Some(5));
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// This method returns an error if the stat operation fails or if there
+    /// is an issue with the strategy configuration.
+    pub async fn stat(&self, path: &Path) -> StorageResult<ListEntry> {
+        self.stat_with_policy(path, &*self.strategy).await
+    }
+
+    /// Retrieves metadata for a single path using a specific strategy.
+    ///
+    /// This method allows specifying a custom strategy for the stat
+    /// operation.
+    ///
+    /// # Errors
+    ///
+    /// This method returns an error if the stat operation fails or if there
+    /// is an issue with the strategy configuration.
+    pub async fn stat_with_policy(
+        &self,
+        path: &Path,
+        strategy: &dyn strategies::StorageStrategy,
+    ) -> StorageResult<ListEntry> {
+        strategy.stat(self, path).await
     }
 
     /// Returns a reference to the store with the specified name if exists.

--- a/src/storage/strategies/mod.rs
+++ b/src/storage/strategies/mod.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use bytes::Bytes;
 
-use crate::storage::{stream::BytesStream, Storage, StorageResult};
+use crate::storage::{drivers::ListEntry, stream::BytesStream, Storage, StorageResult};
 
 #[async_trait::async_trait]
 pub trait StorageStrategy: Sync + Send {
@@ -14,6 +14,14 @@ pub trait StorageStrategy: Sync + Send {
     async fn delete(&self, storage: &Storage, path: &Path) -> StorageResult<()>;
     async fn rename(&self, storage: &Storage, from: &Path, to: &Path) -> StorageResult<()>;
     async fn copy(&self, storage: &Storage, from: &Path, to: &Path) -> StorageResult<()>;
+    async fn exists(&self, storage: &Storage, path: &Path) -> StorageResult<bool>;
+    async fn list(
+        &self,
+        storage: &Storage,
+        path: &Path,
+        recursive: bool,
+    ) -> StorageResult<Vec<ListEntry>>;
+    async fn stat(&self, storage: &Storage, path: &Path) -> StorageResult<ListEntry>;
 
     /// Download content as a stream for memory-efficient large file handling.
     ///

--- a/src/storage/strategies/replicated.rs
+++ b/src/storage/strategies/replicated.rs
@@ -13,16 +13,25 @@
 //!   operation is then fanned out **concurrently** to every secondary; every
 //!   secondary is always attempted. Errors are collected per store and the
 //!   [`FailurePolicy`] decides whether the overall operation fails.
-//! * `download`/`download_stream`: served from the primary. If the primary
-//!   fails and `read_from_secondaries` is set (mirror behavior), each secondary
-//!   is tried in turn until one succeeds; otherwise (backup behavior) the
-//!   primary error is returned.
+//! * `download`/`download_stream`/`stat`: served from the primary. If the
+//!   primary fails and `read_from_secondaries` is set (mirror behavior), each
+//!   secondary is tried in turn until one succeeds; otherwise (backup
+//!   behavior) the primary error is returned.
+//! * `exists`: like the reads above, but a primary `Ok(false)` (missing key)
+//!   also triggers secondary fallback under mirror mode, since a miss is not
+//!   an error.
+//! * `list`: like `exists` — primary `Err` **or** primary `Ok([])` triggers
+//!   secondary fallback under mirror mode. Empty secondary listings are
+//!   skipped (same as `exists` skipping `false`) so a later secondary with
+//!   data remains discoverable.
 use std::{collections::BTreeMap, path::Path};
 
 use bytes::Bytes;
 
 use crate::storage::{
-    drivers::StoreDriver, strategies::StorageStrategy, Storage, StorageError, StorageResult,
+    drivers::{ListEntry, StoreDriver},
+    strategies::StorageStrategy,
+    Storage, StorageError, StorageResult,
 };
 
 /// How many secondary-store failures a [`ReplicatedStrategy`] tolerates before
@@ -60,9 +69,10 @@ pub struct ReplicatedStrategy {
     pub secondaries: Option<Vec<String>>,
     /// Policy deciding when secondary failures fail the overall operation.
     pub failure_policy: FailurePolicy,
-    /// When `true`, reads (`download`/`download_stream`) fall back to
-    /// secondaries if the primary fails (mirror behavior). When `false`, reads
-    /// are served from the primary only (backup behavior).
+    /// When `true`, reads (`download`/`download_stream`/`exists`/`list`/`stat`)
+    /// fall back to secondaries if the primary fails or, for `exists`/`list`,
+    /// reports a miss (mirror behavior). When `false`, reads are served from
+    /// the primary only (backup behavior).
     pub read_from_secondaries: bool,
 }
 
@@ -272,15 +282,105 @@ impl StorageStrategy for ReplicatedStrategy {
         }
         Ok(())
     }
+
+    // Mirror fallback: `exists`/`list` treat a miss (`false` / `[]`) like an
+    // error trigger. Store-resolution errors on the primary also fall back.
+    async fn exists(&self, storage: &Storage, path: &Path) -> StorageResult<bool> {
+        let primary_result = match storage.as_store_err(&self.primary) {
+            Ok(store) => store.exists(path).await,
+            Err(err) => Err(err),
+        };
+
+        if matches!(&primary_result, Ok(true)) {
+            return Ok(true);
+        }
+
+        if self.read_from_secondaries
+            && matches!(&primary_result, Ok(false) | Err(_))
+            && let Some(secondaries) = self.secondaries.as_ref()
+        {
+            for secondary_store in secondaries {
+                if let Some(store) = storage.as_store(secondary_store)
+                    && matches!(store.exists(path).await, Ok(true))
+                {
+                    return Ok(true);
+                }
+            }
+        }
+
+        primary_result
+    }
+
+    async fn list(
+        &self,
+        storage: &Storage,
+        path: &Path,
+        recursive: bool,
+    ) -> StorageResult<Vec<ListEntry>> {
+        let primary_result = match storage.as_store_err(&self.primary) {
+            Ok(store) => store.list(path, recursive).await,
+            Err(err) => Err(err),
+        };
+
+        let should_fallback =
+            self.read_from_secondaries && primary_result.as_ref().map_or(true, Vec::is_empty);
+
+        if should_fallback && let Some(secondaries) = self.secondaries.as_ref() {
+            // Skip empty listings (same as `exists` skipping `false`) so a
+            // barren secondary does not hide data on a later one. No hit →
+            // return `primary_result` (preserves primary `Err`).
+            for secondary_store in secondaries {
+                if let Some(store) = storage.as_store(secondary_store)
+                    && let Ok(entries) = store.list(path, recursive).await
+                    && !entries.is_empty()
+                {
+                    return Ok(entries);
+                }
+            }
+        }
+
+        primary_result
+    }
+
+    async fn stat(&self, storage: &Storage, path: &Path) -> StorageResult<ListEntry> {
+        let primary_result = match storage.as_store_err(&self.primary) {
+            Ok(store) => store.stat(path).await,
+            Err(err) => Err(err),
+        };
+
+        match primary_result {
+            Ok(entry) => Ok(entry),
+            Err(error) => {
+                if self.read_from_secondaries
+                    && let Some(secondaries) = self.secondaries.as_ref()
+                {
+                    for secondary_store in secondaries {
+                        if let Some(store) = storage.as_store(secondary_store)
+                            && let Ok(entry) = store.stat(path).await
+                        {
+                            return Ok(entry);
+                        }
+                    }
+                }
+                Err(error)
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
 
-    use std::{collections::BTreeMap, path::PathBuf};
+    use std::{
+        collections::BTreeMap,
+        path::{Path, PathBuf},
+    };
 
     use super::*;
-    use crate::storage::{drivers, Storage};
+    use crate::storage::{
+        drivers::{self, ListEntry, StoreDriver},
+        Storage,
+    };
 
     // ---------------------------------------------------------------
     // Ported from `mirror.rs`
@@ -1889,5 +1989,232 @@ mod tests {
         assert!(store_1.exists(new_path.as_path()).await.unwrap());
         assert!(!store_2.exists(new_path.as_path()).await.unwrap());
         assert!(!store_3.exists(new_path.as_path()).await.unwrap());
+    }
+
+    // ---------------------------------------------------------------
+    // list / stat / exists (replicated read fallback)
+    // ---------------------------------------------------------------
+
+    fn two_stores() -> BTreeMap<String, Box<dyn StoreDriver>> {
+        BTreeMap::from([
+            ("store_1".to_string(), drivers::mem::new()),
+            ("store_2".to_string(), drivers::mem::new()),
+        ])
+    }
+
+    fn storage_for(
+        strategy: ReplicatedStrategy,
+        stores: BTreeMap<String, Box<dyn StoreDriver>>,
+    ) -> Storage {
+        Storage::new(stores, Box::new(strategy) as Box<dyn StorageStrategy>)
+    }
+
+    async fn put(storage: &Storage, store: &str, path: &Path) {
+        let content = Bytes::from("file content");
+        storage
+            .as_store(store)
+            .unwrap()
+            .upload(path, &content)
+            .await
+            .unwrap();
+    }
+
+    fn paths_of(entries: &[ListEntry]) -> Vec<String> {
+        entries.iter().map(|e| e.path.clone()).collect()
+    }
+
+    #[tokio::test]
+    async fn list_mirror_falls_back_on_empty_or_missing_primary() {
+        let path = PathBuf::from("a").join("1.txt");
+
+        let storage = storage_for(
+            ReplicatedStrategy::mirror(
+                "store_1",
+                Some(vec!["store_2".to_string()]),
+                FailurePolicy::FailIfAny,
+            ),
+            two_stores(),
+        );
+        put(&storage, "store_2", path.as_path()).await;
+        assert!(paths_of(&storage.list(Path::new("a"), true).await.unwrap())
+            .contains(&"a/1.txt".into()));
+
+        let storage = storage_for(
+            ReplicatedStrategy::mirror(
+                "missing_primary",
+                Some(vec!["store_2".to_string()]),
+                FailurePolicy::FailIfAny,
+            ),
+            BTreeMap::from([("store_2".to_string(), drivers::mem::new())]),
+        );
+        put(&storage, "store_2", path.as_path()).await;
+        assert!(paths_of(&storage.list(Path::new("a"), true).await.unwrap())
+            .contains(&"a/1.txt".into()));
+
+        // No secondary hit → keep primary `Err` (do not collapse to `Ok([])`).
+        let storage = storage_for(
+            ReplicatedStrategy::mirror(
+                "missing_primary",
+                Some(vec!["store_2".to_string()]),
+                FailurePolicy::FailIfAny,
+            ),
+            BTreeMap::from([("store_2".to_string(), drivers::mem::new())]),
+        );
+        assert!(storage.list(Path::new("a"), true).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn list_backup_stays_on_primary() {
+        let path = PathBuf::from("a").join("1.txt");
+
+        let storage = storage_for(
+            ReplicatedStrategy::backup(
+                "store_1",
+                Some(vec!["store_2".to_string()]),
+                FailurePolicy::FailIfAny,
+            ),
+            two_stores(),
+        );
+        put(&storage, "store_2", path.as_path()).await;
+        assert!(storage.list(Path::new("a"), true).await.unwrap().is_empty());
+
+        let storage = storage_for(
+            ReplicatedStrategy::backup(
+                "missing_primary",
+                Some(vec!["store_2".to_string()]),
+                FailurePolicy::FailIfAny,
+            ),
+            BTreeMap::from([("store_2".to_string(), drivers::mem::new())]),
+        );
+        put(&storage, "store_2", path.as_path()).await;
+        assert!(storage.list(Path::new("a"), true).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn list_mirror_skips_empty_secondary_and_prefers_primary_data() {
+        let primary_only = PathBuf::from("a").join("primary.txt");
+        let secondary_only = PathBuf::from("a").join("secondary.txt");
+
+        // Non-empty primary must win even when a secondary has other keys.
+        let storage = storage_for(
+            ReplicatedStrategy::mirror(
+                "store_1",
+                Some(vec!["store_2".to_string()]),
+                FailurePolicy::FailIfAny,
+            ),
+            two_stores(),
+        );
+        put(&storage, "store_1", primary_only.as_path()).await;
+        put(&storage, "store_2", secondary_only.as_path()).await;
+        let paths = paths_of(&storage.list(Path::new("a"), true).await.unwrap());
+        assert!(paths.contains(&"a/primary.txt".into()));
+        assert!(!paths.contains(&"a/secondary.txt".into()));
+
+        // Empty secondary must not hide a later secondary that has data.
+        let storage = storage_for(
+            ReplicatedStrategy::mirror(
+                "store_1",
+                Some(vec!["store_2".to_string(), "store_3".to_string()]),
+                FailurePolicy::FailIfAny,
+            ),
+            BTreeMap::from([
+                ("store_1".to_string(), drivers::mem::new()),
+                ("store_2".to_string(), drivers::mem::new()),
+                ("store_3".to_string(), drivers::mem::new()),
+            ]),
+        );
+        put(&storage, "store_3", secondary_only.as_path()).await;
+        let paths = paths_of(&storage.list(Path::new("a"), true).await.unwrap());
+        assert!(paths.contains(&"a/secondary.txt".into()));
+    }
+
+    #[tokio::test]
+    async fn stat_mirror_falls_back_backup_does_not() {
+        let path = PathBuf::from("users").join("data").join("1.txt");
+
+        let storage = storage_for(
+            ReplicatedStrategy::mirror(
+                "store_1",
+                Some(vec!["store_2".to_string()]),
+                FailurePolicy::FailIfAny,
+            ),
+            two_stores(),
+        );
+        put(&storage, "store_2", path.as_path()).await;
+        assert_eq!(
+            storage.stat(path.as_path()).await.unwrap().content_length,
+            Some(12)
+        );
+
+        let storage = storage_for(
+            ReplicatedStrategy::backup(
+                "store_1",
+                Some(vec!["store_2".to_string()]),
+                FailurePolicy::FailIfAny,
+            ),
+            two_stores(),
+        );
+        put(&storage, "store_2", path.as_path()).await;
+        assert!(storage.stat(path.as_path()).await.is_err());
+
+        let storage = storage_for(
+            ReplicatedStrategy::mirror(
+                "missing_primary",
+                Some(vec!["store_2".to_string()]),
+                FailurePolicy::FailIfAny,
+            ),
+            BTreeMap::from([("store_2".to_string(), drivers::mem::new())]),
+        );
+        put(&storage, "store_2", path.as_path()).await;
+        assert!(storage.stat(path.as_path()).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn exists_mirror_falls_back_backup_does_not() {
+        let path = PathBuf::from("users").join("data").join("1.txt");
+
+        let storage = storage_for(
+            ReplicatedStrategy::mirror(
+                "store_1",
+                Some(vec!["store_2".to_string()]),
+                FailurePolicy::FailIfAny,
+            ),
+            two_stores(),
+        );
+        put(&storage, "store_2", path.as_path()).await;
+        assert!(storage.exists(path.as_path()).await.unwrap());
+
+        let storage = storage_for(
+            ReplicatedStrategy::backup(
+                "store_1",
+                Some(vec!["store_2".to_string()]),
+                FailurePolicy::FailIfAny,
+            ),
+            two_stores(),
+        );
+        put(&storage, "store_2", path.as_path()).await;
+        assert!(!storage.exists(path.as_path()).await.unwrap());
+
+        let storage = storage_for(
+            ReplicatedStrategy::mirror(
+                "missing_primary",
+                Some(vec!["store_2".to_string()]),
+                FailurePolicy::FailIfAny,
+            ),
+            BTreeMap::from([("store_2".to_string(), drivers::mem::new())]),
+        );
+        put(&storage, "store_2", path.as_path()).await;
+        assert!(storage.exists(path.as_path()).await.unwrap());
+
+        let storage = storage_for(
+            ReplicatedStrategy::backup(
+                "missing_primary",
+                Some(vec!["store_2".to_string()]),
+                FailurePolicy::FailIfAny,
+            ),
+            BTreeMap::from([("store_2".to_string(), drivers::mem::new())]),
+        );
+        put(&storage, "store_2", path.as_path()).await;
+        assert!(storage.exists(path.as_path()).await.is_err());
     }
 }

--- a/src/storage/strategies/single.rs
+++ b/src/storage/strategies/single.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use bytes::Bytes;
 
-use crate::storage::{strategies::StorageStrategy, Storage, StorageResult};
+use crate::storage::{drivers::ListEntry, strategies::StorageStrategy, Storage, StorageResult};
 
 /// Represents a single storage strategy.
 #[derive(Clone)]
@@ -81,6 +81,41 @@ impl StorageStrategy for SingleStrategy {
         Ok(storage.as_store_err(&self.primary)?.copy(from, to).await?)
     }
 
+    /// Checks if content exists at the given path in the primary storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`StorageResult`] indicating of the operation status.
+    async fn exists(&self, storage: &Storage, path: &Path) -> StorageResult<bool> {
+        storage.as_store_err(&self.primary)?.exists(path).await
+    }
+
+    /// Lists entries under the given prefix in the primary storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`StorageResult`] indicating of the operation status.
+    async fn list(
+        &self,
+        storage: &Storage,
+        path: &Path,
+        recursive: bool,
+    ) -> StorageResult<Vec<ListEntry>> {
+        storage
+            .as_store_err(&self.primary)?
+            .list(path, recursive)
+            .await
+    }
+
+    /// Retrieves metadata for a single path in the primary storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`StorageResult`] indicating of the operation status.
+    async fn stat(&self, storage: &Storage, path: &Path) -> StorageResult<ListEntry> {
+        storage.as_store_err(&self.primary)?.stat(path).await
+    }
+
     /// Downloads content as a stream from the primary storage
     ///
     /// # Errors
@@ -116,7 +151,10 @@ impl StorageStrategy for SingleStrategy {
 #[cfg(test)]
 mod tests {
 
-    use std::{collections::BTreeMap, path::PathBuf};
+    use std::{
+        collections::BTreeMap,
+        path::{Path, PathBuf},
+    };
 
     use super::*;
     use crate::storage::{drivers, Storage};
@@ -233,5 +271,108 @@ mod tests {
 
         assert!(store.exists(orig_path.as_path()).await.unwrap());
         assert!(store.exists(new_path.as_path()).await.unwrap());
+    }
+
+    fn single_storage() -> Storage {
+        Storage::new(
+            BTreeMap::from([("default".to_string(), drivers::mem::new())]),
+            Box::new(SingleStrategy::new("default")) as Box<dyn StorageStrategy>,
+        )
+    }
+
+    #[tokio::test]
+    async fn can_check_exists() {
+        let storage = single_storage();
+        let path = PathBuf::from("users").join("data").join("1.txt");
+        let missing_path = PathBuf::from("users").join("data").join("missing.txt");
+        let file_content = Bytes::from("file content");
+
+        assert!(storage.upload(path.as_path(), &file_content).await.is_ok());
+        assert!(storage.exists(path.as_path()).await.unwrap());
+        assert!(!storage.exists(missing_path.as_path()).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn can_list_recursive() {
+        let storage = single_storage();
+        let file_content = Bytes::from("file content");
+        let path_1 = PathBuf::from("a").join("1.txt");
+        let path_2 = PathBuf::from("a").join("b").join("2.txt");
+
+        assert!(storage
+            .upload(path_1.as_path(), &file_content)
+            .await
+            .is_ok());
+        assert!(storage
+            .upload(path_2.as_path(), &file_content)
+            .await
+            .is_ok());
+
+        let paths: Vec<_> = storage
+            .list(Path::new("a"), true)
+            .await
+            .unwrap()
+            .iter()
+            .map(|e| e.path.as_str().to_string())
+            .collect();
+        assert!(paths.iter().any(|p| p == "a/1.txt"));
+        assert!(paths.iter().any(|p| p == "a/b/2.txt"));
+    }
+
+    #[tokio::test]
+    async fn can_list_non_recursive() {
+        let storage = single_storage();
+        let file_content = Bytes::from("file content");
+        let path_1 = PathBuf::from("a").join("1.txt");
+        let path_2 = PathBuf::from("a").join("b").join("2.txt");
+
+        assert!(storage
+            .upload(path_1.as_path(), &file_content)
+            .await
+            .is_ok());
+        assert!(storage
+            .upload(path_2.as_path(), &file_content)
+            .await
+            .is_ok());
+
+        let paths: Vec<_> = storage
+            .list(Path::new("a"), false)
+            .await
+            .unwrap()
+            .iter()
+            .map(|e| e.path.as_str().to_string())
+            .collect();
+        assert!(paths.iter().any(|p| p == "a/1.txt"));
+        assert!(paths.iter().any(|p| p == "a/b/"));
+        assert!(!paths.iter().any(|p| p == "a/b/2.txt"));
+    }
+
+    #[tokio::test]
+    async fn can_stat() {
+        let storage = single_storage();
+        let path = PathBuf::from("users").join("data").join("1.txt");
+        let file_content = Bytes::from("file content");
+
+        assert!(storage.upload(path.as_path(), &file_content).await.is_ok());
+        let entry = storage.stat(path.as_path()).await.unwrap();
+        assert_eq!(entry.content_length, Some(file_content.len() as u64));
+        assert!(!entry.is_dir);
+    }
+
+    #[tokio::test]
+    async fn stat_missing_path_errors() {
+        let storage = single_storage();
+        let missing = PathBuf::from("users").join("data").join("missing.txt");
+        assert!(storage.stat(missing.as_path()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn list_missing_prefix_returns_empty() {
+        let storage = single_storage();
+        assert!(storage
+            .list(Path::new("missing"), true)
+            .await
+            .unwrap()
+            .is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Adds `exists` / `list` / `stat` on the `Storage` instance api. I've tried to follow the existing read write apis closely.

`StoreDriver` and `StorageStrategy` now require those methods, which is a breaking change.

Mirror mode in `ReplicatedStrategy` falls back on miss/empty/error, skips empty secondary lists so they don't hide data (or swallow a primary error). Backup stays primary-only.

## Validation

In a fresh loco app, added mem storage to `AppContext` in `after_context`, added a small `/api/storage` controller, then hit it with curl / request tests: upload → exists → list (recursive + not) → stat → delete.
