### PR TITLE
ci: pin the toolchain, and stop style from hiding test results

### DIFF
--- a/.github/workflows/lint-future.yml
+++ b/.github/workflows/lint-future.yml
@@ -1,0 +1,59 @@
+name: "[lint:future]"
+
+# The pinned toolchain in `loco-rs-ci.yml` keeps new clippy lints from landing
+# on contributors' pull requests. The cost of pinning is that we stop hearing
+# about them at all — until a bump, when they all arrive at once.
+#
+# This job is the other half: it runs the same lints the `style` job runs, on
+# floating stable and on beta, so we find out what the next toolchain thinks
+# on our own schedule. It is deliberately NOT part of the PR pipeline.
+#
+# It is allowed to fail, and a failure here is not an emergency: it means the
+# next toolchain has an opinion we have not addressed yet. Fix it, then raise
+# `RUST_TOOLCHAIN`. There is no `continue-on-error` here on purpose — this run
+# should go visibly red in the Actions tab, because a check nobody can see
+# failing is a check that verifies nothing.
+
+on:
+  schedule:
+    # Mondays, 06:00 UTC. Rust releases on a Thursday, so this reports on the
+    # new stable within four days of it landing.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  lint-future:
+    # Forks inherit the schedule but not the reason to run it.
+    if: github.repository == 'loco-rs/loco'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    strategy:
+      # Both toolchains report; stable failing should not hide what beta says.
+      fail-fast: false
+      matrix:
+        toolchain: [stable, beta]
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: clippy, rustfmt
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Report the toolchain under test
+        run: cargo clippy --version
+
+      # Kept character-for-character in step with the `style` job in
+      # `loco-rs-ci.yml`. If you change the lint set there, change it here, or
+      # this stops predicting anything.
+      - name: Run cargo clippy
+        run: cargo clippy --workspace --all-features -- -D warnings -W clippy::pedantic -W clippy::nursery -W rust-2018-idioms
+
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check

--- a/.github/workflows/loco-rs-ci.yml
+++ b/.github/workflows/loco-rs-ci.yml
@@ -35,7 +35,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: rustfmt
+          # `clippy` has to be named now that the toolchain is pinned. On
+          # `stable` this step reused the runner's preinstalled toolchain, which
+          # ships clippy; a pinned version installs fresh under the minimal
+          # profile and gets only what is listed here.
+          components: rustfmt, clippy
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo fmt

--- a/.github/workflows/loco-rs-ci.yml
+++ b/.github/workflows/loco-rs-ci.yml
@@ -7,7 +7,19 @@ on:
   pull_request:
 
 env:
-  RUST_TOOLCHAIN: stable
+  # Pinned, not `stable`. The clippy invocation in `style` promotes
+  # `clippy::pedantic` and `clippy::nursery` to hard errors, and those lint sets
+  # are explicitly unstable — upstream adds to them every six weeks. On a
+  # floating toolchain that combination turns master red on a calendar, with
+  # nobody having committed anything: 1.98 extended `unused_async` to trait
+  # impls and six errors appeared across `cli.rs`, the extractors and the format
+  # middleware, landing as a red X on two contributors' unrelated PRs.
+  #
+  # So the toolchain moves when we move it. `lint-future.yml` runs the same
+  # lints on floating stable and beta on a schedule, so a bump is a thing we
+  # do deliberately with the breakage already known, not a thing that happens
+  # to us mid-review.
+  RUST_TOOLCHAIN: "1.98"
   TOOLCHAIN_PROFILE: minimal
 
 jobs:
@@ -43,8 +55,15 @@ jobs:
             -D rustdoc::invalid_html_tags
             -D rustdoc::bare_urls
 
+  # Nothing below depends on `style`. A lint or formatting complaint must never
+  # hide test results from a contributor: when `style` gated these jobs, a
+  # clippy error in a file the PR never touched reported `build`, `test`,
+  # `test-examples` and `msrv` as SKIPPED, so the author saw a red X and no
+  # signal at all about whether their own code worked. `check` is still a gate
+  # for the heavy jobs — it is the cheapest way to find out the code does not
+  # compile under some feature combination — but style is a peer now, not a
+  # gatekeeper.
   check:
-    needs: [style]
     runs-on: ubuntu-latest
 
     permissions:
@@ -64,7 +83,7 @@ jobs:
       - run: cargo hack check --each-feature
 
   build:
-    needs: [check, style]
+    needs: [check]
     runs-on: ubuntu-latest
 
     permissions:
@@ -82,7 +101,7 @@ jobs:
       - name: Run cargo build
         run: cargo build --release
   test:
-    needs: [check, style]
+    needs: [check]
     runs-on: ubuntu-latest
 
     permissions:
@@ -107,7 +126,7 @@ jobs:
   # check --each-feature` above passes no `--tests`, and the job above enables
   # the feature that hides it. This runs everything except that one feature.
   test-without-embedded-assets:
-    needs: [check, style]
+    needs: [check]
     runs-on: ubuntu-latest
 
     permissions:
@@ -135,7 +154,6 @@ jobs:
   # PR fails. That is the intended behaviour — the alternative is finding out
   # from a user.
   supply-chain:
-    needs: [style]
     runs-on: ubuntu-latest
 
     permissions:
