### PR TITLE
feat(storage): add presign_get/presign_put to StoreDriver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+- **`StoreDriver::presign_put` now takes `PresignPutOptions`** so callers can
+  set `Content-Type` on signed uploads. Pass `PresignPutOptions::default()`
+  for the previous behavior.
+- **`StorageStrategy` gains required `presign_get` and `presign_put`
+  methods.** Custom strategy implementations must implement them. Built-in
+  strategies already do.
+
+### Added
+
+- **`Storage` facade exposes `presign_get` / `presign_put`** (and
+  `*_with_policy` siblings), routing through the selected strategy.
+- **`PresignedRequest::url()`** helper and **`PresignPutOptions`** for signed
+  upload metadata.
+- **S3 presign integration test** (`presign_s3_roundtrip_get_and_put`) gated
+  on `LOCO_TEST_S3_*` env vars and the `storage_aws_s3` feature.
+
 ## 1.1.0 - 2026-08-15
 
 Moves the template engine to Tera 2, makes configuration files valid YAML,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,7 @@ opendal = { version = "0.58.1", default-features = false, features = [
     "services-fs",
     "layers-retry",
 ] }
+http = "1"
 
 # cache
 moka = { version = "0.12.7", features = ["future"], optional = true }

--- a/src/storage/drivers/aws_presign_tests.rs
+++ b/src/storage/drivers/aws_presign_tests.rs
@@ -1,0 +1,93 @@
+//! S3 presign round-trip against a real endpoint (MinIO, LocalStack, AWS).
+//!
+//! ```sh
+//! LOCO_TEST_S3_ENDPOINT=http://127.0.0.1:9000 \
+//! LOCO_TEST_S3_BUCKET=loco-presign-test \
+//! LOCO_TEST_S3_ACCESS_KEY_ID=minio \
+//! LOCO_TEST_S3_SECRET_ACCESS_KEY=minio123 \
+//! cargo test -p loco-rs presign_s3_roundtrip --features storage_aws_s3
+//! ```
+
+use std::{path::Path, time::Duration};
+
+use bytes::Bytes;
+use opendal::{services::S3, Operator};
+
+use super::opendal_adapter::OpendalAdapter;
+use super::{PresignPutOptions, StoreDriver};
+
+fn test_s3_store() -> Option<OpendalAdapter> {
+    let endpoint = std::env::var("LOCO_TEST_S3_ENDPOINT").ok()?;
+    let bucket = std::env::var("LOCO_TEST_S3_BUCKET").ok()?;
+    let key_id = std::env::var("LOCO_TEST_S3_ACCESS_KEY_ID").ok()?;
+    let secret_key = std::env::var("LOCO_TEST_S3_SECRET_ACCESS_KEY").ok()?;
+
+    let builder = S3::default()
+        .bucket(&bucket)
+        .endpoint(&endpoint)
+        .region("us-east-1")
+        .access_key_id(&key_id)
+        .secret_access_key(&secret_key);
+
+    let operator = Operator::new(builder).ok()?;
+    Some(OpendalAdapter::new(operator))
+}
+
+#[tokio::test]
+async fn presign_s3_roundtrip_get_and_put() {
+    let Some(store) = test_s3_store() else {
+        return;
+    };
+    let path = Path::new("loco-presign-probe.txt");
+    let body = Bytes::from("loco presign probe");
+    let ttl = Duration::from_secs(300);
+
+    store
+        .upload(path, &body)
+        .await
+        .expect("upload probe object");
+
+    let get = store.presign_get(path, ttl).await.expect("presign get");
+    assert_eq!(get.method, http::Method::GET);
+    let fetched = reqwest::Client::new()
+        .get(get.url())
+        .send()
+        .await
+        .expect("fetch presigned get")
+        .text()
+        .await
+        .expect("read presigned get body");
+    assert_eq!(fetched, "loco presign probe");
+
+    let put_path = Path::new("loco-presign-put-probe.txt");
+    let put = store
+        .presign_put(
+            put_path,
+            ttl,
+            PresignPutOptions {
+                content_type: Some("text/plain".to_string()),
+            },
+        )
+        .await
+        .expect("presign put");
+    assert_eq!(put.method, http::Method::PUT);
+    let client = reqwest::Client::new();
+    let mut put_req = client.request(put.method.clone(), put.url());
+    for (name, value) in put.headers.iter() {
+        put_req = put_req.header(name, value);
+    }
+    put_req
+        .body("uploaded via presign")
+        .send()
+        .await
+        .expect("presigned put")
+        .error_for_status()
+        .expect("presigned put status");
+
+    let roundtrip = store.get(put_path).await.expect("get after presign put");
+    let bytes = roundtrip.bytes().await.expect("read put object");
+    assert_eq!(bytes, Bytes::from("uploaded via presign"));
+
+    let _ = store.delete(path).await;
+    let _ = store.delete(put_path).await;
+}

