### PR TITLE
feat(bgworker): perform_all_later batch job enqueueing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,11 @@ impl BackgroundWorker<DownloadWorkerArgs> for DownloadWorker {
 let job_id = DownloadWorker::perform_later(&ctx, args).await?;
 // enqueue at a priority (higher runs first), on ANY backend:
 DownloadWorker::perform_later_with_priority(&ctx, args, Some(100)).await?;
+// enqueue many jobs in ONE round trip (atomic on every backend); returns
+// one id per job, in input order:
+let job_ids = DownloadWorker::perform_all_later(&ctx, args_list).await?;
+// same, with a priority per job (None = default):
+DownloadWorker::perform_all_later_with_priority(&ctx, vec![(a, Some(100)), (b, None)]).await?;
 ```
 
 - Backends: Postgres and SQLite ship by default (feature `worker`); Redis needs
@@ -154,6 +159,8 @@ DownloadWorker::perform_later_with_priority(&ctx, args, Some(100)).await?;
   (`Result<String>`). Priority (full `i32` range) works on all three
   backends. Redis fully supports job admin now (cancel/clear/requeue/dump/
   import) — it is not Postgres/SQLite-only.
+- ❌ Calling `perform_later` in a loop to fan out N jobs. ✅
+  `perform_all_later(&ctx, Vec<Args>)` — one round trip, one transaction.
 - Manage from the CLI: `cargo loco jobs cancel|tidy|purge|dump|import|requeue`.
 
 ## Scheduler, mailers, tasks

--- a/src/bgworker/mod.rs
+++ b/src/bgworker/mod.rs
@@ -164,6 +164,38 @@ pub trait QueueProvider: Send + Sync {
         priority: Option<i32>,
     ) -> Result<Option<String>>;
 
+    /// Add multiple jobs to the queue in one batch. See [`Queue::enqueue_batch`]
+    /// for the full contract.
+    ///
+    /// Each entry of `jobs` is one job's serialized arguments paired with its
+    /// priority (`None` for the default). `tags` apply to every job.
+    ///
+    /// The default implementation enqueues jobs one at a time and is NOT
+    /// atomic; the built-in Postgres/`SQLite`/Redis providers override it with
+    /// a single-transaction (or `MULTI`/`EXEC`) batch so a mid-batch failure
+    /// leaves nothing behind.
+    ///
+    /// # Errors
+    /// This function will return an error if the enqueue operation fails.
+    async fn enqueue_batch(
+        &self,
+        class: String,
+        queue: Option<String>,
+        jobs: Vec<(JsonValue, Option<i32>)>,
+        tags: Option<Vec<String>>,
+    ) -> Result<Vec<JobId>> {
+        let mut ids = Vec::with_capacity(jobs.len());
+        for (args, priority) in jobs {
+            if let Some(id) = self
+                .enqueue(class.clone(), queue.clone(), args, tags.clone(), priority)
+                .await?
+            {
+                ids.push(id);
+            }
+        }
+        Ok(ids)
+    }
+
     /// Registers a pre-erased job handler under `name`.
     ///
     /// # Errors
@@ -438,6 +470,50 @@ impl Queue {
         self.0
             .enqueue(class, queue, serde_json::to_value(args)?, tags, priority)
             .await
+    }
+
+    /// Add multiple jobs to the queue in a single batch operation, returning
+    /// the assigned job IDs (empty when no provider is configured).
+    ///
+    /// This reduces round trips compared to calling [`Queue::enqueue`] in a
+    /// loop — dispatchers that fan out hundreds of jobs (e.g. a notification
+    /// generator) otherwise pay one INSERT per job. The built-in providers
+    /// enqueue the whole batch atomically: either every job is enqueued or
+    /// none are, so a failed batch is safe to retry without duplicating jobs.
+    ///
+    /// Each entry of `jobs` is one job's arguments paired with its priority
+    /// (`None` for the default); priority semantics match [`Queue::enqueue`].
+    /// `tags` apply to every job in the batch. The returned IDs are in the
+    /// same order as `jobs`.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if serialization or the enqueue
+    /// operation fails.
+    pub async fn enqueue_batch<A: Serialize + Send + Sync>(
+        &self,
+        class: String,
+        queue: Option<String>,
+        jobs: Vec<(A, Option<i32>)>,
+        tags: Option<Vec<String>>,
+    ) -> Result<Vec<JobId>> {
+        if jobs.is_empty() {
+            return Ok(Vec::new());
+        }
+        tracing::debug!(
+            worker = class,
+            queue = ?queue,
+            tags = ?tags,
+            count = jobs.len(),
+            "Batch enqueueing background jobs"
+        );
+        // Serialize every payload up front; a failure is surfaced before
+        // anything is enqueued rather than silently enqueuing a null payload.
+        let jobs = jobs
+            .into_iter()
+            .map(|(args, priority)| Ok((serde_json::to_value(args)?, priority)))
+            .collect::<Result<Vec<_>>>()?;
+        self.0.enqueue_batch(class, queue, jobs, tags).await
     }
 
     /// Register a worker
@@ -744,6 +820,97 @@ pub trait BackgroundWorker<A: Send + Sync + serde::Serialize + 'static>: Send + 
         Ok(job_id)
     }
 
+    /// Enqueue (or run) multiple jobs at once at the default priority and
+    /// return their IDs, in the same order as `args_list`.
+    ///
+    /// Convenience wrapper over
+    /// [`BackgroundWorker::perform_all_later_with_priority`] with no explicit
+    /// priority for any job.
+    async fn perform_all_later(ctx: &AppContext, args_list: Vec<A>) -> crate::Result<Vec<String>>
+    where
+        Self: Sized,
+    {
+        let jobs = args_list.into_iter().map(|args| (args, None)).collect();
+        Self::perform_all_later_with_priority(ctx, jobs).await
+    }
+
+    /// Enqueue (or run) multiple jobs at once, each with its own priority,
+    /// and return their IDs. This is the batch counterpart of
+    /// [`BackgroundWorker::perform_later_with_priority`]: it replaces a loop
+    /// of `perform_later` calls with one round trip to the queue.
+    ///
+    /// Each entry of `jobs` is one job's arguments paired with its priority
+    /// (`None` for the default). Higher values are dequeued first (see
+    /// [`Queue::enqueue`]). The returned IDs are in the same order as `jobs`.
+    ///
+    /// In `BackgroundQueue` mode the whole batch is enqueued atomically by the
+    /// built-in providers — either every job is enqueued or none are — and
+    /// the IDs are the ones assigned by the queue provider. In
+    /// `ForegroundBlocking` mode the jobs run sequentially, in order, and the
+    /// first failure returns early without running the rest. In
+    /// `BackgroundAsync` mode a task is spawned per job. Priority has no
+    /// effect in the two non-queue modes; in both of them fresh IDs are
+    /// generated so callers always get stable handles back, matching
+    /// `perform_later_with_priority`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::QueueProviderMissing`] when `BackgroundQueue` mode is
+    /// selected but no queue provider is populated in the context — no job is
+    /// run and no IDs are fabricated. Otherwise returns the provider's batch
+    /// enqueue error, or (in `ForegroundBlocking` mode) the first job error.
+    async fn perform_all_later_with_priority(
+        ctx: &AppContext,
+        jobs: Vec<(A, Option<i32>)>,
+    ) -> crate::Result<Vec<String>>
+    where
+        Self: Sized,
+    {
+        if jobs.is_empty() {
+            return Ok(Vec::new());
+        }
+        let job_ids = match &ctx.config.workers.mode {
+            WorkerMode::BackgroundQueue => {
+                if let Some(p) = &ctx.queue_provider {
+                    let tags = Self::tags();
+                    let tags_option = if tags.is_empty() { None } else { Some(tags) };
+                    p.enqueue_batch(Self::class_name(), Self::queue(), jobs, tags_option)
+                        .await?
+                } else {
+                    return Err(Error::QueueProviderMissing);
+                }
+            }
+            WorkerMode::ForegroundBlocking => {
+                let worker = Self::build(ctx);
+                let mut ids = Vec::with_capacity(jobs.len());
+                for (args, _priority) in jobs {
+                    worker.perform(args).await?;
+                    ids.push(uuid::Uuid::new_v4().to_string());
+                }
+                ids
+            }
+            WorkerMode::BackgroundAsync => {
+                // One task per job, matching perform_later's fire-and-forget
+                // semantics — handles are dropped, not awaited.
+                jobs.into_iter()
+                    .map(|(args, _priority)| {
+                        let dx = ctx.clone();
+                        tokio::spawn(async move {
+                            if let Err(err) = Self::build(&dx).perform(args).await {
+                                tracing::error!(
+                                    err = err.to_string(),
+                                    "worker failed to perform job"
+                                );
+                            }
+                        });
+                        uuid::Uuid::new_v4().to_string()
+                    })
+                    .collect()
+            }
+        };
+        Ok(job_ids)
+    }
+
     async fn perform(&self, args: A) -> crate::Result<()>;
 }
 
