### PR TITLE
chore(website): make the docs version a badge, read from Cargo.toml

### DIFF
--- a/website/src/components/VersionBadge.astro
+++ b/website/src/components/VersionBadge.astro
@@ -1,57 +1,29 @@
 ---
-// Docs version switcher (v1.0 ▾) shown beside the wordmark in the docs
-// header. Extracted from the former SiteTitleWithVersion override: the docs
-// Header (src/components/starlight/Header.astro) now renders the marketing
-// brand directly and drops it in next to the wordmark, so this no longer
-// wraps Starlight's SiteTitle. See src/lib/versions.ts for the version list.
-import { docVersions } from '../lib/versions';
-
-const current = docVersions.find((v) => v.current) ?? docVersions[0];
+// The released Loco version, shown beside the wordmark in the docs header.
+//
+// This was a dropdown. It had exactly one entry, pointing at the page you
+// were already on — a menu that opened to reveal nothing — and the label was
+// hand-maintained, so it still read `v1.0` after 1.1.0 shipped. Now it is a
+// plain badge, and the version comes from the workspace Cargo.toml so it
+// cannot drift again. It links to that release's notes, which is the thing
+// someone checking the version actually wants next.
+import { locoVersion, locoReleaseUrl } from '../lib/versions';
 ---
 
-<details class="ver-switcher" data-version-switcher>
-  <summary class="ver" aria-label={`Docs version: ${current.label}`}>
-    {current.label}
-    <span class="chevron" aria-hidden="true">▾</span>
-  </summary>
-  <ul class="ver-menu" role="list">
-    {
-      docVersions.map((v) => (
-        <li>
-          <a href={v.href} aria-current={v.current ? 'true' : undefined}>
-            {v.label}
-          </a>
-        </li>
-      ))
-    }
-  </ul>
-</details>
-
-<script>
-  // Native <details> stays open on outside click/Escape by default; close it
-  // to match the conventional dropdown behavior.
-  document.querySelectorAll<HTMLDetailsElement>('[data-version-switcher]').forEach((el) => {
-    document.addEventListener('click', (e) => {
-      if (el.open && !el.contains(e.target as Node)) el.open = false;
-    });
-    el.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' && el.open) {
-        el.open = false;
-        el.querySelector('summary')?.focus();
-      }
-    });
-  });
-</script>
+<a
+  class="ver"
+  href={locoReleaseUrl}
+  aria-label={`Loco v${locoVersion} — release notes`}
+  title={`Loco v${locoVersion} — release notes`}
+>
+  v{locoVersion}
+</a>
 
 <style>
-  .ver-switcher {
-    position: relative;
-    flex-shrink: 0;
-  }
   .ver {
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: 0.3rem;
+    flex-shrink: 0;
     font-family: var(--sl-font-mono, var(--mono));
     font-size: 0.72rem;
     color: var(--ink-2);
@@ -59,60 +31,11 @@ const current = docVersions.find((v) => v.current) ?? docVersions[0];
     background: var(--card);
     padding: 0.19rem 0.55rem;
     border-radius: 0.45rem;
-    cursor: pointer;
-    user-select: none;
-    list-style: none;
+    text-decoration: none;
     white-space: nowrap;
-  }
-  .ver::-webkit-details-marker {
-    display: none;
   }
   .ver:hover {
     border-color: var(--ink-3);
     color: var(--ink);
-  }
-  .ver-switcher[open] .ver {
-    border-color: var(--red);
-    color: var(--ink);
-  }
-  .chevron {
-    font-size: 0.65rem;
-    transition: transform 0.15s ease;
-  }
-  .ver-switcher[open] .chevron {
-    transform: rotate(180deg);
-  }
-  .ver-menu {
-    position: absolute;
-    top: calc(100% + 0.4rem);
-    left: 0;
-    min-width: 6rem;
-    margin: 0;
-    padding: 0.35rem;
-    background: var(--card);
-    border: 1px solid var(--line);
-    border-radius: 0.55rem;
-    box-shadow: 0 12px 24px -12px rgba(0, 0, 0, 0.35);
-    z-index: 30;
-  }
-  .ver-menu li {
-    list-style: none;
-  }
-  .ver-menu a {
-    display: block;
-    padding: 0.3rem 0.55rem;
-    border-radius: 0.35rem;
-    font-family: var(--sl-font-mono, var(--mono));
-    font-size: 0.8rem;
-    color: var(--ink-2);
-    text-decoration: none;
-  }
-  .ver-menu a:hover {
-    background: var(--paper-2);
-    color: var(--ink);
-  }
-  .ver-menu a[aria-current='true'] {
-    color: var(--red-ink);
-    font-weight: 650;
   }
 </style>

