### PR TITLE
ci: bump setup-node and pnpm/action-setup

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v7
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
           # The site lives in website/; read its packageManager pin, since
           # there is no root package.json.

--- a/.github/workflows/loco-rs-ci.yml
+++ b/.github/workflows/loco-rs-ci.yml
@@ -187,12 +187,12 @@ jobs:
       # all.
       - name: Setup node
         if: matrix.example == 'reference_spa'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
       - name: Setup pnpm
         if: matrix.example == 'reference_spa'
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
           # Read the frontend's own packageManager pin; there is no root
           # package.json for the action to fall back on.


### PR DESCRIPTION
Picks up the two dependabot action bumps that are still live, in one commit so CI runs once.

- `actions/setup-node` v4 → v7 in `test-examples`. That job was added late in the 1.1.0 cycle and came in on v4 while `docs.yml` was already on v7 — the two Node setups in the repo disagreed. Closes #1789.
- `pnpm/action-setup` v5 → v6 in both workflows (adds pnpm 11 support). Closes #1801.

Neither job pins a pnpm version — both read `packageManager` from the relevant `package.json` — so the pnpm bump only changes the bootstrap, not the resolved version.

One thing surfaced while reading the v6 notes: its README now points at `pnpm/setup` as the successor action. Worth a look separately; not something to fold into a version bump.