--- a/src/storage/drivers/mod.rs
+++ b/src/storage/drivers/mod.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{path::Path, time::Duration};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -15,7 +15,7 @@ pub mod mem;
 pub mod null;
 pub mod opendal_adapter;
 
-use super::{stream::BytesStream, StorageResult};
+use super::{stream::BytesStream, StorageError, StorageResult};
 
 #[derive(Debug)]
 pub struct UploadResponse {
@@ -32,6 +32,33 @@ impl UploadResponse {
     #[must_use]
     pub fn new(e_tag: Option<String>, version: Option<String>) -> Self {
         Self { e_tag, version }
+    }
+}
+
+/// A presigned HTTP request returned by [`StoreDriver::presign_get`] or
+/// [`StoreDriver::presign_put`].
+#[derive(Debug, Clone)]
+pub struct PresignedRequest {
+    /// The HTTP method to use (e.g. `GET`, `PUT`).
+    pub method: http::Method,
+    /// The URI the client should send the request to.
+    pub uri: http::Uri,
+    /// Headers that must be included on the request.
+    pub headers: http::HeaderMap,
+}
+
+impl PresignedRequest {
+    /// Builds a `PresignedRequest`.
+    ///
+    /// Custom [`StoreDriver`] implementations use this to return a presigned
+    /// request without depending on `opendal` types.
+    #[must_use]
+    pub fn new(method: http::Method, uri: http::Uri, headers: http::HeaderMap) -> Self {
+        Self {
+            method,
+            uri,
+            headers,
+        }
     }
 }
 
@@ -208,6 +235,44 @@ pub trait StoreDriver: Sync + Send {
     ///
     /// Returns a `StorageResult` with the entry's metadata.
     async fn stat(&self, path: &Path) -> StorageResult<ListEntry>;
+
+    /// Builds a presigned URL that lets a client `GET` the content at `path`
+    /// directly from the backing store, without proxying through the app.
+    ///
+    /// # Default Implementation
+    ///
+    /// Returns an error. Only backends that support presigning (e.g. S3,
+    /// Azure Blob, GCS) override this.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `StorageResult` if the driver doesn't support presigning or
+    /// the request could not be built.
+    async fn presign_get(&self, path: &Path, expire: Duration) -> StorageResult<PresignedRequest> {
+        let _ = (path, expire);
+        Err(StorageError::Any(
+            "presign_get is not supported by this storage driver".into(),
+        ))
+    }
+
+    /// Builds a presigned URL that lets a client `PUT` content to `path`
+    /// directly on the backing store, without proxying through the app.
+    ///
+    /// # Default Implementation
+    ///
+    /// Returns an error. Only backends that support presigning (e.g. S3,
+    /// Azure Blob, GCS) override this.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `StorageResult` if the driver doesn't support presigning or
+    /// the request could not be built.
+    async fn presign_put(&self, path: &Path, expire: Duration) -> StorageResult<PresignedRequest> {
+        let _ = (path, expire);
+        Err(StorageError::Any(
+            "presign_put is not supported by this storage driver".into(),
+        ))
+    }
 
     /// Retrieves content from the specified path and returns it as a stream.
     /// This method is more memory-efficient than `get()` for large files as it

--- a/src/storage/drivers/mod.rs
+++ b/src/storage/drivers/mod.rs
@@ -15,6 +15,9 @@ pub mod mem;
 pub mod null;
 pub mod opendal_adapter;
 
+#[cfg(all(test, feature = "storage_aws_s3"))]
+mod aws_presign_tests;
+
 use super::{stream::BytesStream, StorageError, StorageResult};
 
 #[derive(Debug)]
@@ -60,6 +63,19 @@ impl PresignedRequest {
             headers,
         }
     }
+
+    /// The presigned URL as a string.
+    #[must_use]
+    pub fn url(&self) -> String {
+        self.uri.to_string()
+    }
+}
+
+/// Optional parameters for [`StoreDriver::presign_put`].
+#[derive(Debug, Clone, Default)]
+pub struct PresignPutOptions {
+    /// `Content-Type` header included in the signed request.
+    pub content_type: Option<String>,
 }
 
 /// A single entry returned by [`StoreDriver::list`] or [`StoreDriver::stat`].