--- a/website/src/lib/versions.test.ts
+++ b/website/src/lib/versions.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { locoReleaseUrl, locoVersion, packageVersion } from './versions';
+
+describe('packageVersion', () => {
+  it('reads the version out of [package], not out of a dependency', () => {
+    const manifest = `[workspace]
+members = ["xtask", "loco-gen"]
+
+[workspace.package]
+rust-version = "1.94"
+
+[package]
+name = "loco-rs"
+version = "1.1.0"
+
+[dependencies]
+tera = { version = "2.1", features = ["glob_fs"] }
+`;
+    expect(packageVersion(manifest)).toBe('1.1.0');
+  });
+
+  it('is not fooled by a [dependencies] table that starts with a bare version key', () => {
+    const manifest = `[package]
+name = "loco-rs"
+version = "1.1.0"
+
+[dependencies.tera]
+version = "2.1"
+`;
+    expect(packageVersion(manifest)).toBe('1.1.0');
+  });
+
+  it('throws rather than rendering a wrong version', () => {
+    expect(() => packageVersion('[dependencies]\nversion = "9.9.9"\n')).toThrow(/\[package\]/);
+    expect(() => packageVersion('[package]\nname = "loco-rs"\n')).toThrow(/no version/);
+  });
+});
+
+describe('the version the site actually ships', () => {
+  it('is a real semver read from the workspace manifest', () => {
+    expect(locoVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('links at the matching release tag', () => {
+    expect(locoReleaseUrl).toBe(`https://github.com/loco-rs/loco/releases/tag/v${locoVersion}`);
+  });
+});

--- a/website/src/lib/versions.ts
+++ b/website/src/lib/versions.ts
@@ -1,31 +1,49 @@
-export interface DocVersion {
-  /** Badge/menu label, e.g. `"v1.0"`. */
-  label: string;
-  /** Root docs path (or absolute URL) this version is served from. */
-  href: string;
-  /** Marks the version currently being served by this build. Exactly one entry should set this. */
-  current?: boolean;
+// Inlined by Vite at build time, resolved relative to THIS file. Reading the
+// manifest at runtime instead looked fine in vitest and then failed the build:
+// Astro bundles this module into a server chunk, so `import.meta.url` pointed
+// at the bundle and the path collapsed to `website/Cargo.toml`. `?raw` is
+// resolved while the module graph is still source-shaped, and leaves no file
+// IO in the output at all.
+import cargoToml from '../../../Cargo.toml?raw';
+
+const CARGO_TOML = 'the workspace Cargo.toml';
+
+/**
+ * Reads `version` from the `[package]` section of a `Cargo.toml`.
+ *
+ * Scoped to that section deliberately: `version = "..."` also appears inside
+ * every dependency's inline table, and `[workspace.package]` above it carries
+ * its own keys. Anchoring on the section heading is what makes a bare
+ * line-start match safe.
+ *
+ * @param manifest contents of a Cargo.toml
+ * @returns e.g. `'1.1.0'`
+ */
+export function packageVersion(manifest: string): string {
+  const section = manifest.split(/^\[package\]$/m)[1];
+  if (section === undefined) {
+    throw new Error(`${CARGO_TOML} has no [package] section`);
+  }
+  // Stop at the next section heading so a later `[dependencies]` entry cannot
+  // be mistaken for the package's own version.
+  const body = section.split(/^\[/m)[0];
+  const match = body.match(/^version = "([^"]+)"/m);
+  if (!match) {
+    throw new Error(`${CARGO_TOML} [package] section declares no version`);
+  }
+  return match[1];
 }
 
-// Every published docs version, newest first. Loco docs are single-version
-// today — this array has one entry — but `VersionBadge.astro` always
-// renders it as a dropdown (see that component), so it is already wired for
-// more without any template changes.
-//
-// To publish a new version later:
-//   1. Preserve the outgoing version's content somewhere it can still be
-//      served from its own `href` below — e.g. a versioned subpath such as
-//      `/v1.0/docs/...` (a copy of today's `src/content/docs/docs/` tree),
-//      or adopt the `starlight-versions` plugin to manage those snapshots
-//      for you. Either way, don't touch this file until that content exists
-//      and resolves at the URL you're about to add.
-//   2. Add the new version as `current: true` and demote the previous
-//      `current` entry to a plain historical entry pointing at its
-//      preserved path, e.g.:
-//        export const docVersions: DocVersion[] = [
-//          { label: 'v2.0', href: '/docs/', current: true },
-//          { label: 'v1.0', href: '/v1.0/docs/' },
-//        ];
-//   3. That's the whole change — `VersionBadge.astro` maps over this
-//      array unmodified.
-export const docVersions: DocVersion[] = [{ label: 'v1.0', href: '/docs/', current: true }];
+/**
+ * The released Loco version, read from the workspace `Cargo.toml` at build
+ * time.
+ *
+ * It used to be a hand-maintained list, and it drifted: the header still read
+ * `v1.0` after 1.1.0 had shipped. A version string on the docs site that
+ * nobody can trust is worse than no version string, and the only copy that
+ * cannot go stale is the one derived from the manifest being released.
+ */
+export const locoVersion: string = packageVersion(cargoToml);
+
+/** The GitHub release notes for {@link locoVersion}. */
+export const locoReleaseUrl = `https://github.com/loco-rs/loco/releases/tag/v${locoVersion}`;


### PR DESCRIPTION
The docs header carried a version **dropdown**. It had exactly one entry, pointing at `/docs/` — the page you were already on — so it opened to reveal nothing:

```ts
export const docVersions: DocVersion[] = [{ label: 'v1.0', href: '/docs/', current: true }];
```

And that label was hand-maintained, so it had already drifted: the site still said **v1.0** three weeks after 1.1.0 shipped.

Same shape as the Dockerfile MSRV pin from #1815 — a value duplicated by hand with nothing tying it to what it describes.

### Now

A plain badge, linking to that version's release notes. `locoVersion` is read from the `[package]` version in the workspace `Cargo.toml`, so it tracks whatever is actually being released.

`packageVersion` is scoped to the `[package]` section deliberately: `version =` also appears in every dependency inline table, and a `[dependencies.tera]` block would otherwise match a bare line-start `version` key. Both cases are tested, along with the two failure modes — which throw rather than render something wrong.

### One thing worth knowing

The manifest is inlined with `?raw`, not read with `fs`. The `fs` version **passed vitest and then failed the build**: Astro bundles this module into a server chunk, so `import.meta.url` pointed at the bundle and the path collapsed to `website/Cargo.toml`. `?raw` resolves while the module graph is still source-shaped, and leaves no file IO in the output.

### Verified

```
Tests            44 passed (44)
astro check      clean, 45 files
build            85 pages
url-parity       0 missing of 64 doc URLs
url-parity-blog  0 missing of 18 blog/casts/authors URLs
```

Built HTML renders `v1.1.0`, with **0** occurrences of `ver-switcher` / `ver-menu` / `data-version-switcher` and **0** of the stale `v1.0` label.