@@ -947,6 +1114,165 @@ mod tests {
         assert_eq!(count, 14);
     }
 
+    async fn sqlite_queue(db_path: &Path) -> Queue {
+        let queue = sqlt::create_provider(&sqlite_config(db_path))
+            .await
+            .expect("create sqlite queue");
+        queue.setup().await.expect("setup sqlite db");
+        queue
+    }
+
+    #[tokio::test]
+    async fn can_enqueue_batch_through_queue() {
+        let tree_fs = tree_fs::TreeBuilder::default()
+            .drop(true)
+            .create()
+            .expect("create temp folder");
+        let queue = sqlite_queue(tree_fs.root.as_path()).await;
+
+        // Empty input is a no-op that touches no provider.
+        let none = queue
+            .enqueue_batch::<serde_json::Value>("BatchJob".to_string(), None, Vec::new(), None)
+            .await
+            .expect("empty batch");
+        assert!(none.is_empty());
+
+        let ids = queue
+            .enqueue_batch(
+                "BatchJob".to_string(),
+                None,
+                vec![
+                    (serde_json::json!({"user_id": 1}), None),
+                    (serde_json::json!({"user_id": 2}), Some(7)),
+                ],
+                Some(vec!["batch".to_string()]),
+            )
+            .await
+            .expect("batch enqueue");
+        assert_eq!(ids.len(), 2);
+
+        // Each job keeps its own priority; tags apply to the whole batch.
+        let jobs = queue.get_jobs(None, None).await.expect("get jobs");
+        assert_eq!(jobs.len(), 2);
+        for (id, expected_priority) in ids.iter().zip([0, 7]) {
+            let job = jobs
+                .iter()
+                .find(|job| &job.id == id)
+                .expect("batched job must be stored");
+            assert_eq!(job.name, "BatchJob");
+            assert_eq!(job.status, JobStatus::Queued);
+            assert_eq!(job.priority, expected_priority);
+            assert_eq!(job.tags, Some(vec!["batch".to_string()]));
+        }
+    }
+
+    #[tokio::test]
+    async fn enqueue_batch_without_provider_returns_no_ids() {
+        // `Queue::empty` goes through the trait's default `enqueue_batch`,
+        // which loops over `enqueue`; the no-op provider reports no ids.
+        let ids = Queue::empty()
+            .enqueue_batch(
+                "BatchJob".to_string(),
+                None,
+                vec![(serde_json::json!({"user_id": 1}), None)],
+                None,
+            )
+            .await
+            .expect("batch enqueue on the no-op provider");
+        assert!(ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn perform_all_later_runs_jobs_in_order_in_foreground_blocking_mode() {
+        static PERFORMED: std::sync::Mutex<Vec<i32>> = std::sync::Mutex::new(Vec::new());
+
+        struct RecordingWorker;
+        #[async_trait]
+        impl BackgroundWorker<i32> for RecordingWorker {
+            fn build(_ctx: &AppContext) -> Self {
+                Self
+            }
+            async fn perform(&self, args: i32) -> Result<()> {
+                PERFORMED.lock().expect("lock").push(args);
+                Ok(())
+            }
+        }
+
+        let mut ctx = tests_cfg::app::get_app_context().await;
+        ctx.config.workers.mode = WorkerMode::ForegroundBlocking;
+
+        let ids = RecordingWorker::perform_all_later_with_priority(
+            &ctx,
+            vec![(1, None), (2, Some(10)), (3, None)],
+        )
+        .await
+        .expect("perform all later");
+        assert_eq!(ids.len(), 3, "one generated id per job");
+        assert_eq!(
+            *PERFORMED.lock().expect("lock"),
+            vec![1, 2, 3],
+            "foreground mode runs the jobs in input order"
+        );
+
+        let ids = RecordingWorker::perform_all_later(&ctx, Vec::new())
+            .await
+            .expect("empty perform all later");
+        assert!(ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn perform_all_later_enqueues_one_batch_in_background_queue_mode() {
+        struct TaggedWorker;
+        #[async_trait]
+        impl BackgroundWorker<serde_json::Value> for TaggedWorker {
+            fn tags() -> Vec<String> {
+                vec!["batch".to_string()]
+            }
+            fn build(_ctx: &AppContext) -> Self {
+                Self
+            }
+            async fn perform(&self, _args: serde_json::Value) -> Result<()> {
+                Ok(())
+            }
+        }
+
+        let tree_fs = tree_fs::TreeBuilder::default()
+            .drop(true)
+            .create()
+            .expect("create temp folder");
+        let queue = Arc::new(sqlite_queue(tree_fs.root.as_path()).await);
+
+        let mut ctx = tests_cfg::app::get_app_context().await;
+        ctx.config.workers.mode = WorkerMode::BackgroundQueue;
+        ctx.queue_provider = Some(queue.clone());
+
+        let ids = TaggedWorker::perform_all_later_with_priority(
+            &ctx,
+            vec![
+                (serde_json::json!({"user_id": 1}), None),
+                (serde_json::json!({"user_id": 2}), Some(7)),
+            ],
+        )
+        .await
+        .expect("perform all later");
+        assert_eq!(ids.len(), 2);
+
+        // The batch lands under the worker's class name and tags, and the ids
+        // are the ones the provider assigned, in input order.
+        let jobs = queue.get_jobs(None, None).await.expect("get jobs");
+        assert_eq!(jobs.len(), 2);
+        for (id, expected_priority) in ids.iter().zip([0, 7]) {
+            let job = jobs
+                .iter()
+                .find(|job| &job.id == id)
+                .expect("batched job must be stored under the returned id");
+            assert_eq!(job.name, "TaggedWorker");
+            assert_eq!(job.status, JobStatus::Queued);
+            assert_eq!(job.priority, expected_priority);
+            assert_eq!(job.tags, Some(vec!["batch".to_string()]));
+        }
+    }
+
     #[tokio::test]
     async fn perform_later_without_provider_in_background_queue_mode_is_an_error() {
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -973,6 +1299,11 @@ mod tests {
         let err = CountingWorker::perform_later(&ctx, ())
             .await
             .expect_err("perform_later without a provider must fail");
+        assert!(matches!(err, Error::QueueProviderMissing), "{err:?}");
+
+        let err = CountingWorker::perform_all_later(&ctx, vec![(), ()])
+            .await
+            .expect_err("perform_all_later without a provider must fail");
         assert!(matches!(err, Error::QueueProviderMissing), "{err:?}");
 
         assert_eq!(

--- a/src/bgworker/mod.rs
+++ b/src/bgworker/mod.rs
@@ -690,9 +690,17 @@ pub trait BackgroundWorker<A: Send + Sync + serde::Serialize + 'static>: Send + 
     /// Enqueue (or run) the job with an explicit priority and return its ID.
     ///
     /// In `BackgroundQueue` mode the ID is the one assigned by the queue
-    /// provider. In foreground/async modes (or when no provider is configured)
-    /// a fresh ID is generated so callers always get a stable handle back.
-    /// Higher `priority` values are dequeued first (see [`Queue::enqueue`]).
+    /// provider. In foreground/async modes a fresh ID is generated so callers
+    /// always get a stable handle back. Higher `priority` values are dequeued
+    /// first (see [`Queue::enqueue`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::QueueProviderMissing`] when `BackgroundQueue` mode is
+    /// selected but no queue provider is populated in the context — the job
+    /// is not run and no ID is fabricated for it. Otherwise returns the
+    /// provider's enqueue error, or (in `ForegroundBlocking` mode) the
+    /// job's own error.
     async fn perform_later_with_priority(
         ctx: &AppContext,
         args: A,
@@ -716,11 +724,7 @@ pub trait BackgroundWorker<A: Send + Sync + serde::Serialize + 'static>: Send + 
                     .await?
                     .unwrap_or_else(|| uuid::Uuid::new_v4().to_string())
                 } else {
-                    tracing::error!(
-                        "perform_later: background queue is selected, but queue was not populated \
-                         in context"
-                    );
-                    uuid::Uuid::new_v4().to_string()
+                    return Err(Error::QueueProviderMissing);
                 }
             }
             WorkerMode::ForegroundBlocking => {
@@ -791,11 +795,18 @@ pub async fn converge(queue: &Queue, config: &QueueConfig) -> Result<()> {
     Ok(())
 }
 
-/// Create a provider
+/// Create a provider from the `queue` config when `workers.mode` is
+/// `BackgroundQueue`; returns `None` in the other worker modes, which need no
+/// provider.
 ///
 /// # Errors
 ///
-/// This function will return an error if fails to build
+/// Returns an error if the provider fails to build, if the configured queue
+/// kind was not compiled in, or if `workers.mode` is `BackgroundQueue` but the
+/// config has no `queue` section. That last case used to yield `Ok(None)`:
+/// the app booted, and in a server-only process every `perform_later` then
+/// dropped its job while returning a fabricated id. Failing at boot surfaces
+/// the misconfiguration before any job is lost.
 #[allow(clippy::missing_panics_doc)]
 pub async fn create_queue_provider(config: &Config) -> Result<Option<Arc<Queue>>> {
     if config.workers.mode == config::WorkerMode::BackgroundQueue {
@@ -824,8 +835,10 @@ pub async fn create_queue_provider(config: &Config) -> Result<Option<Arc<Queue>>
                 )),
             }
         } else {
-            // tracing::warn!("Worker mode is BackgroundQueue but no queue configuration is present");
-            Ok(None)
+            Err(Error::string(
+                "workers.mode is BackgroundQueue but no `queue` configuration is present; add a \
+                 `queue` section with the connection details or change `workers.mode`",
+            ))
         }
     } else {
         // tracing::debug!("Worker mode is not BackgroundQueue, skipping queue provider creation");
@@ -932,5 +945,64 @@ mod tests {
             .unwrap();
 
         assert_eq!(count, 14);
+    }
+
+    #[tokio::test]
+    async fn perform_later_without_provider_in_background_queue_mode_is_an_error() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static PERFORMED: AtomicUsize = AtomicUsize::new(0);
+
+        struct CountingWorker;
+        #[async_trait]
+        impl BackgroundWorker<()> for CountingWorker {
+            fn build(_ctx: &AppContext) -> Self {
+                Self
+            }
+            async fn perform(&self, (): ()) -> Result<()> {
+                PERFORMED.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        // `BackgroundQueue` selected, but nothing to enqueue into. This must
+        // surface as an error, not as a fabricated id for a job that is gone.
+        let mut ctx = tests_cfg::app::get_app_context().await;
+        ctx.config.workers.mode = WorkerMode::BackgroundQueue;
+        ctx.queue_provider = None;
+
+        let err = CountingWorker::perform_later(&ctx, ())
+            .await
+            .expect_err("perform_later without a provider must fail");
+        assert!(matches!(err, Error::QueueProviderMissing), "{err:?}");
+
+        assert_eq!(
+            PERFORMED.load(Ordering::SeqCst),
+            0,
+            "no job may run inline when the queue is missing"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_queue_provider_rejects_background_queue_without_queue_config() {
+        let mut config = tests_cfg::config::test_config();
+        config.workers.mode = WorkerMode::BackgroundQueue;
+        config.queue = None;
+
+        let Err(err) = create_queue_provider(&config).await else {
+            panic!("BackgroundQueue without a `queue` section must fail at boot");
+        };
+        assert!(
+            err.to_string().contains("no `queue` configuration"),
+            "unexpected error: {err}"
+        );
+
+        // The other modes need no provider and must keep returning `None`.
+        for mode in [WorkerMode::ForegroundBlocking, WorkerMode::BackgroundAsync] {
+            config.workers.mode = mode;
+            assert!(create_queue_provider(&config)
+                .await
+                .expect("non-queue modes need no provider")
+                .is_none());
+        }
     }
 }

--- a/src/bgworker/pg.rs
+++ b/src/bgworker/pg.rs
@@ -81,6 +81,16 @@ impl QueueProvider for PgQueue {
         ))
     }
 
+    async fn enqueue_batch(
+        &self,
+        class: String,
+        _queue: Option<String>,
+        jobs: Vec<(serde_json::Value, Option<i32>)>,
+        tags: Option<Vec<String>>,
+    ) -> Result<Vec<JobId>> {
+        enqueue_batch(&self.pool, &class, jobs, chrono::Utc::now(), tags).await
+    }
+
     async fn register_handler(&self, name: String, handler: JobHandler) -> Result<()> {
         let mut registry = self.registry.lock().await;
         registry.insert_handler(name, handler)
@@ -285,6 +295,70 @@ pub async fn enqueue(
     .execute(pool)
     .await?;
     Ok(id)
+}
+
+/// Maximum number of jobs per INSERT statement. Each row binds 7 parameters,
+/// so this stays well under Postgres's 65535 bind-parameter cap and bounds the
+/// statement size (mirrors Sidekiq's bulk-push chunking). Larger batches are
+/// split across multiple statements that all run inside one transaction, so
+/// the whole batch is still enqueued atomically regardless of how many chunks
+/// it spans.
+const ENQUEUE_BATCH_CHUNK_SIZE: usize = 5_000;
+
+/// Enqueue multiple jobs in a single atomic batch.
+///
+/// Each entry of `jobs` is one job's data paired with its priority (`None`
+/// for the default); `tags` apply to every job. The returned IDs are in the
+/// same order as `jobs`.
+///
+/// Every job is inserted inside one transaction: either all of them are
+/// enqueued or none are. A failure mid-batch rolls back, so the batch leaves
+/// nothing behind and is safe to retry without duplicating jobs.
+///
+/// # Errors
+///
+/// This function will return an error if it fails
+pub async fn enqueue_batch(
+    pool: &PgPool,
+    name: &str,
+    jobs: Vec<(JobData, Option<i32>)>,
+    run_at: DateTime<Utc>,
+    tags: Option<Vec<String>>,
+) -> Result<Vec<JobId>> {
+    if jobs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let tags_json = match &tags {
+        Some(tags) => Some(serde_json::to_value(tags)?),
+        None => None,
+    };
+    let mut ids = Vec::with_capacity(jobs.len());
+
+    debug!(count = jobs.len(), job_name = %name, run_at = %run_at, tags = ?tags, "Batch enqueueing jobs");
+    let mut tx = pool.begin().await?;
+    for chunk in jobs.chunks(ENQUEUE_BATCH_CHUNK_SIZE) {
+        let mut query_builder = sqlx::query_builder::QueryBuilder::<sqlx::Postgres>::new(
+            "INSERT INTO pg_loco_queue (id, task_data, name, run_at, interval, tags, priority) ",
+        );
+
+        query_builder.push_values(chunk.iter(), |mut b, (data, priority)| {
+            let id = Ulid::new().to_string();
+            b.push_bind(id.clone())
+                .push_bind(data.clone())
+                .push_bind(name.to_string())
+                .push_bind(run_at)
+                .push_bind(None::<i64>)
+                .push_bind(tags_json.clone())
+                .push_bind(priority.unwrap_or(0));
+            ids.push(id);
+        });
+
+        query_builder.build().execute(&mut *tx).await?;
+    }
+    tx.commit().await?;
+
+    Ok(ids)
 }
 
 async fn dequeue(client: &PgPool, worker_tags: &[String]) -> Result<Option<Job>> {
@@ -751,6 +825,95 @@ mod tests {
         (pattern, replacement)),     }, {
                 assert_debug_snapshot!(jobs);
             });
+    }
+
+    #[tokio::test]
+    async fn can_enqueue_batch() {
+        let (pool, _container) = setup_pg_test().await;
+        assert_eq!(get_all_jobs(&pool).await.len(), 0);
+
+        // Mixed per-job priorities: the default (None → 0), a high and a low
+        // value. Dequeue order must follow priority, not insertion order.
+        let run_at = Utc::now() - chrono::Duration::minutes(1);
+        let jobs = vec![
+            (serde_json::json!({"user_id": 1}), None),
+            (serde_json::json!({"user_id": 2}), Some(10)),
+            (serde_json::json!({"user_id": 3}), Some(-5)),
+        ];
+        let ids = enqueue_batch(&pool, "BatchJob", jobs, run_at, None)
+            .await
+            .expect("batch enqueue");
+        assert_eq!(ids.len(), 3);
+        assert_eq!(get_all_jobs(&pool).await.len(), 3);
+
+        // Returned ids are in input order and carry each job's own priority.
+        assert_eq!(get_job(&pool, &ids[0]).await.priority, 0);
+        assert_eq!(get_job(&pool, &ids[1]).await.priority, 10);
+        assert_eq!(get_job(&pool, &ids[2]).await.priority, -5);
+
+        for expected_user in [2, 1, 3] {
+            let job = dequeue(&pool, &[])
+                .await
+                .expect("dequeue ok")
+                .expect("a batched job must be dequeueable");
+            assert_eq!(
+                job.data.get("user_id"),
+                Some(&serde_json::json!(expected_user)),
+                "batched jobs must be dequeued by priority"
+            );
+            complete_job(&pool, &job.id, None)
+                .await
+                .expect("complete job");
+        }
+        assert!(dequeue(&pool, &[]).await.expect("dequeue ok").is_none());
+
+        // Tagged batches bind tags_json for every row; a worker carrying the
+        // tag must see them and a tagless worker must not.
+        let tagged = enqueue_batch(
+            &pool,
+            "BatchJob",
+            vec![(serde_json::json!({"user_id": 4}), None)],
+            run_at,
+            Some(vec!["email".to_string()]),
+        )
+        .await
+        .expect("tagged batch enqueue");
+        assert_eq!(tagged.len(), 1);
+        assert!(
+            dequeue(&pool, &[]).await.expect("dequeue ok").is_none(),
+            "an untagged worker must not see tagged jobs"
+        );
+        let job = dequeue(&pool, &["email".to_string()])
+            .await
+            .expect("dequeue ok")
+            .expect("a tagged batched job must be dequeueable by a matching worker");
+        assert_eq!(job.id, tagged[0]);
+        assert_eq!(job.tags, Some(vec!["email".to_string()]));
+    }
+
+    #[tokio::test]
+    async fn can_enqueue_batch_across_chunks() {
+        let (pool, _container) = setup_pg_test().await;
+        assert_eq!(get_all_jobs(&pool).await.len(), 0);
+
+        // Span more than two chunks so the multi-statement path runs inside one
+        // transaction. All rows must commit together (atomic batch) and every
+        // generated id must be unique.
+        let count = ENQUEUE_BATCH_CHUNK_SIZE * 2 + 1;
+        let jobs = (0..count)
+            .map(|i| (serde_json::json!({ "user_id": i }), None))
+            .collect::<Vec<_>>();
+
+        let ids = enqueue_batch(&pool, "BatchJob", jobs, Utc::now(), None)
+            .await
+            .expect("batch enqueue");
+        assert_eq!(ids.len(), count);
+        assert_eq!(
+            ids.iter().collect::<std::collections::HashSet<_>>().len(),
+            count,
+            "every batched job id must be unique"
+        );
+        assert_eq!(get_all_jobs(&pool).await.len(), count);
     }
 
     #[tokio::test]

--- a/src/bgworker/redis.rs
+++ b/src/bgworker/redis.rs
@@ -244,6 +244,54 @@ pub async fn enqueue(
     Ok(job_id)
 }
 
+/// Enqueue multiple jobs in a single atomic pipeline operation.
+///
+/// Each entry of `jobs` is one job's arguments paired with its priority
+/// (`None` for the default); `tags` apply to every job. The returned IDs are
+/// in the same order as `jobs`.
+///
+/// The pipeline runs as a `MULTI`/`EXEC` transaction, so either every job's
+/// payload and queue entry are written or none are. A failure leaves nothing
+/// behind and the batch is safe to retry without duplicating jobs.
+///
+/// # Errors
+///
+/// This function will return an error if it fails
+pub async fn enqueue_batch(
+    client: &RedisPool,
+    class: String,
+    queue: Option<String>,
+    jobs: Vec<(serde_json::Value, Option<i32>)>,
+    tags: Option<Vec<String>>,
+) -> Result<Vec<JobId>> {
+    if jobs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut conn = get_connection(client).await?;
+    let queue_name = queue.unwrap_or_else(|| "default".to_string());
+    let queue_key = format!("{QUEUE_KEY_PREFIX}{queue_name}");
+
+    let mut ids = Vec::with_capacity(jobs.len());
+    let mut pipe = redis::pipe();
+    pipe.atomic();
+    for (args_json, priority) in jobs {
+        let job_id = Ulid::new().to_string();
+        let mut job = Job::new(job_id, class.clone(), args_json);
+        job.tags = tags.clone();
+        job.priority = priority.unwrap_or(0);
+        let job_json = job.to_json()?;
+        let job_key = format!("{JOB_KEY_PREFIX}{}", job.id);
+        pipe.set(&job_key, &job_json).ignore();
+        pipe.zadd(&queue_key, &job.id, calculate_score(job.priority))
+            .ignore();
+        ids.push(job.id);
+    }
+
+    pipe.query_async::<()>(&mut conn).await?;
+    Ok(ids)
+}
+
 /// Redis ZSET score for a job, derived from priority only.
 ///
 /// We deliberately use only the priority in the score to preserve exact
@@ -982,6 +1030,16 @@ impl QueueProvider for RedisQueue {
         ))
     }
 
+    async fn enqueue_batch(
+        &self,
+        class: String,
+        queue: Option<String>,
+        jobs: Vec<(JsonValue, Option<i32>)>,
+        tags: Option<Vec<String>>,
+    ) -> Result<Vec<JobId>> {
+        enqueue_batch(&self.client, class, queue, jobs, tags).await
+    }
+
     async fn register_handler(&self, name: String, handler: JobHandler) -> Result<()> {
         let mut registry = self.registry.lock().await;
         registry.insert_handler(name, handler)
@@ -1273,6 +1331,118 @@ mod tests {
         // Queue should now be empty
         let queue_len: i64 = conn.zcard(&queue_key).await.expect("get queue length");
         assert_eq!(queue_len, 0);
+    }
+
+    #[tokio::test]
+    async fn test_can_enqueue_batch_redis() {
+        let (client, _container) = setup_redis().await;
+        assert!(clear(&client).await.is_ok());
+
+        // Mixed per-job priorities: the default (None → 0), a high and a low
+        // value. Dequeue order must follow priority, not insertion order.
+        let jobs = vec![
+            (serde_json::json!({"user_id": 1}), None),
+            (serde_json::json!({"user_id": 2}), Some(10)),
+            (serde_json::json!({"user_id": 3}), Some(-5)),
+        ];
+        let ids = enqueue_batch(&client, "BatchJob".to_string(), None, jobs, None)
+            .await
+            .expect("batch enqueue");
+        assert_eq!(ids.len(), 3);
+
+        // Every job key was written, in input order, with its own priority.
+        let stored = get_all_jobs(&client).await;
+        assert_eq!(stored.len(), 3);
+        for (id, expected_priority) in ids.iter().zip([0, 10, -5]) {
+            let job = stored
+                .iter()
+                .find(|job| &job.id == id)
+                .expect("batched job must be stored");
+            assert_eq!(job.name, "BatchJob");
+            assert_eq!(job.status, JobStatus::Queued);
+            assert_eq!(job.priority, expected_priority);
+        }
+
+        // Every id landed in the default queue's ZSET.
+        let mut conn = get_test_connection(&client).await;
+        let queue_key = format!("{QUEUE_KEY_PREFIX}default");
+        let queue_len: i64 = conn.zcard(&queue_key).await.expect("get queue length");
+        assert_eq!(queue_len, 3);
+
+        let queues = vec!["default".to_string()];
+        for expected_user in [2, 1, 3] {
+            let (job, _) = dequeue_with_conn(&mut conn, &queues, &[])
+                .await
+                .expect("dequeue")
+                .expect("a batched job must be dequeueable");
+            assert_eq!(
+                job.data.get("user_id"),
+                Some(&serde_json::json!(expected_user)),
+                "batched jobs must be dequeued by priority"
+            );
+            complete_job_with_conn(&mut conn, &job.id, "default", None)
+                .await
+                .expect("complete job");
+        }
+        assert!(dequeue_with_conn(&mut conn, &queues, &[])
+            .await
+            .expect("dequeue")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn test_can_enqueue_batch_with_queue_and_tags_redis() {
+        let (client, _container) = setup_redis().await;
+        assert!(clear(&client).await.is_ok());
+
+        let ids = enqueue_batch(
+            &client,
+            "BatchJob".to_string(),
+            Some("mailer".to_string()),
+            vec![
+                (serde_json::json!({"user_id": 1}), None),
+                (serde_json::json!({"user_id": 2}), None),
+            ],
+            Some(vec!["email".to_string()]),
+        )
+        .await
+        .expect("tagged batch enqueue");
+        assert_eq!(ids.len(), 2);
+
+        // The batch went to the named queue, not the default one.
+        let mut conn = get_test_connection(&client).await;
+        let mailer_len: i64 = conn
+            .zcard(format!("{QUEUE_KEY_PREFIX}mailer"))
+            .await
+            .expect("get queue length");
+        assert_eq!(mailer_len, 2);
+        let default_len: i64 = conn
+            .zcard(format!("{QUEUE_KEY_PREFIX}default"))
+            .await
+            .expect("get queue length");
+        assert_eq!(default_len, 0);
+
+        // Tags apply to every job: a tagless worker must not see them and a
+        // worker carrying the tag must.
+        let queues = vec!["mailer".to_string()];
+        assert!(
+            dequeue_with_conn(&mut conn, &queues, &[])
+                .await
+                .expect("dequeue")
+                .is_none(),
+            "an untagged worker must not see tagged jobs"
+        );
+        for _ in 0..2 {
+            let (job, _) = dequeue_with_conn(&mut conn, &queues, &["email".to_string()])
+                .await
+                .expect("dequeue")
+                .expect("a tagged batched job must be dequeueable by a matching worker");
+            assert!(ids.contains(&job.id));
+            assert_eq!(job.tags, Some(vec!["email".to_string()]));
+            complete_job_with_conn(&mut conn, &job.id, "mailer", None)
+                .await
+                .expect("complete job");
+        }
     }
 
     #[tokio::test]

--- a/src/bgworker/sqlt.rs
+++ b/src/bgworker/sqlt.rs
@@ -81,6 +81,16 @@ impl QueueProvider for SqliteQueue {
         ))
     }
 
+    async fn enqueue_batch(
+        &self,
+        class: String,
+        _queue: Option<String>,
+        jobs: Vec<(serde_json::Value, Option<i32>)>,
+        tags: Option<Vec<String>>,
+    ) -> Result<Vec<JobId>> {
+        enqueue_batch(&self.pool, &class, jobs, tags).await
+    }
+
     async fn register_handler(&self, name: String, handler: JobHandler) -> Result<()> {
         let mut registry = self.registry.lock().await;
         registry.insert_handler(name, handler)
@@ -275,6 +285,75 @@ pub async fn enqueue(
     .execute(pool)
     .await?;
     Ok(id)
+}
+
+/// Maximum number of jobs per INSERT statement. Each row binds 7 parameters,
+/// kept conservatively under `SQLITE_MAX_VARIABLE_NUMBER` (defaults to 32766 on
+/// `SQLite` >= 3.32, which `sqlx` bundles). Larger batches are split across
+/// multiple statements that all run inside one transaction, so the whole batch
+/// is still enqueued atomically regardless of how many chunks it spans.
+const ENQUEUE_BATCH_CHUNK_SIZE: usize = 1_000;
+
+/// Enqueue multiple jobs in a single atomic batch.
+///
+/// Each entry of `jobs` is one job's data paired with its priority (`None`
+/// for the default); `tags` apply to every job. The returned IDs are in the
+/// same order as `jobs`.
+///
+/// Every job is inserted inside one transaction: either all of them are
+/// enqueued or none are. A failure mid-batch rolls back, so the batch leaves
+/// nothing behind and is safe to retry without duplicating jobs.
+///
+/// # Errors
+///
+/// This function will return an error if it fails
+pub async fn enqueue_batch(
+    pool: &SqlitePool,
+    name: &str,
+    jobs: Vec<(JobData, Option<i32>)>,
+    tags: Option<Vec<String>>,
+) -> Result<Vec<JobId>> {
+    if jobs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Store `run_at` in SQLite's canonical `YYYY-MM-DD HH:MM:SS` text format so
+    // it compares correctly against `CURRENT_TIMESTAMP` in `dequeue` — the same
+    // normalization the single-job `enqueue` gets from its `DATETIME($4)` wrap.
+    // Binding a `DateTime<Utc>` directly would store RFC3339 (`...T...+00:00`),
+    // which sorts after `CURRENT_TIMESTAMP` and would hide the job until the
+    // next day.
+    let run_at = Utc::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let tags_json = match &tags {
+        Some(tags) => Some(serde_json::to_value(tags)?),
+        None => None,
+    };
+    let mut ids = Vec::with_capacity(jobs.len());
+
+    debug!(count = jobs.len(), job_name = %name, run_at = %run_at, tags = ?tags, "Batch enqueueing jobs");
+    let mut tx = pool.begin().await?;
+    for chunk in jobs.chunks(ENQUEUE_BATCH_CHUNK_SIZE) {
+        let mut query_builder = sqlx::query_builder::QueryBuilder::<sqlx::Sqlite>::new(
+            "INSERT INTO sqlt_loco_queue (id, task_data, name, run_at, interval, tags, priority) ",
+        );
+
+        query_builder.push_values(chunk.iter(), |mut b, (data, priority)| {
+            let id = Ulid::new().to_string();
+            b.push_bind(id.clone())
+                .push_bind(data.clone())
+                .push_bind(name.to_string())
+                .push_bind(run_at.clone())
+                .push_bind(None::<i64>)
+                .push_bind(tags_json.clone())
+                .push_bind(priority.unwrap_or(0));
+            ids.push(id);
+        });
+
+        query_builder.build().execute(&mut *tx).await?;
+    }
+    tx.commit().await?;
+
+    Ok(ids)
 }
 
 async fn dequeue(client: &SqlitePool, worker_tags: &[String]) -> Result<Option<Job>> {
@@ -777,6 +856,104 @@ mod tests {
         }, {
             assert_debug_snapshot!(jobs);
         });
+    }
+
+    #[tokio::test]
+    async fn can_enqueue_batch() {
+        let tree_fs = tree_fs::TreeBuilder::default()
+            .drop(true)
+            .create()
+            .expect("create temp folder");
+        let pool = init(&tree_fs.root).await;
+
+        assert!(initialize_database(&pool).await.is_ok());
+        assert_eq!(get_all_jobs(&pool).await.len(), 0);
+
+        // Mixed per-job priorities: the default (None → 0), a high and a low
+        // value. Dequeue order must follow priority, not insertion order.
+        let jobs = vec![
+            (serde_json::json!({"user_id": 1}), None),
+            (serde_json::json!({"user_id": 2}), Some(10)),
+            (serde_json::json!({"user_id": 3}), Some(-5)),
+        ];
+        let ids = enqueue_batch(&pool, "BatchJob", jobs, None)
+            .await
+            .expect("batch enqueue");
+        assert_eq!(ids.len(), 3);
+        assert_eq!(get_all_jobs(&pool).await.len(), 3);
+
+        // Returned ids are in input order and carry each job's own priority.
+        assert_eq!(get_job(&pool, &ids[0]).await.priority, 0);
+        assert_eq!(get_job(&pool, &ids[1]).await.priority, 10);
+        assert_eq!(get_job(&pool, &ids[2]).await.priority, -5);
+
+        // Regression guard: run_at must be stored in SQLite's canonical
+        // `YYYY-MM-DD HH:MM:SS` format. If it were bound as a raw RFC3339
+        // `DateTime<Utc>` (with a `T` separator) the `run_at <= CURRENT_TIMESTAMP`
+        // predicate in `dequeue` would never match and this would return None.
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        for expected_user in [2, 1, 3] {
+            let job = dequeue(&pool, &[])
+                .await
+                .expect("dequeue ok")
+                .expect("a batched job must be dequeueable (run_at format regression)");
+            assert_eq!(
+                job.data.get("user_id"),
+                Some(&serde_json::json!(expected_user)),
+                "batched jobs must be dequeued by priority"
+            );
+        }
+
+        // Tagged batches bind tags_json for every row; a worker carrying the
+        // tag must see them (a tagless worker deliberately does not).
+        let tagged = enqueue_batch(
+            &pool,
+            "BatchJob",
+            vec![(serde_json::json!({"user_id": 4}), None)],
+            Some(vec!["email".to_string()]),
+        )
+        .await
+        .expect("tagged batch enqueue");
+        assert_eq!(tagged.len(), 1);
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        let dequeued = dequeue(&pool, &["email".to_string()])
+            .await
+            .expect("dequeue ok");
+        assert!(
+            dequeued.is_some(),
+            "a tagged batched job must be dequeueable by a matching worker"
+        );
+    }
+
+    #[tokio::test]
+    async fn can_enqueue_batch_across_chunks() {
+        let tree_fs = tree_fs::TreeBuilder::default()
+            .drop(true)
+            .create()
+            .expect("create temp folder");
+        let pool = init(&tree_fs.root).await;
+
+        assert!(initialize_database(&pool).await.is_ok());
+        assert_eq!(get_all_jobs(&pool).await.len(), 0);
+
+        // Span more than two chunks so the multi-statement path runs inside one
+        // transaction. All rows must commit together (atomic batch) and every
+        // generated id must be unique.
+        let count = ENQUEUE_BATCH_CHUNK_SIZE * 2 + 1;
+        let jobs = (0..count)
+            .map(|i| (serde_json::json!({ "user_id": i }), None))
+            .collect::<Vec<_>>();
+
+        let ids = enqueue_batch(&pool, "BatchJob", jobs, None)
+            .await
+            .expect("batch enqueue");
+        assert_eq!(ids.len(), count);
+        assert_eq!(
+            ids.iter().collect::<std::collections::HashSet<_>>().len(),
+            count,
+            "every batched job id must be unique"
+        );
+        assert_eq!(get_all_jobs(&pool).await.len(), count);
     }
 
     #[tokio::test]

--- a/website/src/content/docs/docs/explanation/background-processing-model.md
+++ b/website/src/content/docs/docs/explanation/background-processing-model.md
@@ -14,13 +14,16 @@ Loco lets you write one `BackgroundWorker` implementation and one `perform_later
 pub trait BackgroundWorker<A> {
     fn build(ctx: &AppContext) -> Self;
     async fn perform(&self, args: A) -> Result<()>;
-    // + queue(), tags(), class_name(), perform_later(), perform_later_with_priority()
+    // + queue(), tags(), class_name(), perform_later(), perform_later_with_priority(),
+    //   perform_all_later(), perform_all_later_with_priority()
 }
 ```
 
 You implement `perform`, register the worker in `connect_workers`, and enqueue work with `MyWorker::perform_later(&ctx, args).await?`. Nothing in that call references which backend is active — that's decided entirely by `queue.kind` in config (`Redis` | `Postgres` | `Sqlite`), read at boot by `create_queue_provider`. This is the same "config over code" bias covered in [Why batteries included](/docs/explanation/why-batteries-included), applied to durability and delivery semantics: swapping backends is an operational decision (what's already running in your infrastructure, what latency/throughput profile you need), not a rewrite.
 
 `perform_later` (and its sibling `perform_later_with_priority`) returns `Result<String>` — the job's id — rather than `Result<()>`. That return value matters because it's what you'd hand to `cargo loco jobs cancel`/`requeue` or log for later correlation; treat any `perform_later` call site that discards its return value as intentionally choosing not to track the job, not as the only option.
+
+The batch pair, `perform_all_later` and `perform_all_later_with_priority`, follows the same contract for many jobs at once: one `Vec` of ids back, in input order, and one round trip to the queue instead of one per job. Each built-in provider implements `QueueProvider::enqueue_batch` atomically — a single transaction on Postgres/SQLite, a `MULTI`/`EXEC` pipeline on Redis — so a batch either fully enqueues or leaves nothing behind. The trait has a default `enqueue_batch` that loops over `enqueue`, so a third-party provider keeps compiling and gets the batch semantics without the atomicity until it overrides the method. This mirrors Rails' `ActiveJob.perform_all_later`, which falls back to individual enqueues on adapters without bulk support.
 
 ## The two SQL backends share one implementation
 

--- a/website/src/content/docs/docs/how-to/add-worker.md
+++ b/website/src/content/docs/docs/how-to/add-worker.md
@@ -129,6 +129,34 @@ If you need higher/lower priority for this particular job, use `perform_later_wi
 DownloadWorker::perform_later_with_priority(&ctx, args, Some(50)).await?;
 ```
 
+### Enqueue many jobs at once
+
+When one action fans out into many jobs — a notification to every member of a team, an import that spawns one job per row — use `perform_all_later` instead of calling `perform_later` in a loop. It takes a `Vec` of arguments and enqueues the whole batch in one round trip to the queue, the way Rails' `ActiveJob.perform_all_later` does:
+
+```rust
+let args_list: Vec<DownloadWorkerArgs> = team
+    .members
+    .iter()
+    .map(|member| DownloadWorkerArgs { user_guid: member.guid.clone() })
+    .collect();
+
+let job_ids: Vec<String> = DownloadWorker::perform_all_later(&ctx, args_list).await?;
+```
+
+It returns one job id per argument, in the same order. The batch is atomic on all three built-in backends: either every job is enqueued or none are, so a failed call is safe to retry without duplicating jobs. An empty `Vec` is a no-op.
+
+To give each job its own priority, pair every argument with an `Option<i32>` and call `perform_all_later_with_priority` (`None` means the default priority):
+
+```rust
+DownloadWorker::perform_all_later_with_priority(
+    &ctx,
+    vec![(urgent_args, Some(100)), (normal_args, None)],
+)
+.await?;
+```
+
+The worker's `queue()` and `tags()` apply to every job in the batch, exactly as they do for `perform_later`. In `ForegroundBlocking` mode the jobs run one after another in input order and the first error returns early; in `BackgroundAsync` mode one task is spawned per job. Priority has no effect in those two modes.
+
 ## 5. Run the worker process
 
 How you run workers depends on `workers.mode` (see [Choose a queue backend](/docs/how-to/choose-queue-backend)):

--- a/website/src/content/docs/docs/how-to/add-worker.md
+++ b/website/src/content/docs/docs/how-to/add-worker.md
@@ -115,11 +115,13 @@ DownloadWorker::perform_later(
 .await?;
 ```
 
-`perform_later` returns `Result<String>` — the job id, not `Result<()>`. In `BackgroundQueue` mode the id is assigned by the queue provider; in `ForegroundBlocking`/`BackgroundAsync` mode (or when no provider is configured) Loco generates a fresh UUID so you always get a stable handle back:
+`perform_later` returns `Result<String>` — the job id, not `Result<()>`. In `BackgroundQueue` mode the id is assigned by the queue provider; in `ForegroundBlocking`/`BackgroundAsync` mode Loco generates a fresh UUID so you always get a stable handle back:
 
 ```rust
 let job_id: String = DownloadWorker::perform_later(&ctx, args).await?;
 ```
+
+If `workers.mode` is `BackgroundQueue` but no queue provider is available, `perform_later` returns `Error::QueueProviderMissing` and the job is not run. A `BackgroundQueue` config without a `queue:` section fails at boot, so you normally see this at startup rather than at the call site.
 
 If you need higher/lower priority for this particular job, use `perform_later_with_priority` instead — see [Choose a queue backend](/docs/how-to/choose-queue-backend#priority-queues) for priority semantics shared across all three backends:
 

--- a/website/src/content/docs/docs/how-to/choose-queue-backend.md
+++ b/website/src/content/docs/docs/how-to/choose-queue-backend.md
@@ -101,6 +101,8 @@ All three backends support per-job priority: higher `priority` (a full `i32`) is
 DownloadWorker::perform_later_with_priority(&ctx, args, Some(100)).await?;
 ```
 
+To enqueue many jobs in one round trip, use `perform_all_later` (all at the default priority) or `perform_all_later_with_priority` (each job paired with its own `Option<i32>`). All three backends enqueue the batch atomically — one transaction on Postgres/SQLite, one `MULTI`/`EXEC` block on Redis — so either every job is enqueued or none are. See [Add a background worker](/docs/how-to/add-worker#enqueue-many-jobs-at-once).
+
 Redis additionally supports **named** queues via `queue.queues` — `Worker::queue()` picks which named queue a job lands in, and the config list order sets each queue's priority (first = most important). The default named queues are `["default", "mailer"]`.
 
 ## Managing jobs from the CLI


### PR DESCRIPTION
Adds `perform_all_later` and `perform_all_later_with_priority` functions to batch queue jobs, modeled after Rails's [ActiveJob::perform_all_later](https://guides.rubyonrails.org/active_job_basics.html#bulk-enqueuing). A batch is inserted in a single atomic transaction and therefore can be retried on failure without duplication and returns the `JobID`s of all jobs submitted.

Fixes #1803 