### PR TITLE
fix(gen): generated Dockerfile pinned a Rust older than the MSRV

### DIFF
--- a/loco-gen/src/templates/deployment/docker/docker.t
+++ b/loco-gen/src/templates/deployment/docker/docker.t
@@ -2,7 +2,7 @@ to: "Dockerfile"
 skip_exists: true
 message: "Dockerfile generated successfully."
 ---
-FROM rust:1.92.0-slim AS builder
+FROM rust:1.94.0-slim AS builder
 
 WORKDIR /usr/src/
 

--- a/loco-gen/tests/templates/deployment.rs
+++ b/loco-gen/tests/templates/deployment.rs
@@ -3,6 +3,35 @@ use loco_gen::{collect_messages, generate, AppInfo, Component, DeploymentKind};
 use rrgen::RRgen;
 use std::{fs, path::PathBuf};
 
+/// The generated Dockerfile pins its own Rust base image, and nothing tied
+/// that pin to the MSRV the app's dependencies actually require. It drifted:
+/// the 1.0 release raised the MSRV to 1.94 for Sea-ORM 2.0 and left the
+/// template on 1.92.0, so every generated Dockerfile failed at
+/// `cargo build --release` with "rustc 1.92.0 is not supported". The nightly
+/// `loco-gen-deploy` workflow reported it every night and the snapshot test
+/// could not: it filters the version line out before comparing.
+fn assert_dockerfile_rust_meets_msrv(dockerfile: &str) {
+    let pinned = dockerfile
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("FROM rust:")
+                .and_then(|rest| rest.split('-').next())
+        })
+        .expect("Dockerfile has no `FROM rust:<version>` line");
+
+    let parts = |v: &str| -> Vec<u64> { v.split('.').map(|p| p.parse().unwrap_or(0)).collect() };
+    // `rust-version` may be a two-component "1.94"; compare on what it gives.
+    let msrv = env!("CARGO_PKG_RUST_VERSION");
+    let (pinned_parts, msrv_parts) = (parts(pinned), parts(msrv));
+
+    assert!(
+        pinned_parts >= msrv_parts[..msrv_parts.len().min(pinned_parts.len())].to_vec(),
+        "generated Dockerfile pins rust {pinned}, but loco-gen declares rust-version {msrv} — \
+         the image cannot build the app it generates. Bump \
+         `loco-gen/src/templates/deployment/docker/docker.t`."
+    );
+}
+
 #[rstest::rstest]
 fn can_generate_docker(
     #[values(vec![], vec![std::path::PathBuf::from("404.html"), PathBuf::from("asset")])]
@@ -54,6 +83,10 @@ fn can_generate_docker(
             fs::read_to_string(tree_fs.root.join("Dockerfile")).expect("Dockerfile missing")
         );
     });
+
+    assert_dockerfile_rust_meets_msrv(
+        &fs::read_to_string(tree_fs.root.join("Dockerfile")).expect("Dockerfile missing"),
+    );
 
     assert_eq!(
         fs::read_to_string(tree_fs.root.join(".dockerignore")).expect(".dockerignore missing"),


### PR DESCRIPTION
`cargo loco generate deployment docker` emits `FROM rust:1.92.0-slim`. loco-rs, loco-gen, sea-orm 2.0 and sqlx 0.9 all declare **rustc 1.94**. So every generated Dockerfile dies at `cargo build --release`:

```
error: rustc 1.92.0 is not supported by the following packages:
  loco-gen@1.1.0 requires rustc 1.94
  loco-rs@1.1.0 requires rustc 1.94
  sea-orm@2.0.2 requires rustc 1.94.0
  sqlx@0.9.0 requires rustc 1.94.0
```

The pin drifted when **1.0** raised the MSRV for Sea-ORM 2.0 and the template was not moved with it, so this has been broken across the whole 1.0/1.1 line.

### Why it survived

**The nightly `loco-gen-deploy` workflow has been reporting it every night** — it generates an app and builds its Docker image, which is exactly this path. It is a cron job rather than a PR gate, so nothing surfaced the red.

**The snapshot test cannot catch it.** It filters the version out before comparing:

```rust no-syntax-check="an insta filter pair, not an item"
(r"FROM rust:\d+\.\d+\.\d+-slim", "FROM rust:[version]-slim")
```

That is the right call for a snapshot — the version is precisely the part you do not want churning four fixtures — but it left the field with no coverage at all.

### The fix

Bump to `1.94.0-slim`, plus `assert_dockerfile_rust_meets_msrv`, which reads the pin out of the **generated** Dockerfile and compares it against loco-gen's own `CARGO_PKG_RUST_VERSION`. The next MSRV bump cannot drift the same way — and because it reads `rust-version` rather than a literal, it needs no maintenance when that changes.

Verified it actually fails on the old template:

```
generated Dockerfile pins rust 1.92.0, but loco-gen declares rust-version 1.94 —
the image cannot build the app it generates. Bump
`loco-gen/src/templates/deployment/docker/docker.t`.
```

### Verification

```
cargo fmt --all -- --check                                             # exit 0
cargo clippy --workspace --all-features -- -D warnings -W pedantic ...  # exit 0
cargo test -p loco-gen --all-features --test mod                       # 53 passed
```

### Still open

`loco-gen-deploy` failing nightly for weeks with nobody reading it is the more general problem. Worth deciding separately whether it should gate PRs or at least notify on failure.