### PR TITLE
ci: lint the whole workspace, not just loco-rs

### DIFF
--- a/.github/workflows/loco-rs-ci.yml
+++ b/.github/workflows/loco-rs-ci.yml
@@ -28,8 +28,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
+      # `--workspace` is not decoration: this repo has a root package, so a
+      # bare `cargo clippy` lints `loco-rs` and nothing else. `xtask` and
+      # `loco-gen` are workspace members and had never been linted once.
       - name: Run cargo clippy
-        run: cargo clippy --all-features -- -D warnings -W clippy::pedantic -W clippy::nursery -W rust-2018-idioms
+        run: cargo clippy --workspace --all-features -- -D warnings -W clippy::pedantic -W clippy::nursery -W rust-2018-idioms
       # A `[Type]` that no longer resolves is a dead link on docs.rs, and
       # nothing was checking: twelve had accumulated from renames.
       - name: Run cargo doc

--- a/loco-gen/tests/templates/controller.rs
+++ b/loco-gen/tests/templates/controller.rs
@@ -6,10 +6,9 @@ use std::fs;
 
 #[test]
 fn can_generate() {
-    let actions = vec!["GET".to_string(), "POST".to_string()];
     let component = Component::Controller {
         name: "movie".to_string(),
-        actions: actions.clone(),
+        actions: vec!["GET".to_string(), "POST".to_string()],
         auth: false,
     };
 

--- a/loco-gen/tests/templates/scaffold.rs
+++ b/loco-gen/tests/templates/scaffold.rs
@@ -10,6 +10,10 @@ use std::fs;
 /// (`title:string! content:text! status:enum:draft,published,archived!
 /// price:decimal! published_at:tstz`), so this snapshot doubles as the
 /// golden-output check for the DTO + controller generator.
+// A flat inventory of every artifact one scaffold emits. Splitting it into
+// helpers would hide which artifact a failure came from, which is the only
+// thing this test is here to tell you.
+#[allow(clippy::too_many_lines)]
 #[test]
 fn can_generate() {
     // SAFETY: test-local env setup; no other thread reads the environment during this test.

--- a/xtask/src/bin/main.rs
+++ b/xtask/src/bin/main.rs
@@ -25,15 +25,15 @@ enum Commands {
         #[arg(name = "VERSION")]
         new_version: Version,
     },
-    /// Parse every ```rust block in the docs tree and fail on the ones that
-    /// are not valid Rust. Syntax only — see `xtask::docs_syntax`.
+    /// Parse every fenced `rust` block in the docs tree and fail on the ones
+    /// that are not valid Rust. Syntax only — see `xtask::docs_syntax`.
     DocsSyntax,
 }
 
 fn main() -> eyre::Result<()> {
     let cli = Cli::parse();
     let project_dir = env::current_dir()?;
-    println!("running in: {project_dir:?}");
+    println!("running in: {}", project_dir.display());
 
     let res = match cli.command {
         Commands::Test { quick } => {

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -5,7 +5,10 @@ use std::{
 
 use duct::cmd;
 
-use crate::{errors::Result, utils};
+use crate::{
+    errors::{Error, Result},
+    utils,
+};
 
 const FMT_TEST: [&str; 3] = ["test", "--all-features", "--all"];
 const FMT_ARGS: [&str; 2] = ["fmt", "--all"];
@@ -38,10 +41,16 @@ impl RunResults {
 /// Run CI on all Loco resources (lib, cli, starters, examples, etc.).
 ///
 /// # Errors
-/// when could not run ci on the given resource
+/// when `base_dir` is not a Rust project, or CI could not be run on one of
+/// the resources under it
 pub fn all_resources(base_dir: &Path) -> Result<Vec<RunResults>> {
     let mut result = vec![];
-    result.push(run(base_dir).expect("loco lib mast be tested"));
+    result.push(run(base_dir).ok_or_else(|| {
+        Error::Message(format!(
+            "{} is not a Rust project — no Cargo.toml to run the loco lib CI against",
+            base_dir.display()
+        ))
+    })?);
     result.extend(run_all_in_folder(&base_dir.join("examples"))?);
     result.extend(run_all_in_folder(&base_dir.join("loco-new"))?);
 
@@ -85,6 +94,9 @@ pub fn run(dir: &Path) -> Option<RunResults> {
 }
 
 /// Run cargo test on the given directory.
+///
+/// # Errors
+/// when cargo could not be spawned, or the test run exited non-zero
 pub fn cargo_test(dir: &Path, serial: bool) -> Result<Output> {
     let mut params = FMT_TEST.to_vec();
     if serial {
@@ -101,6 +113,9 @@ pub fn cargo_test(dir: &Path, serial: bool) -> Result<Output> {
 }
 
 /// Run cargo fmt on the given directory.
+///
+/// # Errors
+/// when cargo could not be spawned, or the format run exited non-zero
 pub fn cargo_fmt(dir: &Path) -> Result<Output> {
     println!(
         "Running `cargo {}` in folder {}",
@@ -111,6 +126,9 @@ pub fn cargo_fmt(dir: &Path) -> Result<Output> {
 }
 
 /// Run cargo clippy on the given directory.
+///
+/// # Errors
+/// when cargo could not be spawned, or clippy reported a finding
 pub fn cargo_clippy(dir: &Path) -> Result<Output> {
     println!(
         "Running `cargo {}` in folder {}",

--- a/xtask/src/docs_syntax.rs
+++ b/xtask/src/docs_syntax.rs
@@ -1,5 +1,5 @@
-//! Parse every ```rust block in the docs tree and fail on the ones that are
-//! not Rust.
+//! Parse every fenced `rust` block in the docs tree and fail on the ones that
+//! are not Rust.
 //!
 //! **This checks syntax, not types.** It will not tell you a snippet calls a
 //! method that no longer exists — for that a block would have to compile
@@ -34,7 +34,7 @@ use eyre::{bail, eyre, Result};
 use regex::Regex;
 
 const DOCS_DIR: &str = "website/src/content/docs";
-/// Crate sources whose doc comments carry ```rust blocks. `cargo test --doc`
+/// Crate sources whose doc comments carry fenced `rust` blocks. `cargo test --doc`
 /// compiles the runnable ones; the `ignore` ones — every example that names a
 /// type from the user's app rather than from `loco-rs` — are never even
 /// parsed, so this is the only thing standing between them and a truncated
@@ -50,6 +50,9 @@ struct Block {
     skipped: bool,
 }
 
+/// # Errors
+/// when the docs tree is missing, a file cannot be read, or any block that
+/// did not opt out fails to parse as Rust
 pub fn run(project_dir: &Path) -> Result<()> {
     let root = project_dir.join(DOCS_DIR);
     if !root.is_dir() {

--- a/xtask/src/versions.rs
+++ b/xtask/src/versions.rs
@@ -71,6 +71,11 @@ fn bump_version_in_file(
     Ok(())
 }
 
+/// Bump every version a release touches.
+///
+/// # Errors
+/// when a `loco-new` fmt/clippy pre-check fails, a tracked file is missing or
+/// unreadable, or a version pattern no longer matches the file it bumps
 pub fn bump_version(version: &Version) -> Result<()> {
     // testing loco-new will test 4 combinations of starters
     // sets LOCO_DEV_MODE_PATH=/<path-to>/projects/loco/ and shared cargo build path


### PR DESCRIPTION
Stacked on #1810 — merge that first, this retargets to `master` automatically.

### The gap

`cargo clippy` with no `-p` or `--workspace` lints **the root package**. This repo has one (`loco-rs`), so the `style` job's clippy step has only ever seen `src/`. `xtask` and `loco-gen` are workspace members and had never been linted — not by CI, not by the documented local gate.

Adding `--workspace` surfaced 10 findings. All fixed here.

### What the findings were

| | |
|---|---|
| `xtask::ci::all_resources` | Turned a missing root `Cargo.toml` into a panic — `.expect("loco lib mast be tested")`, typo included. Returns an error naming the directory now; the function already returned `Result`. |
| 5 × `missing_errors_doc` | `cargo_test`, `cargo_fmt`, `cargo_clippy`, `docs_syntax::run`, `versions::bump_version` |
| 2 × unbalanced backticks | A literal ` ```rust ` inside a doc comment opens a fence that never closes. Reworded to "fenced `rust` block". |
| `println!("{project_dir:?}")` | Printed a quoted, escaped path. Uses `Path::display` now. |
| `redundant_clone` | `loco-gen/tests/templates/controller.rs` |
| `too_many_lines` | Allowed with a reason on the scaffold golden test — it is a flat inventory of every artifact one scaffold emits, and splitting it would hide which artifact a failure came from. |

### What this deliberately does not do

It does not add `--all-targets`, which would additionally lint `#[cfg(test)]` modules and `tests/`. That is a real gap — **33 pedantic + 16 nursery findings** — but it needs a lint-policy decision before it is worth doing:

- ~10 are `similar_names` on bindings like `res`/`resp` in test code. Renaming those is churn.
- 5 are `future_not_send` on `#[tokio::test]` futures, which have no reason to be `Send`.
- The rest (9 `items_after_statements`, 9 `doc_markdown`, 2 `too_many_lines`, a few singles) are worth fixing.

Happy to do that sweep as a follow-up once you say which lints we actually want held over test code.

### Verification

The exact CI command passes locally:

```
cargo clippy --workspace --all-features -- -D warnings -W clippy::pedantic -W clippy::nursery -W rust-2018-idioms   # exit 0
cargo fmt --all -- --check                                                                                          # exit 0
cargo test -p loco-gen --all-features --test mod                                                                    # 53 passed
```