### PR TITLE
feat(gen): add a user:delete task to generated apps

### DIFF
--- a/loco-new/base_template/src/app.rs.t
+++ b/loco-new/base_template/src/app.rs.t
@@ -95,6 +95,7 @@ impl Hooks for App {
         // tasks-inject (do not remove)
         {%- if settings.auth %}
         tasks.register(tasks::user_create::UserCreate);
+        tasks.register(tasks::user_delete::UserDelete);
         {%- endif %} 
     }
 

--- a/loco-new/base_template/src/tasks/mod.rs.t
+++ b/loco-new/base_template/src/tasks/mod.rs.t
@@ -1,3 +1,4 @@
 {%- if settings.auth %}
 pub mod user_create;
+pub mod user_delete;
 {%- endif %}

--- a/loco-new/base_template/src/tasks/user_delete.rs
+++ b/loco-new/base_template/src/tasks/user_delete.rs
@@ -1,0 +1,77 @@
+use crate::models::_entities::users;
+use loco_rs::prelude::*;
+
+pub struct UserDelete;
+#[async_trait]
+impl Task for UserDelete {
+    fn task(&self) -> TaskInfo {
+        TaskInfo {
+            name: "user:delete".to_string(),
+            detail: "Delete a user by pid. Prompts for confirmation unless force:true is given.\nUsage:\ncargo run task user:delete pid:01H0... force:true".to_string(),
+        }
+    }
+    async fn run(&self, app_context: &AppContext, vars: &task::Vars) -> Result<()> {
+        let Ok(input) = vars.cli_arg("pid") else {
+            return Err(Error::string("pid is mandatory"));
+        };
+        let force_flag = vars
+            .cli_arg("force")
+            .is_ok_and(|v| v.trim().to_lowercase() == "true");
+
+        let user_to_delete = users::Model::find_by_pid(&app_context.db, input).await?;
+
+        println!(
+            "User to delete:\nUsername: {}\nEmail: {}\nPID: {}",
+            user_to_delete.name, user_to_delete.email, user_to_delete.pid
+        );
+
+        if !force_flag {
+            println!(
+                "Are you sure you want to delete the user {}\n({})\nwith pid '{}'?\nType 'yes' and hit enter to confirm",
+                user_to_delete.name, user_to_delete.email, user_to_delete.pid
+            );
+            // Read on a blocking thread: this is an async context, and stdin
+            // blocks until the user types. Doing it inline stalls the runtime.
+            let confirm = tokio::task::spawn_blocking(|| {
+                let mut line = String::new();
+                std::io::stdin().read_line(&mut line).map(|_| line)
+            })
+            .await
+            .map_err(|err| Error::string(&format!("Failed to read confirmation. err: {err}")))?
+            .map_err(|err| {
+                tracing::error!(
+                    message = err.to_string(),
+                    "could not read confirmation input"
+                );
+                Error::string(&format!("Failed to read confirmation input. err: {err}"))
+            })?;
+
+            if confirm.trim().to_lowercase() != "yes" {
+                println!("User deletion cancelled - nothing has been deleted!");
+                return Ok(());
+            }
+        }
+
+        let user_name = user_to_delete.name.clone();
+        let user_email = user_to_delete.email.clone();
+        let user_pid = user_to_delete.pid;
+
+        user_to_delete
+            .into_active_model()
+            .delete(&app_context.db)
+            .await
+            .map_err(|err| {
+                tracing::error!(message = err.to_string(), "could not delete user");
+                Error::string(&format!("Failed to delete user. err: {err}"))
+            })?;
+        println!("User deleted successfully!");
+        tracing::info!(
+            pid = user_pid.to_string(),
+            username = user_name,
+            email = user_email,
+            "User deleted"
+        );
+
+        Ok(())
+    }
+}

--- a/loco-new/base_template/tests/tasks/mod.rs.t
+++ b/loco-new/base_template/tests/tasks/mod.rs.t
@@ -1,3 +1,4 @@
 {%- if settings.auth %}
 pub mod user_create;
+pub mod user_delete;
 {%- endif %}