@@ -267,8 +283,13 @@ pub trait StoreDriver: Sync + Send {
     ///
     /// Returns a `StorageResult` if the driver doesn't support presigning or
     /// the request could not be built.
-    async fn presign_put(&self, path: &Path, expire: Duration) -> StorageResult<PresignedRequest> {
-        let _ = (path, expire);
+    async fn presign_put(
+        &self,
+        path: &Path,
+        expire: Duration,
+        options: PresignPutOptions,
+    ) -> StorageResult<PresignedRequest> {
+        let _ = (path, expire, options);
         Err(StorageError::Any(
             "presign_put is not supported by this storage driver".into(),
         ))

--- a/src/storage/drivers/null.rs
+++ b/src/storage/drivers/null.rs
@@ -137,5 +137,13 @@ mod tests {
         assert!(store.list(path, true).await.is_err());
         assert!(store.list(path, false).await.is_err());
         assert!(store.stat(path).await.is_err());
+        assert!(store
+            .presign_get(path, std::time::Duration::from_secs(60))
+            .await
+            .is_err());
+        assert!(store
+            .presign_put(path, std::time::Duration::from_secs(60))
+            .await
+            .is_err());
     }
 }

--- a/src/storage/drivers/null.rs
+++ b/src/storage/drivers/null.rs
@@ -121,6 +121,7 @@ mod tests {
     use std::path::Path;
 
     use super::new;
+    use crate::storage::drivers::PresignPutOptions;
 
     /// The null driver's contract is that *every* operation refuses rather than
     /// pretending to succeed. `list` returning `Ok(vec![])` or `exists`
@@ -142,7 +143,11 @@ mod tests {
             .await
             .is_err());
         assert!(store
-            .presign_put(path, std::time::Duration::from_secs(60))
+            .presign_put(
+                path,
+                std::time::Duration::from_secs(60),
+                PresignPutOptions::default(),
+            )
             .await
             .is_err());
     }

--- a/src/storage/drivers/opendal_adapter.rs
+++ b/src/storage/drivers/opendal_adapter.rs
@@ -1,11 +1,11 @@
-use std::path::Path;
+use std::{path::Path, time::Duration};
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
 use opendal::{layers::RetryLayer, Operator};
 
-use super::{GetResponse, ListEntry, StoreDriver, UploadResponse};
+use super::{GetResponse, ListEntry, PresignedRequest, StoreDriver, UploadResponse};
 use crate::storage::{stream::BytesStream, StorageError, StorageResult};
 
 pub struct OpendalAdapter {
@@ -197,6 +197,42 @@ impl StoreDriver for OpendalAdapter {
             meta.last_modified()
                 .map(|ts| chrono::DateTime::<chrono::Utc>::from(std::time::SystemTime::from(ts))),
             meta.etag().map(std::string::ToString::to_string),
+        ))
+    }
+
+    /// Builds a presigned `GET` URL via `OpenDAL`'s native presigning support.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `StorageResult` if the backend doesn't support presigning or
+    /// the request could not be built.
+    async fn presign_get(&self, path: &Path, expire: Duration) -> StorageResult<PresignedRequest> {
+        let req = self
+            .opendal_impl
+            .presign_read(&path.display().to_string(), expire)
+            .await?;
+        Ok(PresignedRequest::new(
+            req.method().clone(),
+            req.uri().clone(),
+            req.header().clone(),
+        ))
+    }
+
+    /// Builds a presigned `PUT` URL via `OpenDAL`'s native presigning support.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `StorageResult` if the backend doesn't support presigning or
+    /// the request could not be built.
+    async fn presign_put(&self, path: &Path, expire: Duration) -> StorageResult<PresignedRequest> {
+        let req = self
+            .opendal_impl
+            .presign_write(&path.display().to_string(), expire)
+            .await?;
+        Ok(PresignedRequest::new(
+            req.method().clone(),
+            req.uri().clone(),
+            req.header().clone(),
         ))
     }
 

--- a/src/storage/drivers/opendal_adapter.rs
+++ b/src/storage/drivers/opendal_adapter.rs
@@ -5,7 +5,9 @@ use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
 use opendal::{layers::RetryLayer, Operator};
 
-use super::{GetResponse, ListEntry, PresignedRequest, StoreDriver, UploadResponse};
+use super::{
+    GetResponse, ListEntry, PresignPutOptions, PresignedRequest, StoreDriver, UploadResponse,
+};
 use crate::storage::{stream::BytesStream, StorageError, StorageResult};
 
 pub struct OpendalAdapter {
@@ -224,11 +226,22 @@ impl StoreDriver for OpendalAdapter {
     ///
     /// Returns a `StorageResult` if the backend doesn't support presigning or
     /// the request could not be built.
-    async fn presign_put(&self, path: &Path, expire: Duration) -> StorageResult<PresignedRequest> {
-        let req = self
-            .opendal_impl
-            .presign_write(&path.display().to_string(), expire)
-            .await?;
+    async fn presign_put(
+        &self,
+        path: &Path,
+        expire: Duration,
+        options: PresignPutOptions,
+    ) -> StorageResult<PresignedRequest> {
+        let path = path.display().to_string();
+        let req = match options.content_type.as_deref() {
+            Some(content_type) => {
+                self.opendal_impl
+                    .presign_write_with(&path, expire)
+                    .content_type(content_type)
+                    .await?
+            }
+            None => self.opendal_impl.presign_write(&path, expire).await?,
+        };
         Ok(PresignedRequest::new(
             req.method().clone(),
             req.uri().clone(),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3,7 +3,7 @@
 //! This module defines a generic storage abstraction represented by the
 //! [`Storage`] struct. It provides methods for performing common storage
 //! operations such as upload, download, delete, rename, copy, exists, list,
-//! and stat.
+//! stat, and presigning.
 //!
 //! ## Storage Strategy
 //!
@@ -18,12 +18,13 @@ pub mod stream;
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use bytes::Bytes;
 
 use self::{
-    drivers::{ListEntry, StoreDriver},
+    drivers::{ListEntry, PresignPutOptions, PresignedRequest, StoreDriver},
     stream::BytesStream,
 };
 
@@ -465,6 +466,68 @@ impl Storage {
         strategy: &dyn strategies::StorageStrategy,
     ) -> StorageResult<ListEntry> {
         strategy.stat(self, path).await
+    }
+
+    /// Builds a presigned `GET` URL for `path` using the selected strategy.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the driver does not support presigning or the
+    /// request could not be built.
+    pub async fn presign_get(
+        &self,
+        path: &Path,
+        expire: Duration,
+    ) -> StorageResult<PresignedRequest> {
+        self.presign_get_with_policy(path, expire, &*self.strategy)
+            .await
+    }
+
+    /// Builds a presigned `GET` URL using a specific strategy.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the driver does not support presigning or the
+    /// request could not be built.
+    pub async fn presign_get_with_policy(
+        &self,
+        path: &Path,
+        expire: Duration,
+        strategy: &dyn strategies::StorageStrategy,
+    ) -> StorageResult<PresignedRequest> {
+        strategy.presign_get(self, path, expire).await
+    }
+
+    /// Builds a presigned `PUT` URL for `path` using the selected strategy.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the driver does not support presigning or the
+    /// request could not be built.
+    pub async fn presign_put(
+        &self,
+        path: &Path,
+        expire: Duration,
+        options: PresignPutOptions,
+    ) -> StorageResult<PresignedRequest> {
+        self.presign_put_with_policy(path, expire, options, &*self.strategy)
+            .await
+    }
+
+    /// Builds a presigned `PUT` URL using a specific strategy.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the driver does not support presigning or the
+    /// request could not be built.
+    pub async fn presign_put_with_policy(
+        &self,
+        path: &Path,
+        expire: Duration,
+        options: PresignPutOptions,
+        strategy: &dyn strategies::StorageStrategy,
+    ) -> StorageResult<PresignedRequest> {
+        strategy.presign_put(self, path, expire, options).await
     }
 
     /// Returns a reference to the store with the specified name if exists.

--- a/src/storage/strategies/mod.rs
+++ b/src/storage/strategies/mod.rs
@@ -1,11 +1,15 @@
 pub mod replicated;
 pub mod single;
 
-use std::path::Path;
+use std::{path::Path, time::Duration};
 
 use bytes::Bytes;
 
-use crate::storage::{drivers::ListEntry, stream::BytesStream, Storage, StorageResult};
+use crate::storage::{
+    drivers::{ListEntry, PresignPutOptions, PresignedRequest},
+    stream::BytesStream,
+    Storage, StorageResult,
+};
 
 #[async_trait::async_trait]
 pub trait StorageStrategy: Sync + Send {
@@ -22,6 +26,19 @@ pub trait StorageStrategy: Sync + Send {
         recursive: bool,
     ) -> StorageResult<Vec<ListEntry>>;
     async fn stat(&self, storage: &Storage, path: &Path) -> StorageResult<ListEntry>;
+    async fn presign_get(
+        &self,
+        storage: &Storage,
+        path: &Path,
+        expire: Duration,
+    ) -> StorageResult<PresignedRequest>;
+    async fn presign_put(
+        &self,
+        storage: &Storage,
+        path: &Path,
+        expire: Duration,
+        options: PresignPutOptions,
+    ) -> StorageResult<PresignedRequest>;
 
     /// Download content as a stream for memory-efficient large file handling.
     ///

--- a/src/storage/strategies/replicated.rs
+++ b/src/storage/strategies/replicated.rs
@@ -24,12 +24,14 @@
 //!   secondary fallback under mirror mode. Empty secondary listings are
 //!   skipped (same as `exists` skipping `false`) so a later secondary with
 //!   data remains discoverable.
+//! * `presign_get`/`presign_put`: primary only. Presigned URLs are tied to one
+//!   backend's credentials and are never served from secondaries.
 use std::{collections::BTreeMap, path::Path};
 
 use bytes::Bytes;
 
 use crate::storage::{
-    drivers::{ListEntry, StoreDriver},
+    drivers::{ListEntry, PresignPutOptions, PresignedRequest, StoreDriver},
     strategies::StorageStrategy,
     Storage, StorageError, StorageResult,
 };
@@ -365,6 +367,31 @@ impl StorageStrategy for ReplicatedStrategy {
                 Err(error)
             }
         }
+    }
+
+    async fn presign_get(
+        &self,
+        storage: &Storage,
+        path: &Path,
+        expire: std::time::Duration,
+    ) -> StorageResult<PresignedRequest> {
+        storage
+            .as_store_err(&self.primary)?
+            .presign_get(path, expire)
+            .await
+    }
+
+    async fn presign_put(
+        &self,
+        storage: &Storage,
+        path: &Path,
+        expire: std::time::Duration,
+        options: PresignPutOptions,
+    ) -> StorageResult<PresignedRequest> {
+        storage
+            .as_store_err(&self.primary)?
+            .presign_put(path, expire, options)
+            .await
     }
 }
 
@@ -921,5 +948,19 @@ mod tests {
         );
         put(&storage, "store_2", path.as_path()).await;
         assert!(storage.exists(path.as_path()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn presign_mirror_does_not_fall_back_to_secondary() {
+        let path = orig();
+        let storage = storage_for(
+            ReplicatedStrategy::mirror("store_1", Some(vec!["store_2".to_string()]), FailIfAny),
+            named(&["store_1", "store_2"]),
+        );
+        put(&storage, "store_2", path.as_path()).await;
+        assert!(storage
+            .presign_get(path.as_path(), std::time::Duration::from_secs(60))
+            .await
+            .is_err());
     }
 }

--- a/src/storage/strategies/single.rs
+++ b/src/storage/strategies/single.rs
@@ -2,11 +2,15 @@
 //!
 //! This module provides an implementation of the [`StorageStrategy`] for a
 //! single storage strategy.
-use std::path::Path;
+use std::{path::Path, time::Duration};
 
 use bytes::Bytes;
 
-use crate::storage::{drivers::ListEntry, strategies::StorageStrategy, Storage, StorageResult};
+use crate::storage::{
+    drivers::{ListEntry, PresignPutOptions, PresignedRequest},
+    strategies::StorageStrategy,
+    Storage, StorageResult,
+};
 
 /// Represents a single storage strategy.
 #[derive(Clone)]
@@ -114,6 +118,31 @@ impl StorageStrategy for SingleStrategy {
     /// Returns a [`StorageResult`] indicating of the operation status.
     async fn stat(&self, storage: &Storage, path: &Path) -> StorageResult<ListEntry> {
         storage.as_store_err(&self.primary)?.stat(path).await
+    }
+
+    async fn presign_get(
+        &self,
+        storage: &Storage,
+        path: &Path,
+        expire: Duration,
+    ) -> StorageResult<PresignedRequest> {
+        storage
+            .as_store_err(&self.primary)?
+            .presign_get(path, expire)
+            .await
+    }
+
+    async fn presign_put(
+        &self,
+        storage: &Storage,
+        path: &Path,
+        expire: Duration,
+        options: PresignPutOptions,
+    ) -> StorageResult<PresignedRequest> {
+        storage
+            .as_store_err(&self.primary)?
+            .presign_put(path, expire, options)
+            .await
     }
 
     /// Downloads content as a stream from the primary storage
@@ -446,5 +475,188 @@ mod tests {
             .stat_with_policy(path.as_path(), &other)
             .await
             .is_err());
+    }
+}
+
+#[cfg(test)]
+mod presign_tests {
+    use std::{
+        collections::BTreeMap,
+        path::{Path, PathBuf},
+        time::Duration,
+    };
+
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use http::{HeaderMap, Method, Uri};
+
+    use super::*;
+    use crate::storage::{
+        drivers::{
+            GetResponse, ListEntry, PresignPutOptions, PresignedRequest, StoreDriver,
+            UploadResponse,
+        },
+        Storage, StorageError,
+    };
+
+    struct PresignStub {
+        label: &'static str,
+    }
+
+    fn presign_uri(label: &str, kind: &str, path: &Path) -> StorageResult<Uri> {
+        format!("http://{label}/{kind}/{}", path.display())
+            .parse()
+            .map_err(|err| StorageError::Any(Box::new(err)))
+    }
+
+    #[async_trait]
+    impl StoreDriver for PresignStub {
+        async fn upload(&self, _path: &Path, _content: &Bytes) -> StorageResult<UploadResponse> {
+            Ok(UploadResponse::new(None, None))
+        }
+
+        async fn get(&self, _path: &Path) -> StorageResult<GetResponse> {
+            Err(StorageError::Any("not implemented".into()))
+        }
+
+        async fn delete(&self, _path: &Path) -> StorageResult<()> {
+            Ok(())
+        }
+
+        async fn rename(&self, _from: &Path, _to: &Path) -> StorageResult<()> {
+            Ok(())
+        }
+
+        async fn copy(&self, _from: &Path, _to: &Path) -> StorageResult<()> {
+            Ok(())
+        }
+
+        async fn exists(&self, _path: &Path) -> StorageResult<bool> {
+            Ok(true)
+        }
+
+        async fn list(&self, _path: &Path, _recursive: bool) -> StorageResult<Vec<ListEntry>> {
+            Ok(vec![])
+        }
+
+        async fn stat(&self, _path: &Path) -> StorageResult<ListEntry> {
+            Ok(ListEntry::new(
+                "probe.txt".to_string(),
+                false,
+                Some(0),
+                None,
+                None,
+            ))
+        }
+
+        async fn presign_get(
+            &self,
+            path: &Path,
+            _expire: Duration,
+        ) -> StorageResult<PresignedRequest> {
+            Ok(PresignedRequest::new(
+                Method::GET,
+                presign_uri(self.label, "get", path)?,
+                HeaderMap::new(),
+            ))
+        }
+
+        async fn presign_put(
+            &self,
+            path: &Path,
+            _expire: Duration,
+            options: PresignPutOptions,
+        ) -> StorageResult<PresignedRequest> {
+            let mut headers = HeaderMap::new();
+            if let Some(content_type) = options.content_type.as_deref() {
+                headers.insert(
+                    http::header::CONTENT_TYPE,
+                    http::HeaderValue::from_str(content_type)
+                        .map_err(|err| StorageError::Any(Box::new(err)))?,
+                );
+            }
+            Ok(PresignedRequest::new(
+                Method::PUT,
+                presign_uri(self.label, "put", path)?,
+                headers,
+            ))
+        }
+    }
+
+    fn presign_storage(label: &'static str) -> Storage {
+        Storage::new(
+            BTreeMap::from([(
+                label.to_string(),
+                Box::new(PresignStub { label }) as Box<dyn StoreDriver>,
+            )]),
+            Box::new(SingleStrategy::new(label)) as Box<dyn StorageStrategy>,
+        )
+    }
+
+    #[tokio::test]
+    async fn facade_presign_get_and_put() {
+        let storage = presign_storage("arena");
+        let path = PathBuf::from("exports/checkpoint.bin");
+
+        let get = storage
+            .presign_get(path.as_path(), Duration::from_secs(300))
+            .await
+            .unwrap();
+        assert_eq!(get.method, Method::GET);
+        assert!(get.url().contains("arena/get/exports/checkpoint.bin"));
+
+        let put = storage
+            .presign_put(
+                path.as_path(),
+                Duration::from_secs(300),
+                PresignPutOptions {
+                    content_type: Some("application/octet-stream".to_string()),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(put.method, Method::PUT);
+        assert!(put.url().contains("arena/put/exports/checkpoint.bin"));
+        assert_eq!(
+            put.headers
+                .get(http::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("application/octet-stream")
+        );
+    }
+
+    #[tokio::test]
+    async fn with_policy_presign_routes_to_the_strategy_it_is_handed() {
+        let storage = Storage::new(
+            BTreeMap::from([
+                (
+                    "default".to_string(),
+                    Box::new(PresignStub {
+                        label: "default-store",
+                    }) as Box<dyn StoreDriver>,
+                ),
+                (
+                    "other".to_string(),
+                    Box::new(PresignStub {
+                        label: "other-store",
+                    }) as Box<dyn StoreDriver>,
+                ),
+            ]),
+            Box::new(SingleStrategy::new("default")) as Box<dyn StorageStrategy>,
+        );
+        let other = SingleStrategy::new("other");
+        let path = PathBuf::from("probe.txt");
+
+        let presign = storage
+            .presign_get(path.as_path(), Duration::from_secs(60))
+            .await
+            .unwrap();
+        assert!(presign.url().contains("default-store"));
+
+        let other_presign = storage
+            .presign_get_with_policy(path.as_path(), Duration::from_secs(60), &other)
+            .await
+            .unwrap();
+        assert!(other_presign.url().contains("other-store"));
     }
 }

--- a/website/src/content/docs/docs/how-to/configure-storage.md
+++ b/website/src/content/docs/docs/how-to/configure-storage.md
@@ -229,7 +229,52 @@ On `ReplicatedStrategy` (mirror / `read_from_secondaries`):
 
 Backup mode (`read_from_secondaries: false`) keeps all three primary-only.
 
-## 7. Verify
+## 7. Presign direct uploads and downloads
+
+`Storage` exposes `presign_get` and `presign_put` for handing clients a
+time-limited URL that talks to the backing store directly (S3, Azure Blob, GCS)
+without proxying bytes through your app.
+
+```rust
+use std::{path::Path, time::Duration};
+use loco_rs::storage::drivers::PresignPutOptions;
+
+let ttl = Duration::from_secs(300);
+
+let download = ctx.storage.presign_get(Path::new("exports/checkpoint.bin"), ttl).await?;
+println!("GET {}", download.url());
+
+let upload = ctx
+    .storage
+    .presign_put(
+        Path::new("uploads/report.pdf"),
+        ttl,
+        PresignPutOptions {
+            content_type: Some("application/pdf".to_string()),
+        },
+    )
+    .await?;
+println!("{} {}", upload.method, upload.url());
+```
+
+Each call returns a `storage::drivers::PresignedRequest` with `method`, `uri`,
+`headers`, and a `url()` helper. Clients must send the signed headers exactly
+as returned.
+
+On `ReplicatedStrategy`, presign is **primary-only** — presigned URLs are tied
+to one backend's credentials and never fall back to secondaries.
+
+To exercise presign against a real S3-compatible endpoint in tests:
+
+```sh
+LOCO_TEST_S3_ENDPOINT=http://127.0.0.1:9000 \
+LOCO_TEST_S3_BUCKET=loco-presign-test \
+LOCO_TEST_S3_ACCESS_KEY_ID=minio \
+LOCO_TEST_S3_SECRET_ACCESS_KEY=minio123 \
+cargo test -p loco-rs presign_s3_roundtrip --features storage_aws_s3
+```
+
+## 8. Verify
 
 ```rust
 use axum_test::multipart::{MultipartForm, Part}; // not re-exported by the testing prelude


### PR DESCRIPTION
## Summary

Adds presigned URL support to the storage layer: `StoreDriver::presign_get`/`presign_put`, wired through `StorageStrategy` (single + replicated) and exposed on the `Storage` facade.

Loco apps that hand clients direct upload/download links (large files, browser-side uploads) currently have to reach into the underlying `opendal` operator themselves, bypassing Loco's storage abstraction. This keeps that use case inside the framework's own API.

## Changes

- `presign_get`/`presign_put` on `StoreDriver`, implemented for the opendal adapter and the null driver
- `Storage` facade methods delegating through the active strategy
- `PresignPutOptions` for setting `Content-Type` on signed uploads
- Docs update for configure-storage how-to

## Test plan

- [x] `cargo build --all-features`
- [x] `cargo test --all-features` (storage module: 72 passed)
- [x] `cargo clippy --all-features --all-targets` (clean, only pre-existing unrelated warnings)