### PR TITLE
chore(website): one `pnpm verify` instead of four CI steps

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,23 +71,21 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
         working-directory: website
-      - name: Unit tests (migration / link-rewrite scripts)
-        run: pnpm test
-        working-directory: website
-      # `astro check` type-checks the .astro files and every `astro:content`
-      # call against the generated collection types. It was never wired up, and
-      # by the time it was it had 36 errors: `tsconfig.json` listed `.astro` in
-      # `include`, but TypeScript skips dot-directories when expanding a
-      # directory into a glob, so the generated content types were never loaded
-      # and every `getCollection` silently resolved to `any`.
-      - name: Type-check the site
-        run: pnpm check
-        working-directory: website
-      - name: Build the Astro site (fails on broken links)
-        run: pnpm build
-        working-directory: website
-      - name: URL parity (old loco.rs URLs still resolve)
-        run: |
-          pnpm url-parity
-          pnpm url-parity-blog
+      # One command, defined in website/package.json, so `pnpm verify` locally
+      # is exactly what CI runs — there is no second list to keep in sync.
+      # It chains, in order:
+      #   test        vitest over the migration / link-rewrite scripts
+      #   check       `astro check` — type-checks .astro and every
+      #               `astro:content` call against the generated collection
+      #               types. It was never wired up, and by the time it was it
+      #               had 36 errors: `tsconfig.json` listed `.astro` in
+      #               `include`, but TypeScript skips dot-directories when
+      #               expanding a directory into a glob, so the generated
+      #               content types were never loaded and every `getCollection`
+      #               silently resolved to `any`.
+      #   build       the Astro build (fails on broken links); its `prebuild`
+      #               regenerates llms.txt / llms-full.txt
+      #   url-parity  every URL the retired Zola site published still resolves
+      - name: Verify the site
+        run: pnpm verify
         working-directory: website

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,10 @@ Running the local preview
 + `pnpm install`
 + `pnpm dev`
 
+Before opening a PR that touches the site or the docs, run `pnpm verify` in
+`website/`. It is the single command CI runs — unit tests, type-check, build,
+and URL parity against every address the old site published.
+
 ## Open A Pull Request
 
 The most recommended and straightforward method to contribute changes to the project involves forking it on GitHub and subsequently initiating a pull request to propose the integration of your modifications into our repository.

--- a/website/package.json
+++ b/website/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run",
     "migrate:docs": "node scripts/migrate-docs.mjs",
     "generate:llms": "node scripts/generate-llms-txt.mjs",
+    "verify": "pnpm test && pnpm check && pnpm build && pnpm url-parity && pnpm url-parity-blog",
     "url-parity": "node scripts/url-parity.mjs",
     "url-parity-blog": "node scripts/url-parity-blog.mjs"
   },


### PR DESCRIPTION
Checking the site meant running five commands in the right order, and the only place that order was written down was the `website` job in `docs.yml`. Verifying locally meant reading the workflow and copying it by hand, and nothing kept the two in sync.

`pnpm verify` now chains `test → check → build → url-parity → url-parity-blog`, and the workflow calls it. One list, one file.

`pnpm install --frozen-lockfile` stays its own step — it is setup rather than verification, and the Node cache keys off it.

### One trap worth naming

`build` stays in the chain as a **pnpm script**, not a direct `astro build`. The `prebuild` hook that regenerates `llms.txt` / `llms-full.txt` is bound to the script *name*; calling the binary directly skips it silently, and the LLM docs would quietly go stale — which is exactly the failure mode we just spent a PR removing.

### Verified

`pnpm verify` end to end, exit 0:

```
Test Files  3 passed (3)
     Tests  39 passed (39)
[build] 85 page(s) built
0 missing (checked 64 old doc URLs against 66 new doc URLs)
0 missing (checked 18 old blog/casts/authors URLs against 199 new URLs)
```