--- a/loco-new/base_template/tests/tasks/user_delete.rs.t
+++ b/loco-new/base_template/tests/tasks/user_delete.rs.t
@@ -1,0 +1,35 @@
+use loco_rs::{task, testing::prelude::*};
+use {{settings.module_name}}::{app::App, models::users};
+
+use loco_rs::boot::run_task;
+use serial_test::serial;
+
+
+#[tokio::test]
+#[serial]
+async fn can_run_user_delete_by_pid() {
+    let boot = boot_test::<App>().await.unwrap();
+
+    let user = users::Model::create_with_password(
+        &boot.app_context.db,
+        &users::RegisterParams {
+            email: "test@example.com".to_string(),
+            password: "securepassword".to_string(),
+            name: "Test User".to_string(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let pid = user.pid;
+
+    let vars = task::Vars::from_cli_args(vec![("pid".to_string(), pid.to_string()), ("force".to_string(), "true".to_string())]);
+
+    run_task::<App>(&boot.app_context, Some(&"user:delete".to_string()), &vars)
+        .await
+        .unwrap();
+
+    let user = users::Model::find_by_pid(&boot.app_context.db, &pid.to_string()).await;
+    assert!(user.is_err());
+}
+

--- a/loco-new/setup.rhai
+++ b/loco-new/setup.rhai
@@ -73,7 +73,8 @@ if db {
         gen.copy_file("migration/src/m20220101_000001_users.rs");  // Users migration file
         gen.copy_file("src/models/_entities/users.rs");             // Users entity definition
         gen.copy_file("src/models/users.rs");                      // Users model logic
-         gen.copy_file("src/tasks/user_create.rs");                      
+        gen.copy_file("src/tasks/user_create.rs");
+        gen.copy_file("src/tasks/user_delete.rs");
 
         // Fixtures and test setup for authentication
         gen.copy_dir("src/fixtures");                              // Database fixtures directory
@@ -82,7 +83,8 @@ if db {
         gen.copy_dir("tests/models/snapshots");                    // Test snapshots for models
         gen.copy_template("tests/models/users.rs.t");              // User model test template
         gen.copy_template("tests/requests/prepare_data.rs.t");     // Data preparation template for tests
-        gen.copy_template("tests/tasks/user_create.rs.t");     
+        gen.copy_template("tests/tasks/user_create.rs.t");
+        gen.copy_template("tests/tasks/user_delete.rs.t");
 
     }
    

--- a/loco-new/tests/templates/snapshots/r#mod__templates__auth__src_app_rs_auth_true_None.snap
+++ b/loco-new/tests/templates/snapshots/r#mod__templates__auth__src_app_rs_auth_true_None.snap
@@ -58,6 +58,7 @@ impl Hooks for App {
     #[allow(unused_variables)]
     fn register_tasks(tasks: &mut Tasks) {
         // tasks-inject (do not remove)
-        tasks.register(tasks::user_create::UserCreate); 
+        tasks.register(tasks::user_create::UserCreate);
+        tasks.register(tasks::user_delete::UserDelete); 
     }
 }

--- a/loco-new/tests/templates/snapshots/r#mod__templates__auth__src_app_rs_auth_true_Sqlite.snap
+++ b/loco-new/tests/templates/snapshots/r#mod__templates__auth__src_app_rs_auth_true_Sqlite.snap
@@ -61,7 +61,8 @@ impl Hooks for App {
     #[allow(unused_variables)]
     fn register_tasks(tasks: &mut Tasks) {
         // tasks-inject (do not remove)
-        tasks.register(tasks::user_create::UserCreate); 
+        tasks.register(tasks::user_create::UserCreate);
+        tasks.register(tasks::user_delete::UserDelete); 
     }
     async fn truncate(ctx: &AppContext) -> Result<()> {
         truncate_table(&ctx.db, users::Entity).await?;

--- a/loco-new/tests/wizard/new.rs
+++ b/loco-new/tests/wizard/new.rs
@@ -287,8 +287,13 @@ fn test_combination(
             // Generate AddUserRefToPosts migration
             tester.run_generate_migration(&vec!["AddUserRefToPosts", "users:references"]);
 
-            // Generate CreateJoinTableUsersAndGroups migration
-            tester.run_generate_migration(&vec!["CreateJoinTableUsersAndGroups", "count:int"]);
+            // Generate a join-table migration. It must join two tables that
+            // actually exist: `groups` was never generated, so the join table
+            // carried a foreign key to a missing table. SQLite only checks
+            // that on write, and nothing here ever deleted a row — until the
+            // `user:delete` task did, and every case failed with
+            // `no such table: main.groups`.
+            tester.run_generate_migration(&vec!["CreateJoinTableUsersAndMovies", "count:int"]);
 
             // Everything above proves generated code compiles and its tests
             // pass. It does not prove the app *serves* any of it: the boot


### PR DESCRIPTION
Rebases and lands @floscodes' work from #1708, which had been open since December and predates 1.1.0.

Generated apps ship `user:create` with no way to remove a user again. This adds the symmetric `user:delete` — takes a pid, prints the matched user, confirms before deleting, and `force:true` skips the prompt for scripted use.

Two changes from the original:

- The confirmation read moved to `spawn_blocking`. `stdin().read_line` inline in an `async fn` blocks the runtime thread, and this ships as template code people copy into their own tasks.
- The `detail` string now shows its arguments, matching `user:create`. It previously read `cargo loco run task user:delete` with no hint that `pid` is mandatory.

Left out: the original branch also uncommented the `test_all_combinations` wizard matrix and renamed a join-table fixture. Both are unrelated to the feature — happy to take them separately if wanted.

Verified locally beyond the snapshots: generated an app with auth and ran its own task suite, all three tests pass (`user_create` ×2, `user_delete` ×1).

Closes #1708.