@@ -163,7 +181,7 @@ jobs:
   # `must_exist: true` over `frontend/dist`, so it must be built before the app
   # will boot — exactly what the CI a generated clientside app ships does.
   test-examples:
-    needs: [check, style]
+    needs: [check]
     runs-on: ubuntu-latest
 
     permissions:
@@ -216,7 +234,7 @@ jobs:
   # `loco-new` is its own workspace, so it needs its own invocation — the root
   # `--workspace` does not reach it.
   msrv:
-    needs: [check, style]
+    needs: [check]
     runs-on: ubuntu-latest
 
     permissions:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -798,7 +798,7 @@ pub async fn main<H: Hooks, M: MigratorTrait>() -> crate::Result<()> {
             let boot_result =
                 create_app::<H, M>(start_mode, &environment, app_context.config).await?;
             let serve_params = ServeParams {
-                port: port.map_or(boot_result.app_context.config.server.port, |p| p),
+                port: port.unwrap_or(boot_result.app_context.config.server.port),
                 binding: binding
                     .unwrap_or_else(|| boot_result.app_context.config.server.binding.clone()),
             };
@@ -974,7 +974,7 @@ pub async fn main<H: Hooks>() -> crate::Result<()> {
 
             let boot_result = create_app::<H>(start_mode, &environment, app_context.config).await?;
             let serve_params = ServeParams {
-                port: port.map_or(boot_result.app_context.config.server.port, |p| p),
+                port: port.unwrap_or(boot_result.app_context.config.server.port),
                 binding: binding
                     .unwrap_or_else(|| boot_result.app_context.config.server.binding.clone()),
             };

--- a/src/controller/extractor/auth.rs
+++ b/src/controller/extractor/auth.rs
@@ -110,6 +110,11 @@ where
 {
     type Rejection = Error;
 
+    // Extraction is pure header/state inspection, so there is nothing to await.
+    // `async fn` stays because the shape is axum's, not ours: dropping it means
+    // spelling the desugared `impl Future` by hand at every extractor in the
+    // framework, which is noisier and no faster at the scale of one header read.
+    #[allow(clippy::unused_async_trait_impl)]
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Error> {
         extract_jwt_from_request_parts(parts, state)
     }
@@ -126,6 +131,8 @@ where
 {
     type Rejection = std::convert::Infallible;
 
+    // See the note on the `FromRequestParts` impl above.
+    #[allow(clippy::unused_async_trait_impl)]
     async fn from_request_parts(
         parts: &mut Parts,
         state: &S,

--- a/src/controller/extractor/shared_store.rs
+++ b/src/controller/extractor/shared_store.rs
@@ -11,6 +11,9 @@ where
 {
     type Rejection = Error;
 
+    // A `DiContainer` lookup, no I/O — see `extractor/auth.rs` for why the
+    // `async fn` shape stays anyway.
+    #[allow(clippy::unused_async_trait_impl)]
     async fn from_request_parts(
         _: &mut Parts,
         state: &AppContext,

--- a/src/controller/middleware/format.rs
+++ b/src/controller/middleware/format.rs
@@ -54,6 +54,9 @@ where
 {
     type Rejection = Error;
 
+    // Header inspection only — see `extractor/auth.rs` for why the `async fn`
+    // shape stays anyway.
+    #[allow(clippy::unused_async_trait_impl)]
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Error> {
         Ok(Self(get_respond_to(&parts.headers)))
     }
@@ -65,6 +68,8 @@ where
 {
     type Rejection = Error;
 
+    // As above.
+    #[allow(clippy::unused_async_trait_impl)]
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Error> {
         Ok(get_respond_to(&parts.headers))
     }


### PR DESCRIPTION
Two open PRs (#1821, #1822) carry a red X for six clippy errors in files neither of them touches:

```
error: expression can be simplified using `Option::unwrap_or()`      src/cli.rs
error: unused `async` for async trait impl function ...  (x5)        extractors, format middleware
```

Nobody broke this. `RUST_TOOLCHAIN` was `stable`, and `style` promotes `clippy::pedantic` and `clippy::nursery` to hard errors. Those lint sets are unstable by design; 1.98 added `map_or_identity` and extended `unused_async` to trait impls, so master went red on a calendar. The same invocation on 1.97.1 is clean, which is why no local gate predicted it.

## What this changes

**Pins `RUST_TOOLCHAIN` to 1.98.** The toolchain now moves when we move it.

**Adds `lint-future.yml`.** Same lint set, floating `stable` and `beta`, Mondays. We hear about new lints on our schedule instead of on a contributor's PR. It fails loudly rather than `continue-on-error`, because a check nobody sees fail verifies nothing.

**Drops `style` from every `needs:` clause.** This is the part that mattered most. `style` gated seven jobs, so a clippy error in an unrelated file reported `build`, `test`, `test-examples` and `msrv` as SKIPPED — a red X and no signal about the contributor's own code. `check` still gates the heavy jobs.

## On the lints

`map_or(default, |p| p)` is `unwrap_or`, fixed in both feature branches of `cli.rs` (`--all-features` only ever compiled one of them).

The five extractors have nothing to await, but the `async fn` shape is axum's, not ours. They carry a scoped allow with a reason rather than five hand-desugared `impl Future` signatures.

## Verification

`cargo +1.98.0 clippy --workspace --all-features` with this job's exact flags is clean on this branch, `cargo fmt --all -- --check` is clean, and the extractor/middleware tests pass.